### PR TITLE
UPS Intercepted Package Handling

### DIFF
--- a/lib/active_shipping/shipping/carriers/ups.rb
+++ b/lib/active_shipping/shipping/carriers/ups.rb
@@ -290,7 +290,7 @@ module ActiveMerchant
         xml = REXML::Document.new(response)
         success = response_success?(xml)
         message = response_message(xml)
-        
+
         if success
           tracking_number, origin, destination = nil
           shipment_events = []
@@ -319,18 +319,22 @@ module ActiveMerchant
             end
             
             shipment_events = shipment_events.sort_by(&:time)
-            
+
+
             if origin
               first_event = shipment_events[0]
-              same_country = origin.country_code(:alpha2) == first_event.location.country_code(:alpha2)
-              same_or_blank_city = first_event.location.city.blank? or first_event.location.city == origin.city
-              origin_event = ShipmentEvent.new(first_event.name, first_event.time, origin)
-              if same_country and same_or_blank_city
-                shipment_events[0] = origin_event
-              else
-                shipment_events.unshift(origin_event)
+              if !first_event.location.nil?
+                same_country = origin.country_code(:alpha2) == first_event.location.country_code(:alpha2)
+                same_or_blank_city = first_event.location.city.blank? or first_event.location.city == origin.city
+                origin_event = ShipmentEvent.new(first_event.name, first_event.time, origin)
+                if same_country and same_or_blank_city
+                  shipment_events[0] = origin_event
+                else
+                  shipment_events.unshift(origin_event)
+                end
               end
             end
+
             if shipment_events.last.name.downcase == 'delivered'
               shipment_events[-1] = ShipmentEvent.new(shipment_events.last.name, shipment_events.last.time, destination)
             end

--- a/test/fixtures/xml/ups/intercepted_package_tracking_response.xml
+++ b/test/fixtures/xml/ups/intercepted_package_tracking_response.xml
@@ -1,0 +1,137 @@
+<?xml version="1.0"?>
+<TrackResponse>
+	<Response>
+		<ResponseStatusCode>1</ResponseStatusCode>
+		<ResponseStatusDescription>Success</ResponseStatusDescription>
+	</Response>
+	<Shipment>
+		<Shipper>
+			<ShipperNumber>41701F</ShipperNumber>
+			<Address>
+				<AddressLine1>1 Main ST</AddressLine1>
+				<AddressLine2>SUITE 1</AddressLine2>
+				<City>San Francisco</City>
+				<StateProvinceCode>CA</StateProvinceCode>
+				<PostalCode>94110   1111</PostalCode>
+				<CountryCode>US</CountryCode>
+			</Address>
+		</Shipper>
+		<ShipmentWeight>
+			<UnitOfMeasurement>
+				<Code>LBS</Code>
+			</UnitOfMeasurement>
+			<Weight>0.00</Weight>
+		</ShipmentWeight>
+		<Service>
+			<Code>A8</Code>
+			<Description>GROUND</Description>
+		</Service>
+		<ShipmentIdentificationNumber>1Z9999999999999999</ShipmentIdentificationNumber>
+		<Package>
+			<TrackingNumber>1Z9999999999999999</TrackingNumber>
+			<ReturnTo>
+				<Address>
+					<AddressLine1>5555 BROADWAY ST</AddressLine1>
+					<AddressLine2>RM 100</AddressLine2>
+					<City>AMERICAN CANYON</City>
+					<StateProvinceCode>CA</StateProvinceCode>
+					<PostalCode>94503   1751</PostalCode>
+					<CountryCode>US</CountryCode>
+				</Address>
+			</ReturnTo>
+			<PackageServiceOptions>
+				<SignatureRequired>
+					<Code>A</Code>
+				</SignatureRequired>
+			</PackageServiceOptions>
+			<Activity>
+				<ActivityLocation>
+					<Address>
+						<City>AMERICAN CANYON</City>
+						<StateProvinceCode>CA</StateProvinceCode>
+						<PostalCode>94503</PostalCode>
+						<CountryCode>US</CountryCode>
+					</Address>
+					<Code>M7</Code>
+					<Description>RECEIVER</Description>
+					<SignedForByName>SILVIO</SignedForByName>
+				</ActivityLocation>
+				<Status>
+					<StatusType>
+						<Code>D</Code>
+						<Description>DELIVERED</Description>
+					</StatusType>
+					<StatusCode>
+						<Code>KB</Code>
+					</StatusCode>
+				</Status>
+				<Date>20100924</Date>
+				<Time>141400</Time>
+			</Activity>
+			<Activity>
+				<ActivityLocation>
+					<Address>
+						<City>OAKLAND</City>
+						<StateProvinceCode>CA</StateProvinceCode>
+						<CountryCode>US</CountryCode>
+					</Address>
+				</ActivityLocation>
+				<Status>
+					<StatusType>
+						<Code>X</Code>
+						<Description>THE DELIVERY INTERCEPT REQUEST FOR THIS PACKAGE  WAS SUCCESSFULLY COMPLETED / SHIPPER REQUESTED RETURN OF PACKAGE</Description>
+					</StatusType>
+					<StatusCode>
+						<Code>JA</Code>
+					</StatusCode>
+				</Status>
+				<Date>20100923</Date>
+				<Time>215100</Time>
+			</Activity>
+			<Activity>
+				<ActivityLocation>
+					<Address>
+						<City>OAKLAND</City>
+						<StateProvinceCode>CA</StateProvinceCode>
+						<CountryCode>US</CountryCode>
+					</Address>
+				</ActivityLocation>
+				<Status>
+					<StatusType>
+						<Code>X</Code>
+						<Description>THE PACKAGE IS BEING HELD FOR INTERCEPT PROCESSING</Description>
+					</StatusType>
+					<StatusCode>
+						<Code>T3</Code>
+					</StatusCode>
+				</Status>
+				<Date>20100923</Date>
+				<Time>155600</Time>
+			</Activity>
+			<Activity>
+				<ActivityLocation/>
+				<Status>
+					<StatusType>
+						<Code>X</Code>
+						<Description>THE SHIPPER HAS REQUESTED A DELIVERY INTERCEPT FOR THIS PACKAGE / RETURN TO SENDER PENDING</Description>
+					</StatusType>
+					<StatusCode>
+						<Code>78</Code>
+					</StatusCode>
+				</Status>
+				<Date>20100923</Date>
+				<Time>135100</Time>
+			</Activity>
+			<Message>
+				<Code>03</Code>
+				<Description>RETURNED TO SHIPPER</Description>
+			</Message>
+			<PackageWeight>
+				<UnitOfMeasurement>
+					<Code>LBS</Code>
+				</UnitOfMeasurement>
+				<Weight>0.00</Weight>
+			</PackageWeight>
+		</Package>
+	</Shipment>
+</TrackResponse>

--- a/test/unit/carriers/ups_test.rb
+++ b/test/unit/carriers/ups_test.rb
@@ -78,4 +78,11 @@ class UPSTest < Test::Unit::TestCase
     assert Package.new((150 * 16) + 0.01, [5,5,5], :units => :imperial).mass > @carrier.maximum_weight
     assert Package.new((150 * 16) - 0.01, [5,5,5], :units => :imperial).mass < @carrier.maximum_weight
   end
+
+  def test_should_allow_for_empty_activity_location_for_intercepted_package_tracking_results
+    mock_response = xml_fixture('ups/intercepted_package_tracking_response')  
+    @carrier.expects(:commit).returns(mock_response)
+    tracking = @carrier.find_tracking_info(nil)
+    assert_equal "THE SHIPPER HAS REQUESTED A DELIVERY INTERCEPT FOR THIS PACKAGE / RETURN TO SENDER PENDING", tracking.shipment_events[0].name
+  end
 end


### PR DESCRIPTION
Ran into an exception with a package that had a blank activity location due to it being intercepted.

This includes the XML response and passing tests.

Cheers.
