### PR TITLE
Restrict dependency versions in gemspec

### DIFF
--- a/active_shipping.gemspec
+++ b/active_shipping.gemspec
@@ -16,11 +16,10 @@ Gem::Specification.new do |s|
   s.required_rubygems_version = ">= 1.3.6"
   s.rubyforge_project         = "active_shipping"
 
-  s.add_dependency('activesupport', '>= 3.2')
-  s.add_dependency('i18n')
-  s.add_dependency('active_utils', '~> 3.0.0.pre2')
-  s.add_dependency('builder')
-  s.add_dependency('json', '>= 1.5.1')
+  s.add_dependency('activesupport', '>= 3.2', '< 5.0.0')
+  s.add_dependency('i18n',          '>= 0.6.9')
+  s.add_dependency('active_utils',  '~> 3.0.0.pre2')
+  s.add_dependency('builder',       '>= 2.1.2', '< 4.0.0')
 
   s.add_development_dependency('minitest', '~> 5.0')
   s.add_development_dependency('rake')


### PR DESCRIPTION
This restricts the dependency to certain version ranges.

- Most of the versions I copied from activemerchant. 
- I removed `json` because it is part of the standard library in Ruby 1.9+. We dropped support for Ruby 1.8

@robfoster @RichardBlair 