### PR TITLE
USPS: Return false for canned_address_verification_works? if login is nil

### DIFF
--- a/lib/active_shipping/shipping/carriers/usps.rb
+++ b/lib/active_shipping/shipping/carriers/usps.rb
@@ -241,6 +241,7 @@ module ActiveMerchant
 
       # Once the address verification API is implemented, remove this and have valid_credentials? build the request using that instead.
       def canned_address_verification_works?
+        return false unless @options[:login]
         request = "%3CCarrierPickupAvailabilityRequest%20USERID=%22#{URI.encode(@options[:login])}%22%3E%20%0A%3CFirmName%3EABC%20Corp.%3C/FirmName%3E%20%0A%3CSuiteOrApt%3ESuite%20777%3C/SuiteOrApt%3E%20%0A%3CAddress2%3E1390%20Market%20Street%3C/Address2%3E%20%0A%3CUrbanization%3E%3C/Urbanization%3E%20%0A%3CCity%3EHouston%3C/City%3E%20%0A%3CState%3ETX%3C/State%3E%20%0A%3CZIP5%3E77058%3C/ZIP5%3E%20%0A%3CZIP4%3E1234%3C/ZIP4%3E%20%0A%3C/CarrierPickupAvailabilityRequest%3E%0A"
         # expected_hash = {"CarrierPickupAvailabilityResponse"=>{"City"=>"HOUSTON", "Address2"=>"1390 Market Street", "FirmName"=>"ABC Corp.", "State"=>"TX", "Date"=>"3/1/2004", "DayOfWeek"=>"Monday", "Urbanization"=>nil, "ZIP4"=>"1234", "ZIP5"=>"77058", "CarrierRoute"=>"C", "SuiteOrApt"=>"Suite 777"}}
         xml = REXML::Document.new(commit(:test, request, true))

--- a/test/remote/usps_test.rb
+++ b/test/remote/usps_test.rb
@@ -229,6 +229,11 @@ class USPSTest < Test::Unit::TestCase
     assert USPS.new(fixtures(:usps).merge(:test => true)).valid_credentials?
   end
 
+  def test_valid_credentials_empty_login
+    usps = USPS.new(:test => true)
+    assertEqual false, usps.valid_credentials?
+  end
+
   # Uncomment and switch out SPECIAL_COUNTRIES with some other batch to see which
   # countries are currently working. Commented out here just because it's a lot of
   # hits to their server at once:


### PR DESCRIPTION
Was getting `NoMethodError: undefined method`gsub' for nil:NilClass` if USPS carrier was created without any LoginID specified.

Added a return false if the login is nil to prevent the exception.

Review: @maartenvg @dylanahsmith
