### PR TITLE
Describe inches in the metric primitive unit so it initializes correctly

### DIFF
--- a/lib/vendor/quantified/lib/quantified/length.rb
+++ b/lib/vendor/quantified/lib/quantified/length.rb
@@ -2,16 +2,16 @@ module Quantified
   class Length < Attribute
     system :metric do
       primitive :metre
-      
+
       one :centimetre, :is => Length.new(0.01, :metres)
       one :millimetre, :is => Length.new(0.1, :centimetres)
       one :kilometre, :is => Length.new(1000, :metres)
     end
-    
+
     system :imperial do
       primitive :inch
-      one :inch, :is => Length.new(2.540, :centimetres)
-      
+      one :inch, :is => Length.new(0.0254, :metres)
+
       one :foot, :plural => :feet, :is => Length.new(12, :inches)
       one :yard, :is => Length.new(3, :feet)
       one :mile, :is => Length.new(5280, :feet)

--- a/lib/vendor/quantified/test/length_test.rb
+++ b/lib/vendor/quantified/test/length_test.rb
@@ -4,7 +4,7 @@ require 'quantified/length'
 class LengthTest < Test::Unit::TestCase
   include Quantified
   Length.numeric_methods :metres, :centimetres, :inches, :feet
-  
+
   def setup
     @length = Length.new(5, :feet)
   end
@@ -16,11 +16,11 @@ class LengthTest < Test::Unit::TestCase
   def test_to_s
     assert_equal "5 feet", @length.to_s
   end
-  
+
   def test_initialize_from_numeric
     assert_equal "5 feet", 5.feet.to_s
   end
-  
+
   def test_equalities
     assert_equal 1.feet, (1.0).feet
     # == based on value
@@ -30,46 +30,50 @@ class LengthTest < Test::Unit::TestCase
     # equal? based on object identity
     assert !2.feet.equal?(2.feet)
   end
-  
+
+  def test_convert_mm_to_inches
+    assert_equal 12, Length.new(304.8, :millimetres).to_inches
+  end
+
   def test_convert_yards_to_feet
     assert 6.feet.eql?(Length.new(2, :yards).to_feet)
   end
-  
+
   def test_convert_feet_to_yards
     assert Length.new(2, :yards).eql?(6.feet.to_yards)
   end
-  
+
   def test_convert_yards_to_millimetres
     assert_in_epsilon Length.new(914.4, :millimetres).to_f, Length.new(1, :yards).to_millimetres.to_f
   end
-  
+
   def test_convert_millimetres_to_yards
     assert_in_epsilon Length.new(1, :yards).to_f, Length.new(914.4, :millimetres).to_yards.to_f
   end
-  
+
   def test_convert_metres_to_inches
     assert_in_epsilon 1.inches.to_f, (0.0254).metres.to_inches.to_f
   end
-  
+
   def test_comparison_with_numeric
     assert 2.feet > 1
     assert 2.feet == 2
     assert 2.feet <= 2
     assert 2.feet < 3
   end
-  
+
   def test_method_missing_to_i
     assert_equal 2, (2.4).feet.to_i
   end
-  
+
   def test_method_missing_to_f
     assert_equal 2.4, (2.4).feet.to_f
   end
-  
+
   def test_method_missing_minus
     assert_equal 2.feet, 5.feet - 3.feet
   end
-  
+
   def test_numeric_methods_not_added_for_some_units
     assert_raises NoMethodError do
       2.yards
@@ -78,12 +82,12 @@ class LengthTest < Test::Unit::TestCase
       2.millimetres
     end
   end
-  
+
   def test_systems
     assert_equal [:metric, :imperial], Length.systems
     assert_equal [:metres, :centimetres, :millimetres, :kilometres], Length.units(:metric)
     assert_equal [:inches, :feet, :yards, :miles], Length.units(:imperial)
-    
+
     assert_equal :metric, 2.centimetres.system
     assert_equal :imperial, 2.feet.system
   end


### PR DESCRIPTION
This modifies `Quantified::Length` to describe the imperial primitive in terms on the metric primitive so the conversions table is initialized properly.

Paired with @tylermercier 
#### Review

@garymardell 
