### PR TITLE
UPS correctly parses delivery signature and stores it.

### DIFF
--- a/lib/active_shipping/shipping/carriers/ups.rb
+++ b/lib/active_shipping/shipping/carriers/ups.rb
@@ -325,7 +325,7 @@ module ActiveMerchant
         message = response_message(xml)
 
         if success
-          tracking_number, origin, destination, status_code, status_description = nil
+          tracking_number, origin, destination, status_code, status_description, delivery_signature = nil
           delivered, exception = false
           exception_event = nil
           shipment_events = []
@@ -392,6 +392,7 @@ module ActiveMerchant
 
             # Has the shipment been delivered?
             if status == :delivered
+              delivery_signature = activities.first.get_text('ActivityLocation/SignedForByName').to_s
               if !destination
                 destination = shipment_events[-1].location
               end
@@ -407,6 +408,7 @@ module ActiveMerchant
           :status => status,
           :status_code => status_code,
           :status_description => status_description,
+          :delivery_signature => delivery_signature,
           :scheduled_delivery_date => scheduled_delivery_date,
           :shipment_events => shipment_events,
           :delivered => delivered,

--- a/test/unit/carriers/ups_test.rb
+++ b/test/unit/carriers/ups_test.rb
@@ -57,6 +57,11 @@ class UPSTest < Test::Unit::TestCase
     assert_equal 'delivered', @carrier.find_tracking_info('1Z5FX0076803466397').status_description.downcase
   end
 
+  def test_find_tracking_info_should_return_delivery_signature
+    @carrier.expects(:commit).returns(@tracking_response)
+    assert_equal 'MCAULEY', @carrier.find_tracking_info('1Z5FX0076803466397').delivery_signature
+  end
+
   def test_find_tracking_info_should_have_an_out_for_delivery_status
     out_for_delivery_tracking_response = xml_fixture('ups/out_for_delivery_shipment')
     @carrier.expects(:commit).returns(out_for_delivery_tracking_response)


### PR DESCRIPTION
Modeled after https://github.com/Shopify/active_shipping/pull/81 .  Parses the `delivery_signature` for the UPS carrier and uses it to create the `TrackingResponse`.
