### PR TITLE
USPS improvements

### DIFF
--- a/lib/active_shipping/shipping/carriers/usps.rb
+++ b/lib/active_shipping/shipping/carriers/usps.rb
@@ -141,6 +141,11 @@ module ActiveMerchant
         /Delivery status information is not available/
       ]
 
+      ESCAPING_AND_SYMBOLS = /&amp;lt;\S*&amp;gt;/
+      LEADING_USPS = /^USPS/
+      TRAILING_ASTERISKS = /\*+$/
+      SERVICE_NAME_SUBSTITUTIONS = /#{ESCAPING_AND_SYMBOLS}|#{LEADING_USPS}|#{TRAILING_ASTERISKS}/
+
       def find_tracking_info(tracking_number, options={})
         options = @options.update(options)
         tracking_request = build_tracking_request(tracking_number, options)
@@ -400,13 +405,7 @@ module ActiveMerchant
           package_node.each_element(service_node) do |service_response_node|
             service_name = service_response_node.get_text(service_name_node).to_s
 
-            # strips the double-escaped HTML for trademark symbols from service names
-            service_name.gsub!(/&amp;lt;\S*&amp;gt;/,'')
-            # ...leading "USPS"
-            service_name.gsub!(/^USPS/,'')
-            # ...trailing asterisks
-            service_name.gsub!(/\*+$/,'')
-            # ...surrounding spaces
+            service_name.gsub!(SERVICE_NAME_SUBSTITUTIONS,'')
             service_name.strip!
 
             # aggregate specific package rates into a service-centric RateEstimate

--- a/test/fixtures/xml/usps/beverly_hills_to_ottawa_american_wii_rate_response.xml
+++ b/test/fixtures/xml/usps/beverly_hills_to_ottawa_american_wii_rate_response.xml
@@ -199,5 +199,32 @@ Areas Served: All</ExpressMail>
       <MaxDimensions>Max. length 79", max. length plus girth 108"</MaxDimensions>
       <MaxWeight>66</MaxWeight>
     </Service>
+    <Service ID="15">
+      <Pounds>7</Pounds>
+      <Ounces>8</Ounces>
+      <MailType>Package</MailType>
+      <Container>RECTANGULAR</Container>
+      <Size>REGULAR</Size>
+      <Width>10</Width>
+      <Length>15</Length>
+      <Height>4.5</Height>
+      <Girth>29.0</Girth>
+      <Country>CANADA</Country>
+      <Postage>17.95</Postage>
+      <ExtraServices>
+        <ExtraService>
+          <ServiceID>1</ServiceID>
+          <ServiceName>Insurance</ServiceName>
+          <Available>True</Available>
+          <Price>5.60</Price>
+        </ExtraService>
+      </ExtraServices>
+      <ValueOfContents>269.99</ValueOfContents>
+      <ParcelIndemnityCoverage>86.43</ParcelIndemnityCoverage>
+      <SvcCommitments>Varies by destination</SvcCommitments>
+      <SvcDescription>First-Class Package International Service&amp;lt;sup&amp;gt;&amp;#8482;&amp;lt;/sup&amp;gt;**</SvcDescription>
+      <MaxDimensions>Other than rolls: Max. length 24", max length, height and depth (thickness) combined 36"&lt;br&gt;Rolls: Max. length 36". Max length and twice the diameter combined 42"</MaxDimensions>
+      <MaxWeight>8</MaxWeight>
+    </Service>
   </Package>
 </IntlRateV2Response>

--- a/test/remote/usps_test.rb
+++ b/test/remote/usps_test.rb
@@ -86,8 +86,6 @@ class USPSTest < Test::Unit::TestCase
 
     other_than_two = response.rates.map(&:package_count).reject {|n| n == 2}
     assert_equal [], other_than_two, "Some RateEstimates do not refer to the right number of packages (#{other_than_two.inspect})"
-
-
   end
 
   def test_international_rates
@@ -125,7 +123,6 @@ class USPSTest < Test::Unit::TestCase
 
     other_than_two = response.rates.map(&:package_count).reject {|n| n == 2}
     assert_equal [], other_than_two, "Some RateEstimates do not refer to the right number of packages (#{other_than_two.inspect})"
-
   end
 
   def test_us_to_us_possession

--- a/test/unit/carriers/usps_test.rb
+++ b/test/unit/carriers/usps_test.rb
@@ -169,10 +169,11 @@ class USPSTest < Test::Unit::TestCase
 
     assert_not_equal [],response.rates
 
-    assert_equal [3420, 5835, 8525, 8525], response.rates.map(&:price)
-    assert_equal [1, 2, 4, 12], response.rates.map(&:service_code).map(&:to_i).sort
+    assert_equal [1795, 3420, 5835, 8525, 8525], response.rates.map(&:price)
+    assert_equal [1, 2, 4, 12, 15], response.rates.map(&:service_code).map(&:to_i).sort
 
     ordered_service_names = ["USPS Express Mail International",
+      "USPS First-Class Package International Service",
       "USPS GXG Envelopes",
       "USPS Global Express Guaranteed (GXG)",
       "USPS Priority Mail International"]


### PR DESCRIPTION
Adds more complete fixtures and moves substitutions for service names to one Regex. Extracted from #184

@RichardBlair @garymardell 
