### PR TITLE
Set maximum number of packages for ShipmentPacker.pack

### DIFF
--- a/lib/active_shipping/shipping/shipment_packer.rb
+++ b/lib/active_shipping/shipping/shipment_packer.rb
@@ -4,6 +4,9 @@ module ActiveMerchant
       class OverweightItem < StandardError
       end
 
+      EXCESS_PACKAGE_QUANTITY_THRESHOLD = 10_000
+      class ExcessPackageQuantity < StandardError; end
+
       # items           - array of hashes containing quantity, grams and price.
       #                   ex. [{:quantity => 2, :price => 1.0, :grams => 50}]
       # dimensions      - [5.0, 15.0, 30.0]
@@ -39,6 +42,7 @@ module ActiveMerchant
               state = :package_full
             end
           when :package_full
+            raise ExcessPackageQuantity, "Unable to pack more than #{EXCESS_PACKAGE_QUANTITY_THRESHOLD} packages" if packages.length >= EXCESS_PACKAGE_QUANTITY_THRESHOLD
             packages << ActiveMerchant::Shipping::Package.new(package_weight, dimensions, :value => package_value, :currency => currency)
             state = items.any? ? :package_empty : :packing_finished
           end

--- a/test/unit/shipment_packer_test.rb
+++ b/test/unit/shipment_packer_test.rb
@@ -125,4 +125,11 @@ class ShipmentPackerTest < Test::Unit::TestCase
     assert_equal 1, package.weight
     assert_equal 100, package.value
   end
+
+  def test_excess_packages
+    assert_raises(ShipmentPacker::ExcessPackageQuantity) do
+      items = [{:grams => 1, :quantity => ShipmentPacker::EXCESS_PACKAGE_QUANTITY_THRESHOLD + 1, :price => 1.0}]
+      ShipmentPacker.pack(items, @dimensions, 1, 'USD')
+    end
+  end
 end


### PR DESCRIPTION
@costford, @csaunders 

This moves the logic from https://github.com/Shopify/shopify/pull/20563 into Active Shipping.

When `ShipmentPacker.pack` attempts to pack more than `EXCESS_PACKAGE_QUANTITY_THRESHOLD` (defaulted to 10,000) packages, it will raise with a `ExcessPackageQuantity` exception.
