### PR TITLE
Service to symbol

### DIFF
--- a/lib/active_shipping/shipping/carriers/usps.rb
+++ b/lib/active_shipping/shipping/carriers/usps.rb
@@ -270,7 +270,7 @@ module ActiveMerchant
               end
 
               package << XmlNode.new('Service', US_SERVICES[options[:service].try(:to_sym) || default_service])
-              package << XmlNode.new('FirstClassMailType', FIRST_CLASS_MAIL_TYPES[options[:first_class_mail_type]])
+              package << XmlNode.new('FirstClassMailType', FIRST_CLASS_MAIL_TYPES[options[:first_class_mail_type].try(:to_sym)])
               package << XmlNode.new('ZipOrigination', strip_zip(origin_zip))
               package << XmlNode.new('ZipDestination', strip_zip(destination_zip))
               package << XmlNode.new('Pounds', 0)


### PR DESCRIPTION
@garethson 

Small change to try and convert the `service` option and `first_class_mail_type` to a symbol before use so string values may be used. 
