### PR TITLE
Handle FedEx response with empty destination

### DIFF
--- a/lib/active_shipping/shipping/carriers/fedex.rb
+++ b/lib/active_shipping/shipping/carriers/fedex.rb
@@ -531,7 +531,7 @@ module ActiveMerchant
           break if node
         end
 
-        args = if node
+        args = if node && node.elements['CountryCode']
           {
             :country => node.get_text('CountryCode').to_s,
             :province => node.get_text('StateOrProvinceCode').to_s,

--- a/test/fixtures/xml/fedex/tracking_response_empty_destination.xml
+++ b/test/fixtures/xml/fedex/tracking_response_empty_destination.xml
@@ -1,0 +1,76 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<TrackReply xmlns="http://fedex.com/ws/track/v3" xmlns:SOAP-ENV="http://schemas.xmlsoap.org/soap/envelope/">
+  <HighestSeverity>SUCCESS</HighestSeverity>
+  <Notifications>
+    <Severity>SUCCESS</Severity>
+    <Source>trck</Source>
+    <Code>0</Code>
+    <Message>Request was successfully processed.</Message>
+    <LocalizedMessage>Request was successfully processed.</LocalizedMessage>
+  </Notifications>
+  <TransactionDetail>
+    <CustomerTransactionId>ActiveShipping</CustomerTransactionId>
+  </TransactionDetail>
+  <Version>
+    <ServiceId>trck</ServiceId>
+    <Major>3</Major>
+    <Intermediate>0</Intermediate>
+    <Minor>0</Minor>
+  </Version>
+  <DuplicateWaybill>false</DuplicateWaybill>
+  <MoreData>false</MoreData>
+  <TrackDetails>
+    <Notification>
+      <Severity>SUCCESS</Severity>
+      <Source>trck</Source>
+      <Code>0</Code>
+      <Message>Request was successfully processed.</Message>
+      <LocalizedMessage>Request was successfully processed.</LocalizedMessage>
+    </Notification>
+    <TrackingNumber>805573019619</TrackingNumber>
+    <TrackingNumberUniqueIdentifier>2456790000~805573019619~FX</TrackingNumberUniqueIdentifier>
+    <StatusCode>IT</StatusCode>
+    <StatusDescription>In transit</StatusDescription>
+    <CarrierCode>FDXE</CarrierCode>
+    <ServiceInfo>FedEx 2Day A.M</ServiceInfo>
+    <Packaging>Your Packaging</Packaging>
+    <PackagingType>YOUR_PACKAGING</PackagingType>
+    <PackageSequenceNumber>0</PackageSequenceNumber>
+    <PackageCount>1</PackageCount>
+    <ShipTimestamp>2014-05-12T09:54:00-07:00</ShipTimestamp>
+    <DestinationAddress>
+      <Residential>false</Residential>
+    </DestinationAddress>
+    <EstimatedDeliveryTimestamp>2014-05-14T10:30:00-05:00</EstimatedDeliveryTimestamp>
+    <SignatureProofOfDeliveryAvailable>false</SignatureProofOfDeliveryAvailable>
+    <ProofOfDeliveryNotificationsAvailable>true</ProofOfDeliveryNotificationsAvailable>
+    <ExceptionNotificationsAvailable>true</ExceptionNotificationsAvailable>
+    <Events>
+      <Timestamp>2014-05-12T19:31:00-07:00</Timestamp>
+      <EventType>DP</EventType>
+      <EventDescription>Left FedEx origin facility</EventDescription>
+      <Address>
+        <City>LOS ANGELES</City>
+        <StateOrProvinceCode>CA</StateOrProvinceCode>
+        <PostalCode>90065</PostalCode>
+        <CountryCode>US</CountryCode>
+        <Residential>false</Residential>
+      </Address>
+    </Events>
+    <Events>
+      <Timestamp>2014-05-12T09:54:00-07:00</Timestamp>
+      <EventType>PU</EventType>
+      <EventDescription>Picked up</EventDescription>
+      <StatusExceptionCode>A3</StatusExceptionCode>
+      <StatusExceptionDescription>Tendered at FedEx Office</StatusExceptionDescription>
+      <Address>
+        <City>LOS ANGELES</City>
+        <StateOrProvinceCode>CA</StateOrProvinceCode>
+        <PostalCode>90028</PostalCode>
+        <CountryCode>US</CountryCode>
+        <Residential>false</Residential>
+      </Address>
+    </Events>
+  </TrackDetails>
+</TrackReply>
+

--- a/test/unit/carriers/fedex_test.rb
+++ b/test/unit/carriers/fedex_test.rb
@@ -116,6 +116,14 @@ class FedExTest < MiniTest::Unit::TestCase
     assert_equal 'ZZ', result.destination.country.code(:alpha2).to_s
   end
 
+  def test_find_tracking_info_should_gracefully_handle_empty_destination_information
+    @carrier.expects(:commit).returns(xml_fixture('fedex/tracking_response_empty_destination'))
+    result = @carrier.find_tracking_info('077973360403984')
+    assert_equal 'unknown', result.destination.city.downcase
+    assert_equal 'unknown', result.destination.state
+    assert_equal 'ZZ', result.destination.country.code(:alpha2).to_s
+  end
+
   def test_find_tracking_info_should_return_correct_shipper_address
     @carrier.expects(:commit).returns(xml_fixture('fedex/tracking_response_with_shipper_address'))
     response = @carrier.find_tracking_info('927489999894450502838')


### PR DESCRIPTION
In some cases, a DestinationAddress element is provided containing only a
Residential element
