### PR TITLE
Don't allow negative grams items to put packer in an infinite loop

### DIFF
--- a/lib/active_shipping/shipping/shipment_packer.rb
+++ b/lib/active_shipping/shipping/shipment_packer.rb
@@ -41,7 +41,7 @@ module ActiveMerchant
             state = :filling_package
           when :filling_package
             items.each do |item|
-              quantity = if item[:grams].to_i == 0
+              quantity = if item[:grams].to_i <= 0
                 item[:quantity].to_i
               else
                 # Grab the max amount of this item we can fit into this package

--- a/test/unit/shipment_packer_test.rb
+++ b/test/unit/shipment_packer_test.rb
@@ -165,4 +165,12 @@ def test_raise_over_weight_exceptions_before_over_package_limit_exceptions
 
     assert_equal 5, items.first[:quantity]
   end
+
+  def test_items_with_negative_weight
+    items = [{:grams => -1, :quantity => 5, :price => 1.0}]
+
+    packages = ShipmentPacker.pack(items, @dimensions, 10, 'USD')
+
+    assert_equal 5, items.first[:quantity]
+  end
 end


### PR DESCRIPTION
Currently the shipment packer checks for 0 grams, when passed in items with negative weight this causes us to loop infinitely. This short-circuits negative weights to the item quantity.
#### Review

@garymardell 
