### PR TITLE
Fixes a remote tests for USPS: raise an exception if the tracking number is not found.

### DIFF
--- a/lib/active_shipping/carriers/usps.rb
+++ b/lib/active_shipping/carriers/usps.rb
@@ -540,7 +540,12 @@ module ActiveShipping
         tracking_details = xml.root.xpath('TrackInfo/TrackDetail')
 
         tracking_summary = xml.root.at('TrackInfo/TrackSummary')
-        tracking_details << tracking_summary
+        if tracking_details.length > 0
+          tracking_details << tracking_summary
+        else
+          success = false
+          message = tracking_summary.text
+        end
 
         tracking_number = xml.root.at('TrackInfo').attributes['ID'].value
 
@@ -589,23 +594,12 @@ module ActiveShipping
       !document.at('Error').nil?
     end
 
-    def no_record?(document)
-      summary_node = track_summary_node(document)
-      if summary_node
-        summary = summary_node.text
-        RESPONSE_ERROR_MESSAGES.detect { |re| summary =~ re }
-        summary =~ /There is no record of that mail item/ || summary =~ /This Information has not been included in this Test Server\./
-      else
-        false
-      end
-    end
-
     def tracking_info_error?(document)
       !document.root.at('TrackInfo/Error').nil?
     end
 
     def response_success?(document)
-      !(has_error?(document) || no_record?(document) || tracking_info_error?(document))
+      !(has_error?(document) || tracking_info_error?(document))
     end
 
     def response_message(document)

--- a/test/fixtures/xml/usps/tracking_response_failure.xml
+++ b/test/fixtures/xml/usps/tracking_response_failure.xml
@@ -1,3 +1,2 @@
-<?xml version="1.0"?>
-<TrackResponse><TrackInfo ID="ABC123XYZ"><TrackSummary>There is no record of that mail item. If it was mailed recently, it may not yet be tracked. Please try again later.</TrackSummary></TrackInfo>
-</TrackResponse>
+<?xml version="1.0" encoding="UTF-8"?>
+<TrackResponse><TrackInfo ID="abc123xyz"><TrackSummary>The Postal Service could not locate the tracking information for your request. Please verify your tracking number and try again later.</TrackSummary></TrackInfo></TrackResponse>


### PR DESCRIPTION
@Shopify/shipping This one fell trough the cracks.