### PR TITLE
Remove Extraneous "else" that is Causing a Warning

### DIFF
--- a/lib/active_shipping/shipping/carriers/canada_post_pws.rb
+++ b/lib/active_shipping/shipping/carriers/canada_post_pws.rb
@@ -530,8 +530,6 @@ module ActiveMerchant
           []
         end
 
-        else
-
         receipt
       end
 


### PR DESCRIPTION
I was getting "warning: else without rescue is useless" from this, couldn't see what the point of it was. Removing the else fixed the warning.
