### PR TITLE
Use full list of params for blocks

### DIFF
--- a/test/unit/carriers/canada_post_test.rb
+++ b/test/unit/carriers/canada_post_test.rb
@@ -94,7 +94,7 @@ class CanadaPostTest < Test::Unit::TestCase
   end
 
   def test_turn_around_time_default
-    @carrier.expects(:commit).with do |request|
+    @carrier.expects(:commit).with do |request, options|
       parsed_request = Hash.from_xml(request)
       parsed_request['eparcel']['ratesAndServicesRequest']['turnAroundTime'] == "24"
     end
@@ -102,7 +102,7 @@ class CanadaPostTest < Test::Unit::TestCase
   end
 
   def test_turn_around_time
-    @carrier.expects(:commit).with do |request|
+    @carrier.expects(:commit).with do |request, options|
       parsed_request = Hash.from_xml(request)
       parsed_request['eparcel']['ratesAndServicesRequest']['turnAroundTime'] == "0"
     end

--- a/test/unit/carriers/fedex_test.rb
+++ b/test/unit/carriers/fedex_test.rb
@@ -33,7 +33,7 @@ class FedExTest < Test::Unit::TestCase
     Timecop.freeze(today) do
       delivery_date = Date.today + 7.days # FIVE_DAYS in fixture response, plus weekend
       timestamp = Time.now.iso8601
-      @carrier.expects(:commit).with do |request|
+      @carrier.expects(:commit).with do |request, options|
         parsed_response = Hash.from_xml(request)
         parsed_response['RateRequest']['RequestedShipment']['ShipTimestamp'] == timestamp
       end.returns(mock_response)
@@ -49,7 +49,7 @@ class FedExTest < Test::Unit::TestCase
     Timecop.freeze(DateTime.new(2013, 3, 11)) do
       delivery_date = Date.today + 8.days # FIVE_DAYS in fixture response, plus turn_around_time, plus weekend
       timestamp = (Time.now + 1.day).iso8601
-      @carrier.expects(:commit).with do |request|
+      @carrier.expects(:commit).with do |request, options|
         parsed_response = Hash.from_xml(request)
         parsed_response['RateRequest']['RequestedShipment']['ShipTimestamp'] == timestamp
       end.returns(mock_response)


### PR DESCRIPTION
This uses a full set of params for the blocks being used to mock in tests which was causing test failures in 1.8.7.
### Review

@daverooneyca
