### PR TITLE
Taking an approach to dynamically determining FedEx API version

### DIFF
--- a/active_shipping.gemspec
+++ b/active_shipping.gemspec
@@ -27,6 +27,8 @@ Gem::Specification.new do |s|
   s.add_development_dependency('mocha', '~> 0.14.0')
   s.add_development_dependency('timecop')
   s.add_development_dependency('nokogiri')
+  s.add_development_dependency('pry')
+  s.add_development_dependency('pry-debugger')
 
   s.files        = Dir.glob("lib/**/*") + %w(MIT-LICENSE README.markdown CHANGELOG)
   s.require_path = 'lib'

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -10,6 +10,8 @@ require 'active_shipping'
 require 'mocha/setup'
 require 'timecop'
 require 'nokogiri'
+require 'pry'
+require 'pry-debugger'
 
 XmlNode # trigger autorequire
 


### PR DESCRIPTION
This feels a little obtuse though it does the job of injecting all the
XML namespaces correctly so that there shouldn't be a bunch of rework
done on the rest of the codebase.

Most of the tests are going to fail. This made the following test pass

FedexTest#test_returns_gbp_instead_of_ukl_currency_for_uk_rates

Before I continue down this path I just wanted a bit of feedback on to how good or bad of a solution this is.

Feedback please @maartenvg @dylanahsmith @boourns 
