### PR TITLE
Canada Post with nokogiri

### DIFF
--- a/active_shipping.gemspec
+++ b/active_shipping.gemspec
@@ -20,12 +20,12 @@ Gem::Specification.new do |s|
   s.add_dependency('i18n',          '>= 0.6.9')
   s.add_dependency('active_utils',  '~> 3.0.0.pre2')
   s.add_dependency('builder',       '>= 2.1.2', '< 4.0.0')
+  s.add_dependency('nokogiri',      '>= 1.6')
 
   s.add_development_dependency('minitest')
   s.add_development_dependency('rake')
   s.add_development_dependency('mocha', '~> 1')
   s.add_development_dependency('timecop')
-  s.add_development_dependency('nokogiri')
 
   s.files        = Dir.glob("lib/**/*") + %w(MIT-LICENSE README.md CHANGELOG.md CONTRIBUTING.md)
   s.require_path = 'lib'

--- a/lib/active_shipping.rb
+++ b/lib/active_shipping.rb
@@ -27,6 +27,9 @@ require 'active_support/core_ext/enumerable'
 require 'active_support/core_ext/class/attribute_accessors'
 require 'active_utils'
 
+require 'rexml/document'
+require 'nokogiri'
+
 require 'vendor/quantified/lib/quantified'
 require 'vendor/xml_node/lib/xml_node'
 

--- a/test/fixtures/xml/canadapost/example_request.xml
+++ b/test/fixtures/xml/canadapost/example_request.xml
@@ -1,1 +1,25 @@
-<!DOCTYPE eparcel SYSTEM "http://sellonline.canadapost.ca/DevelopersResources/protocolV3/eParcel.dtd"><eparcel><language>en</language><ratesAndServicesRequest><merchantCPCID>CPC_DEMO_XML</merchantCPCID><fromPostalCode>K1N 5T2</fromPostalCode><itemsPrice>25.00</itemsPrice><lineItems><item><quantity>1</quantity><weight>0.5</weight><length>4</length><width>3</width><height>2</height><description>a box full of stuff</description><readyToShip/></item></lineItems><city>Beverly Hills</city><provOrState>CA</provOrState><country>United States</country><postalCode>90210</postalCode></ratesAndServicesRequest></eparcel>
+<?xml version="1.0"?>
+<!DOCTYPE eparcel SYSTEM "http://sellonline.canadapost.ca/DevelopersResources/protocolV3/eParcel.dtd">
+<eparcel>
+  <language>en</language>
+  <ratesAndServicesRequest>
+    <merchantCPCID>CPC_DEMO_XML</merchantCPCID>
+    <fromPostalCode>K1N 5T2</fromPostalCode>
+    <itemsPrice>25.00</itemsPrice>
+    <lineItems>
+      <item>
+        <quantity>1</quantity>
+        <weight>0.5</weight>
+        <length>4</length>
+        <width>3</width>
+        <height>2</height>
+        <description>a box full of stuff</description>
+        <readyToShip/>
+      </item>
+    </lineItems>
+    <city>Beverly Hills</city>
+    <provOrState>CA</provOrState>
+    <country>United States</country>
+    <postalCode>90210</postalCode>
+  </ratesAndServicesRequest>
+</eparcel>

--- a/test/fixtures/xml/canadapost/example_response_with_nil_value.xml
+++ b/test/fixtures/xml/canadapost/example_response_with_nil_value.xml
@@ -1,0 +1,164 @@
+<?xml version="1.0"?>
+<!DOCTYPE eparcel [
+<!-- EVERY REQUEST CONTAIN THE eparcel TAG -->
+<!ELEMENT eparcel (ratesAndServicesResponse)>
+  <!-- *********************************************************  -->
+  <!-- * Standard response for request for rates and services  *  -->
+  <!-- *********************************************************  -->
+  <!ELEMENT ratesAndServicesResponse (statusCode, statusMessage+, requestID, handling, language, product+, packing*, emptySpace*, shippingOptions, comment, nearestPostalOutlet*)>
+    <!ELEMENT statusCode (#PCDATA)>
+    <!ELEMENT statusMessage (#PCDATA)>
+    <!ELEMENT requestID (#PCDATA)>
+    <!ELEMENT handling (#PCDATA)>
+    <!ELEMENT language (#PCDATA)>
+    <!ELEMENT product (name, rate, shippingDate, deliveryDate, deliveryDayOfWeek, nextDayAM?, packingID)>
+      <!ATTLIST product
+        id CDATA #REQUIRED
+        sequence CDATA #REQUIRED
+      >
+      <!ELEMENT name (#PCDATA)>
+      <!ELEMENT rate (#PCDATA)>
+      <!ELEMENT shippingDate (#PCDATA)>
+      <!ELEMENT deliveryDate (#PCDATA)>
+      <!ELEMENT deliveryDayOfWeek (#PCDATA)>
+      <!ELEMENT nextDayAM (#PCDATA)>
+      <!ELEMENT packingID (#PCDATA)>
+    <!ELEMENT packing (packingID, box+)>
+    <!ELEMENT box (name, weight, expediterWeight, length, width, height, packedItem+)>
+      <!ELEMENT weight (#PCDATA)>
+      <!ELEMENT expediterWeight (#PCDATA)>
+      <!ELEMENT length (#PCDATA)>
+      <!ELEMENT width (#PCDATA)>
+      <!ELEMENT height (#PCDATA)>
+      <!ELEMENT packedItem (quantity, description)>
+    <!ELEMENT quantity (#PCDATA)>
+    <!ELEMENT description (#PCDATA)>
+    <!ELEMENT emptySpace (length, width, height, weight)>
+    <!ELEMENT shippingOptions (insurance, deliveryConfirmation, signature, flexiblePaymentAvailable?)>
+      <!ELEMENT insurance (#PCDATA)>
+      <!ELEMENT deliveryConfirmation (#PCDATA)>
+      <!ELEMENT signature (#PCDATA)>
+      <!ELEMENT flexiblePaymentAvailable EMPTY>
+    <!ELEMENT comment (#PCDATA)>
+    <!-- *********************************************************  -->
+    <!-- * 'nearestPostalOutlet'  is optional and is returned    *  -->
+    <!-- * only if the merchant profile has this option enabled  *  -->
+    <!-- *********************************************************  -->
+    <!ELEMENT nearestPostalOutlet (postalOutletSequenceNo, distance, outletName, businessName, postalAddress, phoneNumber, businessHours+)>
+      <!ELEMENT postalOutletSequenceNo (#PCDATA)>
+      <!ELEMENT distance (#PCDATA)>
+      <!ELEMENT outletName (#PCDATA)>
+      <!ELEMENT businessName (#PCDATA)>
+      <!ELEMENT postalAddress (addressLine+, postalCode, municipality, province?)>
+        <!ELEMENT addressLine (#PCDATA)>
+        <!ELEMENT postalCode (#PCDATA)>
+        <!ELEMENT municipality (#PCDATA)>
+        <!ELEMENT province (#PCDATA)>
+      <!ELEMENT phoneNumber (#PCDATA)>
+      <!ELEMENT businessHours (dayId, dayOfWeek, time)>
+      <!ELEMENT dayId (#PCDATA)>
+      <!ELEMENT dayOfWeek (#PCDATA)>
+      <!ELEMENT time (#PCDATA)>
+
+]>
+<eparcel>
+  <ratesAndServicesResponse>
+
+    <statusCode>1</statusCode>
+    <statusMessage>OK</statusMessage>
+    <requestID>12471821</requestID>
+    <handling>1.0</handling>
+    <language>0</language>
+    <product id="2040" sequence="1">
+      <name>Priority Worldwide USA</name>
+      <rate>139.36</rate>
+      <shippingDate>2015-01-21</shippingDate>
+      <deliveryDate>www.canadapost.ca</deliveryDate>
+      <deliveryDayOfWeek>4</deliveryDayOfWeek>
+      <nextDayAM>false</nextDayAM>
+      <packingID>P_0</packingID>
+    </product>
+    <product id="2030" sequence="2">
+      <name>Xpresspost USA</name>
+      <rate>64.6</rate>
+      <shippingDate>2015-01-21</shippingDate>
+      <deliveryDate>2015-01-24</deliveryDate>
+      <deliveryDayOfWeek>7</deliveryDayOfWeek>
+      <nextDayAM>false</nextDayAM>
+      <packingID>P_0</packingID>
+    </product>
+    <product id="2020" sequence="3">
+      <name>Expedited US Business</name>
+      <rate>38.0</rate>
+      <shippingDate>2015-01-21</shippingDate>
+      <deliveryDate>2015-01-27</deliveryDate>
+      <deliveryDayOfWeek>3</deliveryDayOfWeek>
+      <nextDayAM>false</nextDayAM>
+      <packingID>P_0</packingID>
+    </product>
+    <product id="2000" sequence="4">
+      <name>Tracked Packet - USA</name>
+      <rate>32.82</rate>
+      <shippingDate>2015-01-21</shippingDate>
+      <deliveryDate>2015-01-29</deliveryDate>
+      <deliveryDayOfWeek>5</deliveryDayOfWeek>
+      <nextDayAM>false</nextDayAM>
+      <packingID>P_0</packingID>
+    </product>
+    <product id="2015" sequence="5">
+      <name>Small Packets Air</name>
+      <rate>21.58</rate>
+      <shippingDate>2015-01-21</shippingDate>
+      <deliveryDate>up to 2 weeks</deliveryDate>
+      <deliveryDayOfWeek>4</deliveryDayOfWeek>
+      <nextDayAM>false</nextDayAM>
+      <packingID>P_0</packingID>
+    </product>
+
+
+    <packing>
+      <packingID>P_0</packingID>
+                        <box>
+        <name>a box full of stuff</name>
+        <weight>0.5</weight>
+        <expediterWeight>0.5</expediterWeight>
+        <length>4.0</length>
+        <width>3.0</width>
+        <height>2.0</height>
+                    <packedItem>
+          <quantity>1</quantity>
+          <description>a box full of stuff</description>
+        </packedItem>
+
+
+      </box>
+      <box>
+        <name>another box full of stuff</name>
+        <weight>0.5</weight>
+        <expediterWeight>0.5</expediterWeight>
+        <length>4.0</length>
+        <width>3.0</width>
+        <height>2.0</height>
+                    <packedItem>
+          <quantity>1</quantity>
+          <description>another box full of stuff</description>
+        </packedItem>
+
+
+      </box>
+
+    </packing>
+
+    <shippingOptions>
+      <insurance>No</insurance>
+      <deliveryConfirmation>Yes</deliveryConfirmation>
+      <signature>No</signature>
+
+    </shippingOptions>
+
+    <comment>* For major centres only. Add 1 to 3 business days for other destinations.</comment>
+
+
+  </ratesAndServicesResponse>
+</eparcel>
+<!--END_OF_EPARCEL-->

--- a/test/unit/carriers/canada_post_test.rb
+++ b/test/unit/carriers/canada_post_test.rb
@@ -100,11 +100,13 @@ class CanadaPostTest < Minitest::Test
   end
 
   def test_build_line_items
-    xml_line_items = @carrier.send(:build_line_items, @line_items)
-    assert_instance_of XmlNode, xml_line_items
+    line_items_xml = Nokogiri::XML::Builder.new do |xml|
+      @carrier.send(:build_line_items, xml, @line_items)
+    end
 
-    xml_string = xml_line_items.to_s
-    assert_match /a box full of stuff/, xml_string
+    assert_instance_of Nokogiri::XML::Builder, line_items_xml
+    assert_equal "a box full of stuff", line_items_xml.doc.at_xpath('//description').text
+    assert_equal "0.5", line_items_xml.doc.at_xpath('//weight').text
   end
 
   def test_non_iso_country_names

--- a/test/unit/carriers/canada_post_test.rb
+++ b/test/unit/carriers/canada_post_test.rb
@@ -132,7 +132,12 @@ class CanadaPostTest < Minitest::Test
   end
 
   def test_line_items_with_nil_values
+    @response = xml_fixture('canadapost/example_response_with_nil_value')
+    @carrier.expects(:ssl_post).returns(@response)
+
     @line_items << Package.new(500, [2, 3, 4], :description => "another box full of stuff", :value => nil)
-    @carrier.find_rates(@origin, @destination, @line_items)
+    rate_response = @carrier.find_rates(@origin, @destination, @line_items)
+
+    assert rate_response.rates.length > 0, "Expecting rateestimates even without a value specified."
   end
 end


### PR DESCRIPTION
This updates the legacy Canada Post carrier to use Nokogiri to generate XML requests and parse XML responses, instead of XmlNode and REXML respectively.

I'd like to get rid of XmlNode and standardize on Nokogiri for XML processing. This is one step in that direction. The other option is to standardize on REXML + Builder. Nokogiri is fasterand built on top of a battle tested libxml, but REXML + Builder are pure Ruby. What do you think?

@Shopify/shipping 