### PR TITLE
Adds Travis CI integration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,4 @@
+language: ruby
+rvm:
+  - 1.9.3
+  - 1.8.7

--- a/README.markdown
+++ b/README.markdown
@@ -1,5 +1,7 @@
 # Active Shipping
 
+![Build Status](https://travis-ci.org/Shopify/active_shipping.png)
+
 This library interfaces with the web services of various shipping carriers. The goal is to abstract the features that are most frequently used into a pleasant and consistent Ruby API. Active Shipping is an extension of [Active Merchant][], and as such, it borrows heavily from conventions used in the latter.
 
 Active Shipping is currently being used and improved in a production environment for [Shopify][]. Development is being done by the Shopify integrations team (<integrations-team@shopify.com>). Discussion is welcome in the [Active Merchant Google Group][discuss].


### PR DESCRIPTION
Are there any other ruby versions we promise to support? Otherwise are `1.8.7` and `1.9.3` fine?

Perhaps we can look into ensuring we have ruby 2 support in the future?

Quick review @melari @jduff 
