### PR TITLE
Refactor determining rate_value from a reponse node

### DIFF
--- a/lib/active_shipping/shipping/carriers/usps.rb
+++ b/lib/active_shipping/shipping/carriers/usps.rb
@@ -445,7 +445,7 @@ module ActiveMerchant
             this_service[:service_code] ||= service_response_node.attributes[service_code_node]
             package_rates = this_service[:package_rates] ||= []
             this_package_rate = {:package => this_package,
-                                 :rate => Package.cents_from(service_response_node.get_text(rate_node).to_s.to_f)}
+                                 :rate => Package.cents_from(rate_value(rate_node, service_response_node, commercial_type))}
 
             package_rates << this_package_rate if package_valid_for_service(this_package,service_response_node)
           end
@@ -625,7 +625,10 @@ module ActiveMerchant
       end
 
       private
-
+      def rate_value(rate_node, service_response_node, commercial_type)
+        service_response_node.get_text(rate_node).to_s.to_f
+      end
+      
       def commercial_type(options)
         if options[:commercial_plus] == true
           :plus


### PR DESCRIPTION
Refactors fetching the rate value from a USPS response node. Allows flexibility in pulling this out for other systems. Instead of https://github.com/Shopify/active_shipping/pull/192/files.

cc @RichardBlair @jnormore 
