### PR TITLE
Catches NoMethodError and reraise a ResponseContentError error

### DIFF
--- a/lib/active_shipping/shipping/carriers/shipwire.rb
+++ b/lib/active_shipping/shipping/carriers/shipwire.rb
@@ -161,6 +161,8 @@ module ActiveMerchant
         end
         
         response
+      rescue NoMethodError => e
+        raise ActiveMerchant::Shipping::ResponseContentError.new(e, xml)
       end
       
       def parse_child_text(parent, name)

--- a/test/remote/shipwire_test.rb
+++ b/test/remote/shipwire_test.rb
@@ -52,6 +52,20 @@ class RemoteShipwireTest < Test::Unit::TestCase
     assert_equal 1, response.rates.size
     assert_equal ['INTL'], response.rates.collect(&:service_code)
   end
+
+  def test_invalid_xml_raises_response_content_error
+    @carrier.expects(:ssl_post).returns("")
+
+    assert_raises ActiveMerchant::Shipping::ResponseContentError do
+      rate_estimates = @carrier.find_rates(
+        @locations[:ottawa],
+        @locations[:london],
+        @packages.values_at(:book, :wii),
+        :items => @items,
+        :order_id => '#1000'
+      )
+    end
+  end
   
   def test_invalid_credentials
     shipwire = Shipwire.new(


### PR DESCRIPTION
Fixes https://github.com/Shopify/shopify/issues/12855

This error happens when Shipwire returns an empty response or a badly formatted XML. We never check for the response validity, so of course, we eventually encounters some weird behaviour. In this specific case, we were trying to call `document.root.elements`, where `document.root` returns `nil`.

With this fix, we captures `NoMethodError` and raise a `ResponseContentError`.

Any thoughts?

@costford @csaunders for review
