### PR TITLE
Raise an exception when called without any items

### DIFF
--- a/lib/active_shipping/shipping/shipment_packer.rb
+++ b/lib/active_shipping/shipping/shipment_packer.rb
@@ -10,8 +10,11 @@ module ActiveMerchant
       # maximum_weight  - maximum weight in grams
       # currency        - ISO currency code
       def self.pack(items, dimensions, maximum_weight, currency)
-        items = items.map(&:symbolize_keys).map { |item| [item] * item[:quantity].to_i }.flatten
         packages = []
+
+        return packages if items.empty?
+
+        items = items.map(&:symbolize_keys).map { |item| [item] * item[:quantity].to_i }.flatten
         state = :package_empty
 
         while state != :packing_finished

--- a/test/unit/shipment_packer_test.rb
+++ b/test/unit/shipment_packer_test.rb
@@ -71,6 +71,10 @@ class ShipmentPackerTest < Test::Unit::TestCase
     end
   end
 
+  def test_returns_an_empty_list_when_no_items_provided
+    assert_equal [], ShipmentPacker.pack([], @dimensions, 1, 'USD')
+  end
+
   def test_add_summarized_prices_for_all_items_and_currency_to_package
     items = [
       {:grams => 1, :quantity => 3, :price => 1.0},


### PR DESCRIPTION
Calling `ShipmentPacker.pack` with an empty item list raises a `undefined method '[]' for nil:NilClass` exception. With this PR, we throw a `NoItemsProvided` error, which can be rescued.

Not sure if we should instead return an empty package list.

@csaunders any thoughts?

ref.: https://github.com/Shopify/shopify/issues/7572
