### PR TITLE
Don't modify the inputs to packer aside from symbolize_keys

### DIFF
--- a/lib/active_shipping/shipping/shipment_packer.rb
+++ b/lib/active_shipping/shipping/shipment_packer.rb
@@ -31,7 +31,7 @@ module ActiveMerchant
           end
         end
 
-        items.sort_by! {|i| i[:grams].to_i}
+        items = items.sort_by {|i| i[:grams].to_i}
 
         state = :package_empty
         while state != :packing_finished

--- a/test/unit/shipment_packer_test.rb
+++ b/test/unit/shipment_packer_test.rb
@@ -148,4 +148,13 @@ def test_raise_over_weight_exceptions_before_over_package_limit_exceptions
     assert_equal 0, packages[0].grams
     assert_equal 100_000_000, packages[0].value
   end
+
+  def test_dont_destroy_input_items
+    items = [{:grams => 1, :quantity => 5, :price => 1.0}]
+
+    packages = ShipmentPacker.pack(items, @dimensions, 10, 'USD')
+
+    assert_equal 1, items.size
+    assert_equal 1, packages.size
+  end
 end


### PR DESCRIPTION
Fixes an issue where we modify the input instances of items, this modifies a copy instead (aside from `symbolize_keys` which is legacy).

@csfrancis 
