### PR TITLE
Deal with incorrect currency code being returned for Signapore

### DIFF
--- a/lib/active_shipping/shipping/carriers/fedex.rb
+++ b/lib/active_shipping/shipping/carriers/fedex.rb
@@ -236,7 +236,7 @@ module ActiveMerchant
           is_saturday_delivery = rated_shipment.get_text('AppliedOptions').to_s == 'SATURDAY_DELIVERY'
           service_type = is_saturday_delivery ? "#{service_code}_SATURDAY_DELIVERY" : service_code
           
-          currency = handle_uk_currency(rated_shipment.get_text('RatedShipmentDetails/ShipmentRateDetail/TotalNetCharge/Currency').to_s)
+          currency = handle_incorrect_currency_codes(rated_shipment.get_text('RatedShipmentDetails/ShipmentRateDetail/TotalNetCharge/Currency').to_s)
           rate_estimates << RateEstimate.new(origin, destination, @@name,
                               self.class.service_name_for_code(service_type),
                               :service_code => service_code,
@@ -322,8 +322,14 @@ module ActiveMerchant
         ssl_post(test ? TEST_URL : LIVE_URL, request.gsub("\n",''))        
       end
       
-      def handle_uk_currency(currency)
-        currency =~ /UKL/i ? 'GBP' : currency
+      def handle_incorrect_currency_codes(currency)
+        if currency =~ /UKL/i
+          'GBP'
+        elsif currency =~ /SID/i
+          'SGD'
+        else
+          currency
+        end
       end
     end
   end

--- a/test/unit/carriers/fedex_test.rb
+++ b/test/unit/carriers/fedex_test.rb
@@ -127,6 +127,26 @@ class FedExTest < Test::Unit::TestCase
     end
   end
 
+  def test_returns_sgd_instead_of_sid_currency_for_signapore_rates
+    mock_response = xml_fixture('fedex/ottawa_to_beverly_hills_rate_response').gsub('CAD', 'SID')
+    Time.any_instance.expects(:to_xml_value).returns("2009-07-20T12:01:55-04:00")
+    
+    @carrier.expects(:commit).returns(mock_response)
+    response = @carrier.find_rates( @locations[:ottawa],
+                                    @locations[:beverly_hills],
+                                    @packages.values_at(:book, :wii), :test => true)
+    assert_equal ["FedEx Ground"], response.rates.map(&:service_name)
+    assert_equal [3836], response.rates.map(&:price)
+    
+    assert response.success?, response.message
+    assert_not_equal [], response.rates
+    
+    response.rates.each do |rate|
+      assert_equal 'FedEx', rate.carrier
+      assert_equal 'SGD', rate.currency
+    end
+  end
+
   def test_delivery_range_based_on_delivery_date
     mock_response = xml_fixture('fedex/ottawa_to_beverly_hills_rate_response').gsub('CAD', 'UKL')
 


### PR DESCRIPTION
from the FedEx API

This fixes issue #45

Please review @soleone @burke 
