### PR TITLE
don't assume first UPS event has a location

### DIFF
--- a/lib/active_shipping/shipping/carriers/ups.rb
+++ b/lib/active_shipping/shipping/carriers/ups.rb
@@ -455,10 +455,10 @@ module ActiveMerchant
         ssl_post("#{test ? TEST_URL : LIVE_URL}/#{RESOURCES[action]}", request)
       end
 
-      def within_same_area(origin, location)
+      def within_same_area?(origin, location)
         return false unless location
         matching_country_codes = origin.country_code(:alpha2) == location.country_code(:alpha2)
-        matching_or_blank_city = location.city.blank || location.city == origin.city
+        matching_or_blank_city = location.city.blank? || location.city == origin.city
         matching_country_codes && matching_or_blank_city
       end
 


### PR DESCRIPTION
e.g. package 1Z05R2W10378274146 has a first event:
"The shipper has requested a Delivery Intercept for this package. /
Return to sender pending."
This event has no location associated with it.

Please review @costford @maartenvg 

/cc @levity since this is based on all your work. Thanks!
