### PR TITLE
Forces line_items to array in find_rates call for CPPWS

### DIFF
--- a/lib/active_shipping/shipping/carriers/canada_post_pws.rb
+++ b/lib/active_shipping/shipping/carriers/canada_post_pws.rb
@@ -237,6 +237,7 @@ module ActiveMerchant
       # rating
 
       def build_rates_request(origin, destination, line_items = [], options = {}, package = nil, services = [])
+        line_items = Array(line_items)
         xml =  XmlNode.new('mailing-scenario', :xmlns => "http://www.canadapost.ca/ws/ship/rate") do |node|
           node << customer_number_node(options)
           node << contract_id_node(options)

--- a/test/unit/carriers/canada_post_pws_rating_test.rb
+++ b/test/unit/carriers/canada_post_pws_rating_test.rb
@@ -84,6 +84,26 @@ class CanadaPostPwsRatingTest < Test::Unit::TestCase
     assert_equal "You cannot mail on behalf of the requested customer.", exception.message
   end
 
+  def test_find_rates_line_items_single_object
+    response = xml_fixture('canadapost_pws/rates_info')
+    expected_headers = {
+      'Authorization'   => "#{@cp.send(:encoded_authorization)}",
+      'Accept-Language' => 'en-CA',
+      'Accept'          => 'application/vnd.cpc.ship.rate+xml',
+      'Content-Type'    => 'application/vnd.cpc.ship.rate+xml'
+    }
+    CanadaPostPWS.any_instance.expects(:ssl_post).with(anything, anything, expected_headers).returns(response)
+
+    rates_response = @cp.find_rates(@home_params, @dest_params, @pkg1, @default_options)
+    
+    assert_equal 4, rates_response.rates.size
+    rate = rates_response.rates.first
+    assert_equal RateEstimate, rate.class
+    assert_equal "Canada Post PWS", rate.carrier
+    assert_equal @home.to_s, Location.new(rate.origin).to_s
+    assert_equal @dest.to_s, Location.new(rate.destination).to_s
+  end
+
   # build rates
 
   def test_build_rates_request


### PR DESCRIPTION
To be consistent across all carrier implementations find_rates should accept both an array and a single object. This PR just forces line_items to an array in the build_rates_request method.

@csaunders @jeromecornet please review, thanks!
