### PR TITLE
Usps base price fallback

### DIFF
--- a/lib/active_shipping/shipping/carriers/usps.rb
+++ b/lib/active_shipping/shipping/carriers/usps.rb
@@ -627,10 +627,12 @@ module ActiveMerchant
       private
 
       def rate_value(rate_node, service_response_node, commercial_type)
-        rate = service_response_node.get_text(rate_node)
-        rate ||= service_response_node.get_text(DOMESTIC_RATE_FIELD[:base]) if commercial_type == :plus
-        rate ||= service_response_node.get_text('Rate')
-        rate.to_s.to_f
+        rate_value = service_response_node.get_text(rate_node).to_s.to_f
+        return rate_value unless commercial_type == :plus
+
+        commercial_base_rate = service_response_node.get_text(DOMESTIC_RATE_FIELD[:base]).to_s.to_f
+        return commercial_base_rate if commercial_base_rate > 0 && commercial_base_rate < rate_value
+        rate_value
       end
 
       def commercial_type(options)

--- a/test/unit/carriers/usps_test.rb
+++ b/test/unit/carriers/usps_test.rb
@@ -422,7 +422,7 @@ class USPSTest < Test::Unit::TestCase
     rates = Hash[response.rates.map {|rate| [rate.service_name, rate.price]}]
 
     assert_equal 0,rates["USPS First-Class Mail Parcel"]
-    assert_equal 405,rates["USPS First-Class Package Service"]
+    assert_equal 276,rates["USPS First-Class Package Service"]
     assert_equal 625,rates["USPS Priority Mail 2-Day"]
   end
 


### PR DESCRIPTION
Do to nuances in how First Class mail pricing is returned, we need to fall back to commercial base pricing if it happens to cost less than commercial plus:

```
        <Postage CLASSID="61">
            <MailService>First-Class&amp;lt;sup&amp;gt;&amp;#8482;&amp;lt;/sup&amp;gt; Package Service</MailService>
            <Rate>0.00</Rate>
            <CommercialRate>2.76</CommercialRate>
            <CommercialPlusRate>4.05</CommercialPlusRate>
        </Postage>
```

cc @RichardBlair @snormore 
