### PR TITLE
Fedex requests no longer send StateOrProvinceCode

### DIFF
--- a/test/fixtures/xml/fedex/freight_rate_request.xml
+++ b/test/fixtures/xml/fedex/freight_rate_request.xml
@@ -27,7 +27,6 @@
         <StreetLines>1202 Chalet Ln</StreetLines>
         <StreetLines>Do Not Delete - Test Account</StreetLines>
         <City>Harrison</City>
-        <StateOrProvinceCode>AR</StateOrProvinceCode>
         <PostalCode>72601</PostalCode>
         <CountryCode>US</CountryCode>
         <Residential>true</Residential>
@@ -37,7 +36,6 @@
       <Address>
         <StreetLines>110 Laurier Avenue West</StreetLines>
         <City>Ottawa</City>
-        <StateOrProvinceCode>ON</StateOrProvinceCode>
         <PostalCode>K1P 1J1</PostalCode>
         <CountryCode>CA</CountryCode>
         <Residential>true</Residential>
@@ -58,7 +56,6 @@
           <StreetLines>2000 Freight LTL Testing</StreetLines>
           <StreetLines>Do Not Delete - Test Account</StreetLines>
           <City>Harrison</City>
-          <StateOrProvinceCode>AR</StateOrProvinceCode>
           <PostalCode>72601</PostalCode>
           <CountryCode>US</CountryCode>
           <Residential>true</Residential>

--- a/test/fixtures/xml/fedex/ottawa_to_beverly_hills_commercial_rate_request.xml
+++ b/test/fixtures/xml/fedex/ottawa_to_beverly_hills_commercial_rate_request.xml
@@ -29,7 +29,6 @@
       <Address>
         <StreetLines>110 Laurier Avenue West</StreetLines>
         <City>Ottawa</City>
-        <StateOrProvinceCode>ON</StateOrProvinceCode>
         <PostalCode>K1P 1J1</PostalCode>
         <CountryCode>CA</CountryCode>
         <Residential>true</Residential>
@@ -40,7 +39,6 @@
         <StreetLines>455 N. Rexford Dr.</StreetLines>
         <StreetLines>3rd Floor</StreetLines>
         <City>Beverly Hills</City>
-        <StateOrProvinceCode>CA</StateOrProvinceCode>
         <PostalCode>90210</PostalCode>
         <CountryCode>US</CountryCode>
       </Address>

--- a/test/fixtures/xml/fedex/ottawa_to_beverly_hills_rate_request.xml
+++ b/test/fixtures/xml/fedex/ottawa_to_beverly_hills_rate_request.xml
@@ -29,7 +29,6 @@
       <Address>
         <StreetLines>110 Laurier Avenue West</StreetLines>
         <City>Ottawa</City>
-        <StateOrProvinceCode>ON</StateOrProvinceCode>
         <PostalCode>K1P 1J1</PostalCode>
         <CountryCode>CA</CountryCode>
         <Residential>true</Residential>
@@ -40,7 +39,6 @@
         <StreetLines>455 N. Rexford Dr.</StreetLines>
         <StreetLines>3rd Floor</StreetLines>
         <City>Beverly Hills</City>
-        <StateOrProvinceCode>CA</StateOrProvinceCode>
         <PostalCode>90210</PostalCode>
         <CountryCode>US</CountryCode>
         <Residential>true</Residential>


### PR DESCRIPTION
While fixing another issue I noticed 3 Fedex tests were not passing.

@maartenvg @csaunders should this be merged? Or was that Fedex fix from #141 temporary?
