### PR TITLE
Rdoc for response classes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ Gemfile*.lock
 test/fixtures/live_credentials.yml
 .rbenv-version
 .yardoc/
+doc/

--- a/lib/active_shipping/carrier.rb
+++ b/lib/active_shipping/carrier.rb
@@ -136,7 +136,7 @@ module ActiveShipping
 
     # Calculates a timestamp that corresponds a given number if business days in the future
     #
-    # @param [Integer] The number of business days from now.
+    # @param days [Integer] The number of business days from now.
     # @return [DateTime] A timestamp, the provided number of business days in the future.
     def timestamp_from_business_day(days)
       return unless days

--- a/lib/active_shipping/label_response.rb
+++ b/lib/active_shipping/label_response.rb
@@ -1,7 +1,7 @@
 module ActiveShipping
+
   # This is UPS specific for now; the hash is not at all generic
   # or common between carriers.
-
   class LabelResponse < Response
     attr :params # maybe?
 

--- a/lib/active_shipping/rate_estimate.rb
+++ b/lib/active_shipping/rate_estimate.rb
@@ -1,18 +1,64 @@
-module ActiveShipping #:nodoc:
+module ActiveShipping
+
+  # Class representing a shipping option with estimated price.
+  #
+  # @!attribute origin
+  #   The origin of the shipment
+  #   @return [ActiveShipping::Location]
+  #
+  # @!attribute desination
+  #   The desination of the shipment
+  #   @return [ActiveShipping::Location]
+  #
+  # @!attribute package_rates
+  #   A list of rates for all the packages in the shipment.
+  #   @return [Array<{:rate => Integer, :package => ActiveShipping::Package}>]
+  #
+  # @!attribute carrier
+  #   The name of the carrier (i.e. , e.g. 'USPS', 'FedEx')
+  #   @return [String]
+  #   @see ActiveShipping::Carrier.name
+  #
+  # @!attribute service_name
+  #   The name of the shipping service (e.g. `"First Class Ground"`)
+  #   @return [String]
+  #
+  # @!attribute service_code
+  #   The code of the shipping service
+  #   @return [String]
+  #
+  # @!attribute shipping_date
+  #   The date on which the shipment will be expected. Normally, this means that the
+  #   delivery date range can only pe prmoised if the shipment is handed over on or
+  #   before this date.
+  #   @return [Date]
+  #
+  # @!attribute delivery_date
+  #   The date on which the shipment will be delivered. This is usually only availablee
+  #   for express shipments; in order cases a {#delivery_range} is given instead.
+  #   @return [Date]
+  #
+  # @!attribute delivery_range
+  #   The minimum and maximum date of when the shipment is expected to be delivered.
+  #   @return [Array<Date>]
+  #
+  # @!attribute currency
+  #   ISO4217 currency code of the quoted rate estimates, e.g. `CAD`, `EUR`, or `USD`.
+  #   @return [String]
+  #   @see http://en.wikipedia.org/wiki/ISO_4217
+  #
+  # @!attribute negotiated_rate
+  #   The negotiated rate in cents
+  #   @return [Integer]
+  #
+  # @!attribute insurance_price
+  #   The price of insurance in cents.
+  #   @return [Integer]
   class RateEstimate
-    attr_reader :origin         # Location objects
-    attr_reader :destination
-    attr_reader :package_rates  # array of hashes in the form of {:package => <Package>, :rate => 500}
-    attr_reader :carrier        # Carrier.name ('USPS', 'FedEx', etc.)
-    attr_reader :service_name   # name of service ("First Class Ground", etc.)
-    attr_reader :service_code
-    attr_reader :currency       # 'USD', 'CAD', etc.
-    # http://en.wikipedia.org/wiki/ISO_4217
-    attr_reader :shipping_date
-    attr_reader :delivery_date  # Usually only available for express shipments
-    attr_reader :delivery_range # Min and max delivery estimate in days
-    attr_reader :negotiated_rate
-    attr_reader :insurance_price
+    attr_reader :origin, :destination, :package_rates,
+                :carrier, :service_name, :service_code,
+                :shipping_date, :delivery_date, :delivery_range,
+                :currency, :negotiated_rate, :insurance_price
 
     def initialize(origin, destination, carrier, service_name, options = {})
       @origin, @destination, @carrier, @service_name = origin, destination, carrier, service_name
@@ -31,13 +77,20 @@ module ActiveShipping #:nodoc:
       @insurance_price = Package.cents_from(options[:insurance_price])
     end
 
+    # The total price of the shipments in cents.
+    # @return [Integer]
     def total_price
-      @total_price || @package_rates.sum { |p| p[:rate] }
+      @total_price || @package_rates.sum { |pr| pr[:rate] }
     rescue NoMethodError
       raise ArgumentError.new("RateEstimate must have a total_price set, or have a full set of valid package rates.")
     end
     alias_method :price, :total_price
 
+    # Adds a package to this rate estimate
+    # @param package [ActiveShipping::Package] The package to add.
+    # @param rate [#cents, Float, String, nil] The rate for this package. This is only required if
+    #   there is no total price for this shipment
+    # @return [self]
     def add(package, rate = nil)
       cents = Package.cents_from(rate)
       raise ArgumentError.new("New packages must have valid rate information since this RateEstimate has no total_price set.") if cents.nil? and total_price.nil?
@@ -45,16 +98,24 @@ module ActiveShipping #:nodoc:
       self
     end
 
+    # The list of packages for which rate estimates are given.
+    # @return [Array<ActiveShipping::Package>]
     def packages
       package_rates.map { |p| p[:package] }
     end
 
+    # The number of packages for which rate estimates are given.
+    # @return [Integer]
     def package_count
       package_rates.length
     end
 
     private
 
+    # Returns a Date object for a given input
+    # @param [String, Date, Time, DateTime, ...] The object to infer a date from.
+    # @return [Date, nil] The Date object absed on the input, or `nil` if no date
+    #   could be determined.
     def date_for(date)
       date && DateTime.strptime(date.to_s, "%Y-%m-%d")
     rescue ArgumentError

--- a/lib/active_shipping/rate_response.rb
+++ b/lib/active_shipping/rate_response.rb
@@ -1,7 +1,27 @@
 module ActiveShipping
+
+  # The `RateResponse` object is returned by the {ActiveShipping::Carrier#find_rates}
+  # call. The most important method is {#rates}, which will return a list of possible
+  # shipping options with ane stiated price.
+  #
+  # @note Some carriers provide more information that others, so not all attributes
+  #   will be set, depending on what carrier you are using.
+  #
+  # @!attribute rates
+  #    The available rate options for the shipment, with an estimated price.
+  #    @return [Array<ActiveShipping::RateEstimate>]
   class RateResponse < Response
+
     attr_reader :rates
 
+    # Initializes a new RateResponse instance.
+    #
+    # @param success (see ActiveShipping::Response#initialize)
+    # @param message (see ActiveShipping::Response#initialize)
+    # @param params (see ActiveShipping::Response#initialize)
+    # @option options (see ActiveShipping::Response#initialize)
+    # @option options [Array<ActiveShipping::RateEstimate>] :rates The rate estimates to
+    #   populate the {#rates} method with.
     def initialize(success, message, params = {}, options = {})
       @rates = Array(options[:estimates] || options[:rates] || options[:rate_estimates])
       super

--- a/lib/active_shipping/response.rb
+++ b/lib/active_shipping/response.rb
@@ -15,6 +15,7 @@ module ActiveShipping #:nodoc:
     end
   end
 
+  # Basic Response class for requests against a carrier's API.
   class Response
     attr_reader :params
     attr_reader :message
@@ -22,6 +23,16 @@ module ActiveShipping #:nodoc:
     attr_reader :xml
     attr_reader :request
 
+    # @param success [Boolean] Whether the request was considered successful, i.e. this
+    #   response object will have the expected data set.
+    # @param message [String] A status message. Usuaully set when `success` is `false`,
+    #   but can also be set for successful responses.
+    # @param params [Hash] Response parameters
+    # @param options [Hash]
+    # @option options [Boolean] :test (default: false) Whether this reponse was a result
+    #   of a request executed against the sandbox or test environment of the carrier's API.
+    # @option options [String] :xml The raw XML of the response.
+    # @option options [String] :request The payload of the request.
     def initialize(success, message, params = {}, options = {})
       @success, @message, @params = success, message, params.stringify_keys
       @test = options[:test] || false
@@ -30,10 +41,16 @@ module ActiveShipping #:nodoc:
       raise ResponseError.new(self) unless success
     end
 
+    # Whether the request was executed successfully or not.
+    # @return [Boolean] Should only return `true` if the attributes of teh response
+    #   instance are set with useful values.
     def success?
       @success ? true : false
     end
 
+    # Whether this request was executed against the sandbox or test environment instead of
+    # the production environment of the carrier.
+    # @return [Boolean]
     def test?
       @test ? true : false
     end

--- a/lib/active_shipping/shipment_packer.rb
+++ b/lib/active_shipping/shipment_packer.rb
@@ -7,8 +7,8 @@ module ActiveShipping
     class ExcessPackageQuantity < StandardError; end
 
     # items           - array of hashes containing quantity, grams and price.
-    #                   ex. [{:quantity => 2, :price => 1.0, :grams => 50}]
-    # dimensions      - [5.0, 15.0, 30.0]
+    #                   ex. `[{:quantity => 2, :price => 1.0, :grams => 50}]`
+    # dimensions      - `[5.0, 15.0, 30.0]`
     # maximum_weight  - maximum weight in grams
     # currency        - ISO currency code
     def self.pack(items, dimensions, maximum_weight, currency)

--- a/lib/active_shipping/shipping_response.rb
+++ b/lib/active_shipping/shipping_response.rb
@@ -1,8 +1,30 @@
 module ActiveShipping
-  class ShippingResponse < Response
-    attr_reader :shipping_id # string
-    attr_reader :tracking_number # string
 
+  # Responce object class for calls to {ActiveShipping::Carrier#create_shipment}.
+  #
+  # @note Some carriers provide more information that others, so not all attributes
+  #   will be set, depending on what carrier you are using.
+  #
+  # @!attribute shipping_id
+  #   The unique identifier of the shipment, which can be used to further interact
+  #   with the carrier's API.
+  #   @return [String]
+  #
+  # @!attribute tracking_number
+  #   The tracking number of the shipments, witch can be shared with the customer and
+  #   be used for {ActiveShipping::Carrier#find_tracking_info}.
+  #   @return [String]
+  class ShippingResponse < Response
+    attr_reader :shipping_id, :tracking_number
+
+    # Initializes a new ShippingResponse instance.
+    #
+    # @param success (see ActiveShipping::Response#initialize)
+    # @param message (see ActiveShipping::Response#initialize)
+    # @param params (see ActiveShipping::Response#initialize)
+    # @option options (see ActiveShipping::Response#initialize)
+    # @option options [String] :shipping_id Populates {#shipping_id}.
+    # @option options [String] :tracking_number Populates {#tracking_number}.
     def initialize(success, message, params = {}, options = {})
       @shipping_id = options[:shipping_id]
       @tracking_number = options[:tracking_number]

--- a/lib/active_shipping/tracking_response.rb
+++ b/lib/active_shipping/tracking_response.rb
@@ -1,18 +1,59 @@
 module ActiveShipping
-  class TrackingResponse < Response
-    attr_reader :carrier # symbol
-    attr_reader :carrier_name # string
-    attr_reader :status # symbol
-    attr_reader :status_code # string
-    attr_reader :status_description # string
-    attr_reader :ship_time # time
-    attr_reader :scheduled_delivery_date # time
-    attr_reader :actual_delivery_date # time
-    attr_reader :delivery_signature # string
-    attr_reader :tracking_number # string
-    attr_reader :shipment_events # array of ShipmentEvents in chronological order
-    attr_reader :shipper_address, :origin, :destination # Location objects
 
+  # Represents the response to a {ActiveShipping::Carrier#find_tracking_info} call.
+  #
+  # @note Some carriers provide more information that others, so not all attributes
+  #   will be set, depending on what carrier you are using.
+  #
+  # @!attribute carrier
+  #   @return [Symbol]
+  #
+  # @!attribute carrier_name
+  #   @return [String]
+  #
+  # @!attribute status
+  #   @return [Symbol]
+  #
+  # @!attribute status_code
+  #   @return [string]
+  #
+  # @!attribute status_description
+  #   @return [String]
+  #
+  # @!attribute ship_time
+  #   @return [Date, Time]
+  #
+  # @!attribute scheduled_delivery_date
+  #   @return [Date, Time]
+  #
+  # @!attribute actual_delivery_date
+  #   @return [Date, Time]
+  #
+  # @!attribute delivery_signature
+  #   @return [String]
+  #
+  # @!attribute tracking_number
+  #   @return [String]
+  #
+  # @!attribute shipment_events
+  #   @return [Array<ActiveShipping::ShipmentEvent>]
+  #
+  # @!attribute shipper_address
+  #   @return [ActiveShipping::Location]
+  #
+  # @!attribute origin
+  #   @return [ActiveShipping::Location]
+  #
+  # @!attribute destination
+  #   @return [ActiveShipping::Location]
+  class TrackingResponse < Response
+    attr_reader :carrier,:carrier_name,
+                :status,:status_code, :status_description,
+                :ship_time, :scheduled_delivery_date, :actual_delivery_date,
+                :delivery_signature, :tracking_number, :shipment_events,
+                :shipper_address, :origin, :destination
+
+    # @params (see ActiveShipping::Response#initialize)
     def initialize(success, message, params = {}, options = {})
       @carrier = options[:carrier].parameterize.to_sym
       @carrier_name = options[:carrier]
@@ -31,22 +72,29 @@ module ActiveShipping
       super
     end
 
+    # The latest tracking event for this shipment, i.e. the current status.
+    # @return [ActiveShipping::ShipmentEvent]
     def latest_event
       @shipment_events.last
     end
 
+    # Returns `true` if something the shipment has arrived at the destination.
+    # @return [Boolean]
     def is_delivered?
       @status == :delivered
     end
 
+    # Returns `true` if something out of the ordinary has happened during
+    # the delivery of this package.
+    # @return [Boolean]
     def has_exception?
       @status == :exception
     end
 
-    alias_method(:exception_event, :latest_event)
-    alias_method(:delivered?, :is_delivered?)
-    alias_method(:exception?, :has_exception?)
-    alias_method(:scheduled_delivery_time, :scheduled_delivery_date)
-    alias_method(:actual_delivery_time, :actual_delivery_date)
+    alias_method :exception_event, :latest_event
+    alias_method :delivered?, :is_delivered?
+    alias_method :exception?, :has_exception?
+    alias_method :scheduled_delivery_time, :scheduled_delivery_date
+    alias_method :actual_delivery_time, :actual_delivery_date
   end
 end


### PR DESCRIPTION
This adds some documentation for the different response classes.

I tried to do this as well as possible, but the different carriers are not necessarily consistent in what values they assign to the different attributes in the response objects. Not sure if we want to tackle these; for now I left the scope of this PR to docs only.

@Shopify/shipping 