### PR TITLE
Use deep_dup on items in ShipmentPacker

### DIFF
--- a/lib/active_shipping/shipping/shipment_packer.rb
+++ b/lib/active_shipping/shipping/shipment_packer.rb
@@ -31,7 +31,7 @@ module ActiveMerchant
           end
         end
 
-        items = items.sort_by {|i| i[:grams].to_i}
+        items = items.deep_dup.sort_by! {|i| i[:grams].to_i}
 
         state = :package_empty
         while state != :packing_finished

--- a/test/unit/shipment_packer_test.rb
+++ b/test/unit/shipment_packer_test.rb
@@ -157,4 +157,12 @@ def test_raise_over_weight_exceptions_before_over_package_limit_exceptions
     assert_equal 1, items.size
     assert_equal 1, packages.size
   end
+
+  def test_dont_modify_input_item_quantities
+    items = [{:grams => 1, :quantity => 5, :price => 1.0}]
+
+    packages = ShipmentPacker.pack(items, @dimensions, 10, 'USD')
+
+    assert_equal 5, items.first[:quantity]
+  end
 end


### PR DESCRIPTION
My previous PR missed duplicating the objects inside the array, so they held references to their originals and modified their quantities. This does a `deep_dup` to prevent the issue of modifying those instances.

@camilo 

/cc @csfrancis 
