### PR TITLE
Document ActiveShipping::Carrier using yardoc.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,4 +8,4 @@ Gemfile*.lock
 .rvmrc
 test/fixtures/live_credentials.yml
 .rbenv-version
-
+.yardoc/

--- a/.yardopts
+++ b/.yardopts
@@ -1,0 +1,14 @@
+--readme README.md
+--title 'ActiveShipping API documentation'
+--charset utf-8
+--hide-void-return
+--protected
+--no-private
+--markup markdown
+--markup-provider redcarpet
+--exclude /lib/vendor/xml_node/
+-
+README.md
+CHANGELOG.md
+CONTRIBUTING.md
+MIT-LICENSE

--- a/README.md
+++ b/README.md
@@ -1,10 +1,9 @@
-# Active Shipping
-
-[![Build Status](https://travis-ci.org/Shopify/active_shipping.png)](https://travis-ci.org/Shopify/active_shipping)
+# ActiveShipping [![Build status](https://travis-ci.org/Shopify/active_shipping.svg?branch=master)](https://travis-ci.org/Shopify/active_shipping)
 
 This library interfaces with the web services of various shipping carriers. The goal is to abstract the features that are most frequently used into a pleasant and consistent Ruby API.
 
 - Finding shipping rates
+- Registering shipments
 - Tracking shipments
 
 Active Shipping is currently being used and improved in a production environment for [Shopify][]. Development is being done by the Shopify integrations team (<integrations-team@shopify.com>). Discussion is welcome in the [Active Merchant Google Group][discuss].

--- a/lib/active_shipping/carrier.rb
+++ b/lib/active_shipping/carrier.rb
@@ -1,7 +1,22 @@
 module ActiveShipping
+
+  # Carrier is abstract the base class for all supported carriers.
+  #
+  # To implement support for a carrier, you should subclass this class and
+  # implement all the methods the carrier supports.
+  #
+  # @see #find_rates
+  # @see #create_shipment
+  # @see #find_tracking_info
+  #
+  # @!attribute test_mode
+  #   Whether to interact with the carrier's sandbox environment.
+  #   @return [Boolean]
+  #
+  # @!attribute last_request
+  #   The last request performed against the carrier's API.
+  #   @see #save_request
   class Carrier
-    include ActiveUtils::RequiresParameters
-    include ActiveUtils::PostsData
     include Quantified
 
     attr_reader :last_request
@@ -9,6 +24,9 @@ module ActiveShipping
     alias_method :test_mode?, :test_mode
 
     # Credentials should be in options hash under keys :login, :password and/or :key.
+    # @param options [Hash] The details needed to connect to the carrier's API.
+    # @option options [Boolean] :test Set this to true to connect to the carrier's
+    #   sandbox environment instead of the production environment.
     def initialize(options = {})
       requirements.each { |key| requires!(options, key) }
       @options = options
@@ -16,22 +34,59 @@ module ActiveShipping
       @test_mode = @options[:test]
     end
 
-    # Override to return required keys in options hash for initialize method.
-    def requirements
-      []
-    end
-
-    # Override with whatever you need to get the rates
+    # Asks the carrier for rate estimates for a given shipment.
+    #
+    # @note Override with whatever you need to get the rates from the carrier.
+    #
+    # @param origin [ActiveShipping::Location] Where the shipment will originate from.
+    # @param destination [ActiveShipping::Location] Where the package will go.
+    # @param packages [Array<ActiveShipping::Package>] The list of packages that will
+    #   be in the shipment.
+    # @param options [Hash] Carrier-specific parameters.
+    # @return [ActiveShipping::RateResponse] The response from the carrier, which
+    #   includes 0 or more rate estimates for different shipping products
     def find_rates(origin, destination, packages, options = {})
+      raise NotImplementedError, "#find_rates is not supported by #{self.class.name}."
     end
 
-    # Override with whatever you need to get a shipping label
+    # Registers a new shipment with the carrier, to get a tracking number and
+    # potentially shipping labels
+    #
+    # @note Override with whatever you need to register a shipment, and obtain
+    #   shipping labels if supported by the carrier.
+    #
+    # @param origin [ActiveShipping::Location] Where the shipment will originate from.
+    # @param destination [ActiveShipping::Location] Where the package will go.
+    # @param packages [Array<ActiveShipping::Package>] The list of packages that will
+    #   be in the shipment.
+    # @param options [Hash] Carrier-specific parameters.
+    # @return [ActiveShipping::ShipmentResponse] The response from the carrier. This
+    #   response should include a shipment identifier or tracking_number if successful,
+    #   and potentially shipping labels.
     def create_shipment(origin, destination, packages, options = {})
+      raise NotImplementedError, "#create_shipment is not supported by #{self.class.name}."
     end
 
-    # Validate credentials with a call to the API. By default this just does a find_rates call
-    # with the orgin and destination both as the carrier's default_location. Override to provide
-    # alternate functionality, such as checking for test_mode to use test servers, etc.
+    # Retrieves tracking information for a previous shipment
+    #
+    # @note Override with whatever you need to get a shipping label
+    #
+    # @param tracking_number [String] The unique identifier of the shipment to track.
+    # @param options [Hash] Carrier-specific parameters.
+    # @return [ActiveShipping::TrackingResponse] The response from the carrier. This
+    #   response should a list of shipment tracking events if successful.
+    def find_tracking_info(tracking_number, options = {})
+      raise NotImplementedError, "#find_tracking_info is not supported by #{self.class.name}."
+    end
+
+    # Validate credentials with a call to the API.
+    #
+    # By default this just does a `find_rates` call with the orgin and destination both as
+    # the carrier's default_location. Override to provide alternate functionality, such as
+    # checking for `test_mode` to use test servers, etc.
+    #
+    # @return [Boolean] Should return `true` if the provided credentials proved to work,
+    #   `false` otherswise.
     def valid_credentials?
       location = self.class.default_location
       find_rates(location, location, Package.new(100, [5, 15, 30]), :test => test_mode)
@@ -41,13 +96,27 @@ module ActiveShipping
       true
     end
 
+    # The maximum weight the carrier will accept.
+    # @return [Quantified::Mass]
     def maximum_weight
       Mass.new(150, :pounds)
     end
 
     protected
 
-    # Override in subclasses for non-U.S.-based carriers.
+    include ActiveUtils::RequiresParameters
+    include ActiveUtils::PostsData
+
+    # Returns the keys that are required to be passed to the options hash
+    # @note Override to return required keys in options hash for initialize method.
+    # @return [Array<Symbol>]
+    def requirements
+      []
+    end
+
+    # The default location to use for {#valid_credentials?}.
+    # @note Override for non-U.S.-based carriers.
+    # @return [ActiveShipping::Location]
     def self.default_location
       Location.new( :country => 'US',
                     :state => 'CA',
@@ -59,11 +128,16 @@ module ActiveShipping
                     :fax => '1-310-275-8159')
     end
 
-    # Use after building the request to save for later inspection. Probably won't ever be overridden.
+    # Use after building the request to save for later inspection.
+    # @return [void]
     def save_request(r)
       @last_request = r
     end
 
+    # Calculates a timestamp that corresponds a given number if business days in the future
+    #
+    # @param [Integer] The number of business days from now.
+    # @return [DateTime] A timestamp, the provided number of business days in the future.
     def timestamp_from_business_day(days)
       return unless days
       date = DateTime.now.utc


### PR DESCRIPTION
This adds Yardoc documentation to the `ActiveShipping::Carrier` class.

Some of the helper classes and response classes definitely need documentation too, but given that the Carrier primarily defines the abstraction, this is a good place to start.

Once we do a release, the docs should show up here: http://www.rubydoc.info/gems/active_shipping

@kmcphillips @jnormore @garethson 