### PR TITLE
Check for missing expected-delivery-date in PWS response

### DIFF
--- a/lib/active_shipping/shipping/carriers/canada_post_pws.rb
+++ b/lib/active_shipping/shipping/carriers/canada_post_pws.rb
@@ -293,7 +293,7 @@ module ActiveMerchant
         options = {
           :carrier                 => @@name,
           :service_name            => root_node.get_text('service-name').to_s,
-          :expected_date           => Date.parse(expected_date),
+          :expected_date           => expected_date.blank? ? nil : Date.parse(expected_date),
           :changed_date            => change_date.blank? ? nil : Date.parse(change_date),
           :change_reason           => root_node.get_text('changed-expected-delivery-reason').to_s.strip,
           :destination_postal_code => root_node.get_text('destination-postal-id').to_s,

--- a/test/fixtures/xml/canadapost_pws/tracking_details_no_expected_delivery_date.xml
+++ b/test/fixtures/xml/canadapost_pws/tracking_details_no_expected_delivery_date.xml
@@ -1,0 +1,40 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<tracking-detail xmlns="http://www.canadapost.ca/ws/track">
+  <pin>8213295707205355</pin>
+  <active-exists>1</active-exists>
+  <archive-exists/>
+  <changed-expected-date/>
+  <destination-postal-id>J7Y0E4</destination-postal-id>
+  <expected-delivery-date/>
+  <changed-expected-delivery-reason/>
+  <mailed-by-customer-number>0008213295</mailed-by-customer-number>
+  <mailed-on-behalf-of-customer-number>0008213295</mailed-on-behalf-of-customer-number>
+  <original-pin/>
+  <service-name>Expedited Parcels</service-name>
+  <service-name-2>Colis accélérés</service-name-2>
+  <customer-ref-1/>
+  <customer-ref-2/>
+  <return-pin/>
+  <signature-image-exists>false</signature-image-exists>
+  <suppress-signature>false</suppress-signature>
+  <delivery-options>
+    <item>
+      <delivery-option>CH_SGN_OPTION</delivery-option>
+      <delivery-option-description>Signature Required</delivery-option-description>
+    </item>
+  </delivery-options>
+  <significant-events>
+    <occurrence>
+      <event-identifier>3000</event-identifier>
+      <event-date>2014-01-26</event-date>
+      <event-time>20:18:06</event-time>
+      <event-time-zone>EST</event-time-zone>
+      <event-description>Electronic information submitted by shipper</event-description>
+      <signatory-name/>
+      <event-site>MAPLE</event-site>
+      <event-province>ON</event-province>
+      <event-retail-location-id/>
+      <event-retail-name/>
+    </occurrence>
+  </significant-events>
+</tracking-detail>

--- a/test/unit/carriers/canada_post_pws_tracking_test.rb
+++ b/test/unit/carriers/canada_post_pws_tracking_test.rb
@@ -103,6 +103,26 @@ class CanadaPostPwsTrackingTest < Test::Unit::TestCase
     assert_equal Time.parse('2011-02-03 16:59:59 UTC'), response.actual_delivery_time
   end
 
+  def test_parse_tracking_response_no_expected_delivery_date
+    @response = xml_fixture('canadapost_pws/tracking_details_no_expected_delivery_date')
+    @cp.expects(:ssl_get).returns(@response)
+
+    response = @cp.find_tracking_info('1371134583769923', {})
+
+    assert_equal CPPWSTrackingResponse, response.class
+    assert_equal "Expedited Parcels", response.service_name
+    assert_equal nil, response.expected_date
+    assert_equal "8213295707205355", response.tracking_number
+    assert_equal 1, response.shipment_events.size
+    assert_equal response.origin.city, "MAPLE"
+    assert_equal response.origin.province, "ON"
+    assert response.origin.is_a?(Location)
+    assert response.destination.is_a?(Location)
+    assert_equal "J7Y0E4", response.destination.to_s
+    assert_equal "0008213295", response.customer_number
+    assert_equal false, response.delivered?
+  end
+
   def test_parse_undelivered_tracking_response
     @response = xml_fixture('canadapost_pws/tracking_details_en_undelivered')
     @cp.expects(:ssl_get).returns(@response)


### PR DESCRIPTION
Fix for valid response from Canada Post that does not contain an expected delivery date in the XML.

Please review @matthelm @csaunders
