### PR TITLE
Add FirstClassMailType to USPS package.

### DIFF
--- a/lib/active_shipping/shipping/carriers/usps.rb
+++ b/lib/active_shipping/shipping/carriers/usps.rb
@@ -74,6 +74,13 @@ module ActiveMerchant
         :library => 'LIBRARY',
         :all => 'ALL'
       }
+      FIRST_CLASS_MAIL_TYPES = {
+        :letter => 'LETTER',
+        :flat => 'FLAT',
+        :parcel => 'PARCEL',
+        :post_card => 'POSTCARD',
+        :package_service => 'PACKAGESERVICE'
+      }
       
       # TODO: get rates for "U.S. possessions and Trust Territories" like Guam, etc. via domestic rates API: http://www.usps.com/ncsc/lookups/abbr_state.txt
       # TODO: figure out how USPS likes to say "Ivory Coast"
@@ -205,6 +212,7 @@ module ActiveMerchant
           packages.each_with_index do |p,id|
             rate_request << XmlNode.new('Package', :ID => id.to_s) do |package|
               package << XmlNode.new('Service', US_SERVICES[options[:service] || :all])
+              package << XmlNode.new('FirstClassMailType', FIRST_CLASS_MAIL_TYPES[options[:first_class_mail_type]])
               package << XmlNode.new('ZipOrigination', strip_zip(origin_zip))
               package << XmlNode.new('ZipDestination', strip_zip(destination_zip))
               package << XmlNode.new('Pounds', 0)

--- a/test/fixtures/xml/usps/first_class_packages_with_invalid_mail_type_response.xml
+++ b/test/fixtures/xml/usps/first_class_packages_with_invalid_mail_type_response.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" ?>
+<RateV4Response>
+  <Package ID="0">
+    <Error>
+      <Number>-2147219428</Number>
+      <Source>DomesticRatesV4;clsRateV4.ValidateFirstClassMailType;RateEngineV4.ProcessRequest</Source>
+      <Description>Invalid First Class Mail Type.</Description>
+      <HelpFile/>
+      <HelpContext>1000440</HelpContext>
+    </Error>
+  </Package>
+</RateV4Response>

--- a/test/fixtures/xml/usps/first_class_packages_with_mail_type_response.xml
+++ b/test/fixtures/xml/usps/first_class_packages_with_mail_type_response.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" ?>
+<RateV4Response>
+  <Package ID="0">
+    <ZipOrigination>90210</ZipOrigination>
+    <ZipDestination>10017</ZipDestination>
+    <Pounds>0</Pounds>
+    <Ounces>1.0</Ounces>
+    <Size>REGULAR</Size>
+    <Machinable>FALSE</Machinable>
+    <Zone>8</Zone>
+    <Postage CLASSID="0">
+      <MailService>First-Class Mail</MailService>
+      <Rate>2.07</Rate>
+    </Postage>
+  </Package>
+</RateV4Response>

--- a/test/fixtures/xml/usps/first_class_packages_without_mail_type_response.xml
+++ b/test/fixtures/xml/usps/first_class_packages_without_mail_type_response.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" ?>
+<RateV4Response>
+  <Package ID="0">
+    <Error>
+      <Number>-2147219428</Number>
+      <Source>DomesticRatesV4;clsRateV4.ValidateFirstClassMailType;RateEngineV4.ProcessRequest</Source>
+      <Description>Invalid First Class Mail Type.</Description>
+      <HelpFile/>
+      <HelpContext>1000440</HelpContext>
+    </Error>
+  </Package>
+</RateV4Response>

--- a/test/remote/usps_test.rb
+++ b/test/remote/usps_test.rb
@@ -145,6 +145,60 @@ class USPSTest < Test::Unit::TestCase
     end
     assert response.success?, response.message
   end
+
+  def test_first_class_packages_with_mail_type
+    response = nil
+    response = begin
+      @carrier.find_rates(
+        @locations[:beverly_hills], # imperial (U.S. origin)
+        @locations[:new_york],
+        Package.new(0,0),
+        {
+          :test => true,
+          :service => :first_class,
+          :first_class_mail_type => :parcel
+        }
+      )
+    rescue ResponseError => e
+      e.response
+    end
+    assert response.success?, response.message
+  end
+
+  def test_first_class_packages_without_mail_type
+    response = nil
+    response = begin
+      @carrier.find_rates(
+        @locations[:beverly_hills], # imperial (U.S. origin)
+        @locations[:new_york],
+        Package.new(0,0),
+        {
+          :test => true,
+          :service => :first_class
+        }
+      )
+    rescue ResponseError => e
+      assert_equal "Invalid First Class Mail Type.", e.message
+    end
+  end
+
+  def test_first_class_packages_with_invalid_mail_type
+    response = nil
+    response = begin
+      @carrier.find_rates(
+        @locations[:beverly_hills], # imperial (U.S. origin)
+        @locations[:new_york],
+        Package.new(0,0),
+        {
+          :test => true,
+          :service => :first_class,
+          :first_class_mail_tpe => :invalid
+        }
+      )
+    rescue ResponseError => e
+      assert_equal "Invalid First Class Mail Type.", e.message
+    end
+  end
   
   def test_valid_credentials
     assert USPS.new(fixtures(:usps).merge(:test => true)).valid_credentials?

--- a/test/unit/carriers/usps_test.rb
+++ b/test/unit/carriers/usps_test.rb
@@ -172,6 +172,63 @@ class USPSTest < Test::Unit::TestCase
     ]
     assert_equal rate_names, rates_response.rates.collect(&:service_name).sort
   end
+
+  def test_first_class_packages_with_mail_type
+    @carrier.expects(:commit).returns(xml_fixture('usps/first_class_packages_with_mail_type_response'))
+    
+    response = begin
+      @carrier.find_rates(
+        @locations[:beverly_hills], # imperial (U.S. origin)
+        @locations[:new_york],
+        Package.new(0,0),
+        {
+          :test => true,
+          :service => :first_class,
+          :first_class_mail_type => :parcel
+        }
+      )
+    rescue ResponseError => e
+      e.response
+    end
+    assert response.success?, response.message
+  end
+
+  def test_first_class_packages_without_mail_type
+    @carrier.expects(:commit).returns(xml_fixture('usps/first_class_packages_without_mail_type_response'))
+
+    response = begin
+      @carrier.find_rates(
+        @locations[:beverly_hills], # imperial (U.S. origin)
+        @locations[:new_york],
+        Package.new(0,0),
+        {
+          :test => true,
+          :service => :first_class
+        }
+      )
+    rescue ResponseError => e
+      assert_equal "Invalid First Class Mail Type.", e.message
+    end
+  end
+
+  def test_first_class_packages_with_invalid_mail_type
+    @carrier.expects(:commit).returns(xml_fixture('usps/first_class_packages_with_invalid_mail_type_response'))
+
+    response = begin
+      @carrier.find_rates(
+        @locations[:beverly_hills], # imperial (U.S. origin)
+        @locations[:new_york],
+        Package.new(0,0),
+        {
+          :test => true,
+          :service => :first_class,
+          :first_class_mail_tpe => :invalid
+        }
+      )
+    rescue ResponseError => e
+      assert_equal "Invalid First Class Mail Type.", e.message
+    end
+  end
   
   private
   


### PR DESCRIPTION
Without specifying FirstClassMailType while specifying First Class as the service you get this error:

ActiveMerchant::Shipping::ResponseError: Invalid First Class Mail Type

According to the API docs you need to specify a First Class Mail Type when using first class.
