### PR TITLE
Shipwire now returns 401 Unauthorized when bad credentials are provided vs successful response

### DIFF
--- a/lib/active_shipping/shipping/carriers/shipwire.rb
+++ b/lib/active_shipping/shipping/carriers/shipwire.rb
@@ -36,8 +36,10 @@ module ActiveMerchant
         find_rates(location, location, Package.new(100, [5,15,30]),
           :items => [ { :sku => '', :quantity => 1 } ]
         )
-      rescue ActiveMerchant::Shipping::ResponseError => e
-        e.message != "Could not verify Username/EmailAddress and Password combination"
+      rescue ActiveMerchant::Shipping::ResponseError
+        true
+      rescue ActiveMerchant::ResponseError => e
+        e.response.code != '401'
       end
       
       private

--- a/test/fixtures/xml/shipwire/invalid_credentials_response.xml
+++ b/test/fixtures/xml/shipwire/invalid_credentials_response.xml
@@ -1,4 +1,0 @@
-<RateResponse>
-	<Status>Error</Status>
-	<ErrorMessage><![CDATA[Could not verify Username/EmailAddress and Password combination]]></ErrorMessage>
-</RateResponse>

--- a/test/remote/shipwire_test.rb
+++ b/test/remote/shipwire_test.rb
@@ -66,32 +66,11 @@ class RemoteShipwireTest < Test::Unit::TestCase
       )
     end
   end
-  
-  def test_invalid_credentials
-    shipwire = Shipwire.new(
-      :login => 'your@email.com',
-      :password => 'password'
-    )
-    
-    begin
-      assert_raises(ActiveMerchant::Shipping::ResponseError) do
-        shipwire.find_rates(
-          @locations[:ottawa],
-          @locations[:beverly_hills],
-          @packages.values_at(:book, :wii),
-          :items => @items,
-          :order_id => '#1000'
-        )
-      end
-    rescue ResponseError => e
-      assert_equal "Could not verify e-mail/password combination", response.message
-    end
-  end
-  
+
   def test_validate_credentials_with_valid_credentials
     assert @carrier.valid_credentials?
   end
-  
+
   def test_validate_credentials_with_invalid_credentials
     shipwire = Shipwire.new(
       :login => 'your@email.com',

--- a/test/unit/carriers/shipwire_test.rb
+++ b/test/unit/carriers/shipwire_test.rb
@@ -8,23 +8,7 @@ class ShipwireTest < Test::Unit::TestCase
     @carrier   = Shipwire.new(:login => 'l', :password => 'p')
     @items = [ { :sku => 'AF0001', :quantity => 1 }, { :sku => 'AF0002', :quantity => 2 } ]
   end
-  
-  def test_invalid_credentials
-    @carrier.expects(:ssl_post).returns(xml_fixture('shipwire/invalid_credentials_response'))
-    
-    begin
-      @carrier.find_rates(
-        @locations[:ottawa],
-        @locations[:beverly_hills],
-        @packages.values_at(:book, :wii),
-        :order_id => '#1000',
-        :items => @items
-      )
-    rescue ResponseError => e
-      assert_equal "Could not verify Username/EmailAddress and Password combination", e.message
-    end
-  end
-  
+
   def test_response_with_no_rates_is_unsuccessful
     @carrier.expects(:ssl_post).returns(xml_fixture('shipwire/no_rates_response'))
 
@@ -136,7 +120,9 @@ class ShipwireTest < Test::Unit::TestCase
   end
   
   def test_validate_credentials_with_invalid_credentials
-    @carrier.expects(:ssl_post).returns(xml_fixture('shipwire/invalid_credentials_response'))
+    response = stub(:code => '401', :body => 'Could not verify Username/EmailAddress and Password combination')
+
+    @carrier.expects(:ssl_post).raises(ActiveMerchant::ResponseError.new(response))
     assert !@carrier.valid_credentials?
   end
   


### PR DESCRIPTION
@csaunders 

Shipwire used to return a 200 with an error in the body when bad credentials were provided, they now return a 401 instead.
If we get an `ActiveMerchant::Shipping::ResponseError`, that would mean we've gotten past the credential verification and credentials are valid. If we get an `ActiveMerchant::ResponseError` with 401, we return false.

I'm not sure what the point is of some of the tests (verifying that the message of the ResponseError equals the message in the body?), so I removed them.
