### PR TITLE
adds benchmark carrier

### DIFF
--- a/lib/active_shipping/shipping/carriers.rb
+++ b/lib/active_shipping/shipping/carriers.rb
@@ -1,3 +1,4 @@
+require 'active_shipping/shipping/carriers/benchmark_carrier'
 require 'active_shipping/shipping/carriers/bogus_carrier'
 require 'active_shipping/shipping/carriers/ups'
 require 'active_shipping/shipping/carriers/usps'
@@ -13,7 +14,7 @@ module ActiveMerchant
     module Carriers
       class <<self
         def all
-          [BogusCarrier, UPS, USPS, FedEx, Shipwire, Kunaki, CanadaPost, NewZealandPost, CanadaPostPWS]
+          [BenchmarkCarrier, BogusCarrier, UPS, USPS, FedEx, Shipwire, Kunaki, CanadaPost, NewZealandPost, CanadaPostPWS]
         end
       end
     end

--- a/lib/active_shipping/shipping/carriers/benchmark_carrier.rb
+++ b/lib/active_shipping/shipping/carriers/benchmark_carrier.rb
@@ -8,15 +8,27 @@ module ActiveMerchant
       cattr_reader :name
       @@name = "Benchmark Carrier"
       
-      DELAY_MAX = 30
-
       def find_rates(origin, destination, packages, options = {})
-        sleep Random.rand * DELAY_MAX
         origin = Location.from(origin)
         destination = Location.from(destination)
         packages = Array(packages)
+
+        delay_time = generate_simulated_lag
+
+        bogus_estimate = RateEstimate.new(
+          origin, destination, @@name,
+          "Free Benchmark Shipping", :total_price => 0, :currency => 'USD',
+          :packages => packages, :delivery_range => [Time.now.utc.strftime("%Y-%d-%m"), Time.now.utc.strftime("%Y-%d-%m")]
+          )
+        RateResponse.new(true, "Success (delayed #{delay_time} seconds)", {:rate => 'free'}, :rates => [bogus_estimate], :xml => "<rate>free</rate>")
       end
       
+      private
+
+      def generate_simulated_lag(max_delay = 30)
+        sleep Random.rand * max_delay
+      end
+
     end
   end
 end

--- a/test/unit/carriers/benchmark_test.rb
+++ b/test/unit/carriers/benchmark_test.rb
@@ -1,0 +1,20 @@
+require 'test_helper'
+
+class BenchmarkTest < Test::Unit::TestCase
+
+  def setup
+    @packages = TestFixtures.packages
+    @locations = TestFixtures.locations
+    @carrier = BenchmarkCarrier.new
+  end
+
+  def test_benchmark_response_is_valid
+    @carrier.stubs(:generate_simulated_lag).returns(0)
+    response = @carrier.find_rates(@locations[:london], @locations[:new_york], @packages.values_at(:wii))
+    assert_equal 1, response.rates.count
+    rate = response.rates.first
+    assert_equal "Free Benchmark Shipping", rate.service_name
+    assert_equal 0, rate.price
+  end
+
+end


### PR DESCRIPTION
@csaunders @odorcicd 

I needed a shipping carrier that will sleep for a random amount (0-30s) to simulate the time it takes a real-world 3rd-party API to respond. This will be used by our load-testing tools, and I figured it might be useful to other people using active_shipping.

For more info related to Shopify's use-case see: See: https://github.com/Shopify/shopify/pull/10071#issuecomment-30453485
