### PR TITLE
Updates CPPWS rates and shipment methods to accept location objects

### DIFF
--- a/lib/active_shipping/shipping/carriers/canada_post_pws.rb
+++ b/lib/active_shipping/shipping/carriers/canada_post_pws.rb
@@ -329,9 +329,9 @@ module ActiveMerchant
       # :show_postage_rate
       # :cod, :cod_amount, :insurance, :insurance_amount, :signature_required, :pa18, :pa19, :hfp, :dns, :lad
       # 
-      def build_shipment_request(origin_hash, destination_hash, package, line_items = [], options = {})
-        origin = Location.new(sanitize_zip(origin_hash))
-        destination = Location.new(sanitize_zip(destination_hash))
+      def build_shipment_request(origin, destination, package, line_items = [], options = {})
+        origin = sanitize_location(origin)
+        destination = sanitize_location(destination)
 
         xml = XmlNode.new('non-contract-shipment', :xmlns => "http://www.canadapost.ca/ws/ncshipment") do |root_node|
           root_node << XmlNode.new('delivery-spec') do |node|
@@ -652,13 +652,13 @@ module ActiveMerchant
         end
       end
 
-      def origin_node(location_hash)
-        origin = Location.new(sanitize_zip(location_hash))
+      def origin_node(location)
+        origin = sanitize_location(location)
         XmlNode.new("origin-postal-code", origin.zip)
       end
 
-      def destination_node(location_hash)
-        destination = Location.new(sanitize_zip(location_hash))
+      def destination_node(location)
+        destination = sanitize_location(location)
         case destination.country_code
           when 'CA'
             XmlNode.new('destination') do |node|
@@ -737,6 +737,12 @@ module ActiveMerchant
 
       def shipping_date(options)
         DateTime.strptime((options[:shipping_date] || Time.now).to_s, "%Y-%m-%d")
+      end
+
+      def sanitize_location(location)
+        location_hash = location.is_a?(Location) ? location.to_hash : location
+        location_hash = sanitize_zip(location_hash)
+        Location.new(location_hash)
       end
 
       def sanitize_zip(hash)

--- a/test/unit/carriers/canada_post_pws_rating_test.rb
+++ b/test/unit/carriers/canada_post_pws_rating_test.rb
@@ -97,6 +97,17 @@ class CanadaPostPwsRatingTest < Test::Unit::TestCase
     assert_equal "3.427", doc.xpath('//parcel-characteristics//weight').first.content
   end
 
+  def test_build_rates_request_location_object
+    xml = @cp.build_rates_request(Location.new(@home_params), Location.new(@dest_params), [@pkg1, @pkg2], @default_options)
+    doc = Nokogiri::HTML(xml)
+
+    assert_equal @default_options[:customer_number], doc.xpath('//customer-number').first.content
+    assert_equal 'K1P1J1', doc.xpath('//origin-postal-code').first.content
+    assert_equal 'united-states', doc.xpath('//destination').children.first.name
+    assert !doc.xpath('//parcel-characteristics').empty?
+    assert_equal "3.427", doc.xpath('//parcel-characteristics//weight').first.content
+  end
+
   def test_build_rates_request_domestic
     @dest_params = {       
       :name        => "John Smith", 

--- a/test/unit/carriers/canada_post_pws_shipping_test.rb
+++ b/test/unit/carriers/canada_post_pws_shipping_test.rb
@@ -110,6 +110,12 @@ class CanadaPostPwsShippingTest < Test::Unit::TestCase
     assert_not_nil request
   end
 
+  def test_build_shipment_request_location_object
+    options = @default_options.dup
+    request = @cp.build_shipment_request(Location.new(@home_params), Location.new(@dom_params), @pkg1, @line_item1, options)
+    assert_not_nil request
+  end
+
   def test_create_shipment_request_with_options
     options = @default_options.merge(@shipping_opts1)
     request = @cp.build_shipment_request(@home_params, @paris_params, @pkg1, @line_item1, options)


### PR DESCRIPTION
Another one to make the canada_post_pws carrier interface more consistent with the others by allowing location objects to be passed to rate and shipment methods as well as location hashes (hashes used to be all that it allowed for some reason).

Resolves https://github.com/Shopify/active_shipping/issues/105

@csaunders @jeromecornet please review again, thanks!
