### PR TITLE
Add USPS handling for "delivered to an individual at the address"

### DIFF
--- a/lib/active_shipping/shipping/carriers/usps.rb
+++ b/lib/active_shipping/shipping/carriers/usps.rb
@@ -15,7 +15,7 @@ module ActiveMerchant
       EventDetails = Struct.new(:description, :time, :zoneless_time, :location)
       EVENT_MESSAGE_PATTERNS = [
         /^(.*), (\w+ \d{1,2}, \d{4}, \d{1,2}:\d\d [ap]m), (.*), (\w\w) (\d{5})$/i,
-        /^Your item \w{2,3} (out for delivery|delivered) at (\d{1,2}:\d\d [ap]m on \w+ \d{1,2}, \d{4}) in (.*), (\w\w) (\d{5})\.$/i
+        /^Your item \w{2,3} (out for delivery|delivered)(?: to an individual at the address)? at (\d{1,2}:\d\d [ap]m on \w+ \d{1,2}, \d{4}) in (.*), (\w\w) (\d{5})\.$/i
       ]
       self.retry_safe = true
 

--- a/lib/active_shipping/shipping/carriers/usps.rb
+++ b/lib/active_shipping/shipping/carriers/usps.rb
@@ -15,7 +15,7 @@ module ActiveMerchant
       EventDetails = Struct.new(:description, :time, :zoneless_time, :location)
       EVENT_MESSAGE_PATTERNS = [
         /^(.*), (\w+ \d{1,2}, \d{4}, \d{1,2}:\d\d [ap]m), (.*), (\w\w) (\d{5})$/i,
-        /^Your item \w{2,3} (out for delivery|delivered)(?: to an individual at the address)? at (\d{1,2}:\d\d [ap]m on \w+ \d{1,2}, \d{4}) in (.*), (\w\w) (\d{5})\.$/i
+        /^Your item \w{2,3} (out for delivery|delivered)[\w\s]* at (\d{1,2}:\d\d [ap]m on \w+ \d{1,2}, \d{4}) in (.*), (\w\w) (\d{5})\.$/i
       ]
       self.retry_safe = true
 

--- a/test/unit/carriers/usps_test.rb
+++ b/test/unit/carriers/usps_test.rb
@@ -454,6 +454,11 @@ class USPSTest < Test::Unit::TestCase
     assert_equal "DELIVERED", details.description
   end
 
+  def test_extract_event_details_handles_delivered_on_or_at_the_mailbox
+    assert details = carrier.extract_event_details("Your item was delivered in or at the mailbox at 1:58 pm on November 20, 2014 in AJO, AZ 85321.")
+    assert_equal "DELIVERED", details.description
+  end
+
   private
 
   def build_service_node(options = {})

--- a/test/unit/carriers/usps_test.rb
+++ b/test/unit/carriers/usps_test.rb
@@ -449,6 +449,11 @@ class USPSTest < Test::Unit::TestCase
     assert_equal 12, details.zoneless_time.mday
   end
 
+  def test_extract_event_details_handles_delivered_to_an_individual
+    assert details = carrier.extract_event_details("Your item was delivered to an individual at the address at 1:10 pm on November 24, 2014 in VAN NUYS, CA 91411.")
+    assert_equal "DELIVERED", details.description
+  end
+
   private
 
   def build_service_node(options = {})


### PR DESCRIPTION
Marks tracking info for links such as https://tools.usps.com/go/TrackConfirmAction?qtc_tLabels1=9405515901127581242940 as delivered correctly.