### PR TITLE
CanadaPost - Support multiple packages with nil values

### DIFF
--- a/lib/active_shipping/shipping/carriers/canada_post.rb
+++ b/lib/active_shipping/shipping/carriers/canada_post.rb
@@ -127,7 +127,7 @@ module ActiveMerchant
             request << XmlNode.new('merchantCPCID', @options[:login])
             request << XmlNode.new('fromPostalCode', origin.postal_code)
             request << XmlNode.new('turnAroundTime', options[:turn_around_time] ? options[:turn_around_time] : DEFAULT_TURN_AROUND_TIME)
-            request << XmlNode.new('itemsPrice', dollar_amount(line_items.sum(&:value)))
+            request << XmlNode.new('itemsPrice', dollar_amount(line_items.map(&:value).compact.sum))
 
             #line items
             request << build_line_items(line_items)

--- a/test/unit/carriers/canada_post_test.rb
+++ b/test/unit/carriers/canada_post_test.rb
@@ -143,4 +143,9 @@ class CanadaPostTest < Test::Unit::TestCase
 
     assert_equal [], rate_estimates.rates[0].delivery_range
   end
+
+  def test_line_items_with_nil_values
+    @line_items << Package.new(500, [2, 3, 4], :description => "another box full of stuff", :value => nil)
+    @carrier.find_rates(@origin, @destination, @line_items)
+  end
 end


### PR DESCRIPTION
line_items.sum(&:value) returns an error if any of the values are nil. I modified it to allow nils
