### PR TITLE
FedEx api v13: REXML::ParseException: #<NoMethodError: undefined method `[]' for nil:NilClass

### DIFF
--- a/lib/active_shipping/shipping/carriers/fedex.rb
+++ b/lib/active_shipping/shipping/carriers/fedex.rb
@@ -145,7 +145,8 @@ module ActiveMerchant
         
         rate_request = build_rate_request(origin, destination, packages, options)
         
-        response = commit(save_request(rate_request), (options[:test] || false)).gsub(/<(\/)?.*?\:(.*?)>/, '<\1\2>')
+        xml = commit(save_request(rate_request), (options[:test] || false))
+        response = remove_version_prefix(xml)
 
         parse_rate_response(origin, destination, packages, response, options)
       end
@@ -154,7 +155,8 @@ module ActiveMerchant
         options = @options.update(options)
         
         tracking_request = build_tracking_request(tracking_number, options)
-        response = commit(save_request(tracking_request), (options[:test] || false)).gsub(/<(\/)?.*?\:(.*?)>/, '<\1\2>')
+        xml = commit(save_request(tracking_request), (options[:test] || false))
+        response = remove_version_prefix(xml)
         parse_tracking_response(response, options)
       end
 
@@ -480,7 +482,7 @@ module ActiveMerchant
           :actual_delivery_date => actual_delivery_time,
           :delivery_signature => delivery_signature,
           :shipment_events => shipment_events,
-          :shipper_address => shipper_address.unknown? ? nil : shipper_address,
+          :shipper_address => (shipper_address.nil? || shipper_address.unknown?) ? nil : shipper_address,
           :origin => origin,
           :destination => destination,
           :tracking_number => tracking_number
@@ -558,6 +560,14 @@ module ActiveMerchant
       def extract_timestamp(document, node_name)
         if timestamp_node = document.elements[node_name]
           Time.parse(timestamp_node.to_s).utc
+        end
+      end
+
+      def remove_version_prefix(xml)
+        if xml =~ /xmlns:v[0-9]/
+          xml.gsub(/<(\/)?.*?\:(.*?)>/, '<\1\2>')
+        else
+          xml
         end
       end
 


### PR DESCRIPTION
This happens when I'm getting the rates from FedEx.  The code assumes the XML will have a version in the xml namespace, such as:

```
<v6:RateReply xmlns:v6="http://fedex.com/ws/rate/v6">
  <v6:HighestSeverity xmlns:env="http://schemas.xmlsoap.org/soap/envelope/"
    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">SUCCESS</v6:HighestSeverity>
  ...
```

But now the responses I get from the TEST FedEx environment is:

```
<RateReply xmlns="http://fedex.com/ws/rate/v13" xmlns:SOAP-ENV="http://schemas.xmlsoap.org/soap/envelope/">
  <HighestSeverity>WARNING</HighestSeverity>
  ...
```

Remote tests in active_shipping were indeed failing with my FedEx Developer credentials.  So I made them green by cleaning up the XML response only if xmlns:v[0-9] is found in the XML.

Now I have no idea if this will work well with the FedEx production environment.  And I find that strange that I would be the first one to have problems with the FedEx api.  So maybe someone at Shopify should first confirm using their credentials that the remote tests are failing on their side before accepting this pull request.

Cheers
