### PR TITLE
clean up unused code and fix or disable broken tests

### DIFF
--- a/lib/active_shipping/shipping/carriers/usps.rb
+++ b/lib/active_shipping/shipping/carriers/usps.rb
@@ -276,11 +276,21 @@ module ActiveMerchant
       # Once the address verification API is implemented, remove this and have valid_credentials? build the request using that instead.
       def canned_address_verification_works?
         return false unless @options[:login]
-        request = "%3CCarrierPickupAvailabilityRequest%20USERID=%22#{URI.encode(@options[:login])}%22%3E%20%0A%3CFirmName%3EABC%20Corp.%3C/FirmName%3E%20%0A%3CSuiteOrApt%3ESuite%20777%3C/SuiteOrApt%3E%20%0A%3CAddress2%3E1390%20Market%20Street%3C/Address2%3E%20%0A%3CUrbanization%3E%3C/Urbanization%3E%20%0A%3CCity%3EHouston%3C/City%3E%20%0A%3CState%3ETX%3C/State%3E%20%0A%3CZIP5%3E77058%3C/ZIP5%3E%20%0A%3CZIP4%3E1234%3C/ZIP4%3E%20%0A%3C/CarrierPickupAvailabilityRequest%3E%0A"
-        # expected_hash = {"CarrierPickupAvailabilityResponse"=>{"City"=>"HOUSTON", "Address2"=>"1390 Market Street", "FirmName"=>"ABC Corp.", "State"=>"TX", "Date"=>"3/1/2004", "DayOfWeek"=>"Monday", "Urbanization"=>nil, "ZIP4"=>"1234", "ZIP5"=>"77058", "CarrierRoute"=>"C", "SuiteOrApt"=>"Suite 777"}}
-        xml = REXML::Document.new(commit(:test, request, true))
-        xml.get_text('/CarrierPickupAvailabilityResponse/City').to_s == 'HOUSTON' &&
-          xml.get_text('/CarrierPickupAvailabilityResponse/Address2').to_s == '1390 Market Street'
+        request = <<-EOF
+        <?xml version="1.0" encoding="UTF-8"?>
+        <CarrierPickupAvailabilityRequest USERID="#{URI.encode(@options[:login])}">
+          <FirmName>Shopifolk</FirmName>
+          <SuiteOrApt>Suite 0</SuiteOrApt>
+          <Address2>18 Fair Ave</Address2>
+          <Urbanization />
+          <City>San Francisco</City>
+          <State>CA</State>
+          <ZIP5>94110</ZIP5>
+          <ZIP4>9411</ZIP4>
+        </CarrierPickupAvailabilityRequest>
+        EOF
+        xml = REXML::Document.new(commit(:test, URI.encode(request), true))
+        xml.get_text('/CarrierPickupAvailabilityResponse/City').to_s == 'SAN FRANCISCO' && xml.get_text('/CarrierPickupAvailabilityResponse/Address2').to_s == '18 FAIR AVE'
       end
 
       # options[:service] --    One of [:first_class, :priority, :express, :bpm, :parcel,

--- a/test/remote/canada_post_pws_test.rb
+++ b/test/remote/canada_post_pws_test.rb
@@ -79,7 +79,7 @@ class CanadaPostPWSTest < Test::Unit::TestCase
     @DEFAULT_RESPONSE = {
       :shipping_id => "406951321983787352",
       :tracking_number => "11111118901234",
-      :label_url => "https://ct.soa-gw.canadapost.ca/ers/artifact/c70da5ed5a0d2c32/20238/0"
+      :label_url => "https://ct.soa-gw.canadapost.ca/ers/artifact/#{@login[:api_key]}/20238/0"
     }
   end
 

--- a/test/remote/fedex_test.rb
+++ b/test/remote/fedex_test.rb
@@ -28,6 +28,7 @@ class FedExTest < Test::Unit::TestCase
   end
 
   def test_freight
+    skip 'Cannot find the fedex freight creds. Whomp, whomp.'
     response = nil
     freight = fixtures(:fedex_freight)
 

--- a/test/remote/new_zealand_post_test.rb
+++ b/test/remote/new_zealand_post_test.rb
@@ -45,12 +45,14 @@ class NewZealandPostTest < Test::Unit::TestCase
   end
 
   def test_domestic_failed_response_raises
+    skip 'ActiveMerchant::Shipping::ResponseError expected but nothing was raised.'
     assert_raises ActiveMerchant::Shipping::ResponseError do
       @carrier.find_rates(@wellington, @auckland, @packages[:shipping_container])
     end
   end
 
   def test_domestic_failed_response_message
+    skip 'Expected /Length can only be between 0 and 150cm/ to match "success".'
     error = @carrier.find_rates(@wellington, @auckland, @packages[:shipping_container]) rescue $!
     assert_match /Length can only be between 0 and 150cm/, error.message
   end

--- a/test/remote/shipwire_test.rb
+++ b/test/remote/shipwire_test.rb
@@ -39,6 +39,7 @@ class RemoteShipwireTest < Test::Unit::TestCase
   end
 
   def test_successful_international_rates_request_for_single_line_item
+    skip 'ActiveMerchant::Shipping::ResponseError: No shipping rates could be found for the destination address'
     response = @carrier.find_rates(
                  @locations[:ottawa],
                  @locations[:london],

--- a/test/remote/ups_test.rb
+++ b/test/remote/ups_test.rb
@@ -58,7 +58,7 @@ class UPSTest < Test::Unit::TestCase
                     Package.new(100, [5, 10, 20])
                   )
        assert_not_equal [], response.rates
-     end
+    end
   end
 
   def test_just_country_given_with_origin_account_fails
@@ -71,7 +71,7 @@ class UPSTest < Test::Unit::TestCase
                  )
       end
     end
- end
+  end
 
   def test_ottawa_to_beverly_hills
     response = nil
@@ -213,6 +213,7 @@ class UPSTest < Test::Unit::TestCase
   end
 
   def test_obtain_shipping_label
+    skip '<#<RuntimeError: Could not obtain shipping label. Invalid Access License number.>>.'
     response = nil
 
     # I want to provide some helpful information if this test fails.
@@ -239,6 +240,7 @@ class UPSTest < Test::Unit::TestCase
   end
 
   def test_obtain_shipping_label_without_dimensions
+    skip '<#<RuntimeError: Could not obtain shipping label. Invalid Access License number.>>.'
     response = nil
     assert_nothing_raised do
       response = @carrier.create_shipment(

--- a/test/remote/usps_test.rb
+++ b/test/remote/usps_test.rb
@@ -8,6 +8,7 @@ class USPSTest < Test::Unit::TestCase
   end
 
   def test_tracking
+    skip '<#<ActiveMerchant::Shipping::ResponseError: There is no record of that mail item. If it was mailed recently, it may not yet be tracked. Please try again later.>>.'
     assert_nothing_raised do
       @carrier.find_tracking_info('EJ958083578US', :test => true)
     end
@@ -224,9 +225,10 @@ class USPSTest < Test::Unit::TestCase
     assert USPS.new(fixtures(:usps).merge(:test => true)).valid_credentials?
   end
 
-  def test_valid_credentials_empty_login
-    usps = USPS.new(:test => true)
-    assertEqual false, usps.valid_credentials?
+  def test_must_provide_login_creds_when_instantiating
+    assert_raises ArgumentError do
+      usps = USPS.new(:test => true)
+    end
   end
 
   # Uncomment and switch out SPECIAL_COUNTRIES with some other batch to see which

--- a/test/unit/carriers/canada_post_pws_rating_test.rb
+++ b/test/unit/carriers/canada_post_pws_rating_test.rb
@@ -293,7 +293,6 @@ class CanadaPostPwsRatingTest < Test::Unit::TestCase
     body = xml_fixture('canadapost_pws/services_response')
     response = @cp.parse_services_response(body)
     assert_equal 6, response.size
-    service = response.first
     assert service = response['INT.PW.ENV']
     assert_equal "Priority Worldwide envelope INT'L", service[:name]
   end

--- a/test/unit/carriers/canada_post_test.rb
+++ b/test/unit/carriers/canada_post_test.rb
@@ -87,7 +87,7 @@ class CanadaPostTest < Test::Unit::TestCase
     @carrier.expects(:ssl_post).returns(@bad_response)
 
     error = assert_raise ActiveMerchant::Shipping::ResponseError do
-      rate_estimates = @carrier.find_rates(@origin, @destination, @line_items)
+      @carrier.find_rates(@origin, @destination, @line_items)
     end
 
     assert_equal 'Parcel too heavy to be shipped with CPC.', error.message
@@ -111,9 +111,8 @@ class CanadaPostTest < Test::Unit::TestCase
 
   def test_non_iso_country_names
     @destination[:country] = 'RU'
-
     @carrier.expects(:ssl_post).with(anything, regexp_matches(%r{<country>Russia</country>})).returns(@response)
-    rate_estimates = @carrier.find_rates(@origin, @destination, @line_items)
+    @carrier.find_rates(@origin, @destination, @line_items)
   end
 
   def test_delivery_range_based_on_delivery_date

--- a/test/unit/carriers/fedex_test.rb
+++ b/test/unit/carriers/fedex_test.rb
@@ -326,9 +326,9 @@ class FedExTest < MiniTest::Unit::TestCase
 
     @carrier.expects(:commit).with { |request, test_mode| Hash.from_xml(request) == Hash.from_xml(expected_request) && test_mode }.returns(mock_response)
     exception = assert_raises ActiveMerchant::Shipping::ResponseContentError do
-      response = @carrier.find_rates( @locations[:ottawa],
-                                      @locations[:beverly_hills],
-                                      @packages.values_at(:book, :wii), :test => true)
+      @carrier.find_rates( @locations[:ottawa],
+                           @locations[:beverly_hills],
+                           @packages.values_at(:book, :wii), :test => true)
     end
     message = "Invalid document \n\n<?xml version='1.0' encoding='UTF-8'?>\n<RandomElement xmlns:v6='http://fedex.com/ws/rate/v6' xmlns:xsi='http://www.w3.org/2001/XMLSchema-instance'>\n</RandomElement>\n"
     assert_equal message, exception.message

--- a/test/unit/carriers/kunaki_test.rb
+++ b/test/unit/carriers/kunaki_test.rb
@@ -13,12 +13,12 @@ class KunakiTest < Test::Unit::TestCase
 
     assert_raises(ResponseError) do
       begin
-        response = @carrier.find_rates(
-                     @locations[:ottawa],
-                     @locations[:beverly_hills],
-                     @packages.values_at(:book, :wii),
-                     :items => @items
-                   )
+        @carrier.find_rates(
+          @locations[:ottawa],
+          @locations[:beverly_hills],
+          @packages.values_at(:book, :wii),
+          :items => @items
+        )
       rescue ResponseError => e
         assert_equal "Request contains invalid XML syntax", e.response.message
         assert_equal "100", e.response.params["ErrorCode"]

--- a/test/unit/carriers/shipwire_test.rb
+++ b/test/unit/carriers/shipwire_test.rb
@@ -12,13 +12,13 @@ class ShipwireTest < Test::Unit::TestCase
     @carrier.expects(:ssl_post).returns(xml_fixture('shipwire/no_rates_response'))
 
     assert_raises(ResponseError) do
-      response = @carrier.find_rates(
-                   @locations[:ottawa],
-                   @locations[:beverly_hills],
-                   @packages.values_at(:book, :wii),
-                   :order_id => '#1000',
-                   :items => @items
-                 )
+      @carrier.find_rates(
+        @locations[:ottawa],
+        @locations[:beverly_hills],
+        @packages.values_at(:book, :wii),
+        :order_id => '#1000',
+        :items => @items
+      )
     end
   end
 

--- a/test/unit/carriers/ups_test.rb
+++ b/test/unit/carriers/ups_test.rb
@@ -179,7 +179,7 @@ class UPSTest < Test::Unit::TestCase
                   "UPS Saver"], response.rates.map(&:service_name)
     assert_equal [18893, 17856, 23473, 18286], response.rates.map(&:price)
     assert_equal [18704, 17677, 23238, 18103], response.rates.map(&:negotiated_rate)
-   end
+  end
 
   def test_delivery_range_takes_weekend_into_consideration
     mock_response = xml_fixture('ups/test_real_home_as_residential_destination_response')

--- a/test/unit/carriers/usps_test.rb
+++ b/test/unit/carriers/usps_test.rb
@@ -313,7 +313,7 @@ class USPSTest < Test::Unit::TestCase
   def test_first_class_packages_without_mail_type
     @carrier.expects(:commit).returns(xml_fixture('usps/first_class_packages_without_mail_type_response'))
 
-    response = begin
+    begin
       @carrier.find_rates(
         @locations[:beverly_hills], # imperial (U.S. origin)
         @locations[:new_york],
@@ -331,7 +331,7 @@ class USPSTest < Test::Unit::TestCase
   def test_first_class_packages_with_invalid_mail_type
     @carrier.expects(:commit).returns(xml_fixture('usps/first_class_packages_with_invalid_mail_type_response'))
 
-    response = begin
+    begin
       @carrier.find_rates(
         @locations[:beverly_hills], # imperial (U.S. origin)
         @locations[:new_york],
@@ -398,8 +398,6 @@ class USPSTest < Test::Unit::TestCase
       :test => true
     )
 
-    rates = Hash[response.rates.map { |rate| [rate.service_name, rate.price] }]
-
     assert_equal [4112, 6047, 7744, 7744], response.rates.map(&:price) # note these prices are higher than the normal/retail unit tests because the rates from that test is years older than from this test
   end
 
@@ -435,8 +433,6 @@ class USPSTest < Test::Unit::TestCase
       @packages.values_at(:american_wii),
       :test => true
     )
-
-    rates = Hash[response.rates.map { |rate| [rate.service_name, rate.price] }]
 
     assert_equal [3767, 5526, 7231, 7231], response.rates.map(&:price)
   end

--- a/test/unit/shipment_packer_test.rb
+++ b/test/unit/shipment_packer_test.rb
@@ -161,16 +161,14 @@ class ShipmentPackerTest < Test::Unit::TestCase
   def test_dont_modify_input_item_quantities
     items = [{:grams => 1, :quantity => 5, :price => 1.0}]
 
-    packages = ShipmentPacker.pack(items, @dimensions, 10, 'USD')
-
+    ShipmentPacker.pack(items, @dimensions, 10, 'USD')
     assert_equal 5, items.first[:quantity]
   end
 
   def test_items_with_negative_weight
     items = [{:grams => -1, :quantity => 5, :price => 1.0}]
 
-    packages = ShipmentPacker.pack(items, @dimensions, 10, 'USD')
-
+    ShipmentPacker.pack(items, @dimensions, 10, 'USD')
     assert_equal 5, items.first[:quantity]
   end
 end


### PR DESCRIPTION
### Problem

Broken remote tests makes it hard to test changes and unnecessary variable declarations is messy.
### Solution

Fix or skip broken tests so that we can think about enabling them on Travis CI (which we'll need test creds for)

Thoughts?

pls2review @Shopify/shipping 
