### PR TITLE
Fix for bug in Package

### DIFF
--- a/lib/active_shipping/shipping/package.rb
+++ b/lib/active_shipping/shipping/package.rb
@@ -108,7 +108,7 @@ module ActiveMerchant #:nodoc:
       
       def attribute_from_metric_or_imperial(obj, klass, metric_unit, imperial_unit)
         if obj.is_a?(klass)
-          return value
+          return obj
         else
           return klass.new(obj, (@unit_system == :imperial ? imperial_unit : metric_unit))
         end

--- a/test/unit/package_test.rb
+++ b/test/unit/package_test.rb
@@ -62,4 +62,9 @@ class PackageTest < Test::Unit::TestCase
     assert_equal 'GBP', wii.currency
     assert_equal 26999, wii.value
   end
+
+  def test_package_from_mass
+    pkg = Package.new(Quantified::Mass.new(10, :pounds), [])
+    assert_equal 10, pkg.weight
+  end
 end


### PR DESCRIPTION
Currently prevents the weight of a package from being handled properly if it is passed as a Mass object.
