### PR TITLE
Update test framework so remote tests can be run on CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 language: ruby
-script: bundle exec rake
+script: bundle exec rake test
 sudo: false
 
 rvm:
@@ -12,3 +12,8 @@ gemfile:
 - Gemfile.activesupport40
 - Gemfile.activesupport41
 - Gemfile.activesupport42
+
+env:
+  global:
+  - ACTIVESHIPPING_NEW_ZEALAND_POST_KEY=4d9dc0f0-dda0-012e-066f-000c29b44ac0
+  - ACTIVESHIPPING_CANADA_POST_LOGIN=CPC_DEMO_XML

--- a/Rakefile
+++ b/Rakefile
@@ -1,14 +1,22 @@
-require 'bundler'
 require 'bundler/gem_tasks'
 require 'rake/testtask'
 
+desc "Run the unit and functioknal remote tests"
+Rake::TestTask.new(:test) do |t|
+  t.libs << "test"
+  t.pattern = 'test/**/*_test.rb'
+  t.verbose = true
+end
+
 namespace :test do
+  desc "Run unit tests"
   Rake::TestTask.new(:units) do |t|
     t.libs << "test"
     t.pattern = 'test/unit/**/*_test.rb'
     t.verbose = true
   end
 
+  desc "Run functional remote tests"
   Rake::TestTask.new(:remote) do |t|
     t.libs << "test"
     t.pattern = 'test/remote/*_test.rb'
@@ -16,8 +24,4 @@ namespace :test do
   end
 end
 
-desc "Default Task"
 task :default => 'test:units'
-
-desc "Run the unit and remote tests"
-task :test => %w(test:units test:remote)

--- a/Rakefile
+++ b/Rakefile
@@ -10,7 +10,7 @@ end
 
 namespace :test do
   desc "Run unit tests"
-  Rake::TestTask.new(:units) do |t|
+  Rake::TestTask.new(:unit) do |t|
     t.libs << "test"
     t.pattern = 'test/unit/**/*_test.rb'
     t.verbose = true
@@ -24,4 +24,4 @@ namespace :test do
   end
 end
 
-task :default => 'test:units'
+task :default => 'test'

--- a/test/credentials.yml
+++ b/test/credentials.yml
@@ -1,47 +1,61 @@
+# The following file is used to specify credentials for the remote tests.
+# In the CI environment, the environment are populated with proper values.
+# If the values are not set, the remote tests will be skipped.
+#
+# If you want to run remote tests locally, you can set these environment
+# variables, or you can create a file `~/.active_shipping/credentials.yml`,
+# and set the values in there. This way you won't accidentially commit them
+# to git.
+
 usps:
-  login: APIKey
+  login: <%= ENV['ACTIVESHIPPING_USPS_LOGIN'] %>
+
 ups:
-  key: XmlAccessKey
-  login: UPSDotComLogin
-  password: UPSDotComPassword
+  key: <%= ENV['ACTIVESHIPPING_UPS_LOGIN'] %>
+  login: <%= ENV['ACTIVESHIPPING_UPS_KEY'] %>
+  password: <%= ENV['ACTIVESHIPPING_UPS_PASSWORD'] %>
 
 fedex:
-  account: FedExAccountNumber
-  login: FedExMeterNumber
-  password: FedExMeterPassword
-  test: true
-  key: FedExDeveloperKey
-
-fedex_freight:
-  account: FedExFreightAccountNumber
-  shipping_address1: FedExShippingAddress1
-  shipping_address2: FedExShippingAddress2
-  shipping_city: FedExShippingCity
-  shipping_postal_code: FedExShippingPostalCode
-  shipping_state: FedExShippingState
-  shipping_country: FedExShippingCountry
-  billing_address1: FedExBillingAddress1
-  billing_address2: FedExBillingAddress2
-  billing_city: FedExBillingCity
-  billing_postal_code: FedExBillingPostalCode
-  billing_state: FedExBillingState
-  billing_country: FedExBillingCountry
-  payment_type: SENDER
-  freight_class: CLASS_050
-  packaging: PALLET
-  role: SHIPPER
+  account: <%= ENV['ACTIVESHIPPING_FEDEX_ACCOUNT'] %>
+  login: <%= ENV['ACTIVESHIPPING_FEDEX_LOGIN'] %>
+  password: <%= ENV['ACTIVESHIPPING_FEDEX_PASSWORD'] %>
+  key: <%= ENV['ACTIVESHIPPING_FEDEX_KEY'] %>
 
 shipwire:
-  login: EmailAddress
-  password: Password
+  login: <%= ENV['ACTIVESHIPPING_SHIPWIRE_LOGIN'] %>
+  password: <%= ENV['ACTIVESHIPPING_SHIPWITE_PASSWORD'] %>
 
 canada_post:
-  login: CPC_DEMO_XML
+  login: <%= ENV['ACTIVESHIPPING_CANADA_POST_LOGIN'] %>
 
 new_zealand_post:
-  key: '4d9dc0f0-dda0-012e-066f-000c29b44ac0'
+  key: <%= ENV['ACTIVESHIPPING_NEW_ZEALAND_POST_KEY'] %>
 
 canada_post_pws:
-  platform_id: 12345678
-  api_key: 1234789
-  secret: 1245743
+  platform_id: <%= ENV['ACTIVESHIPPING_CANADA_POST_PWS_PLATFORM_ID'] %>
+  api_key: <%= ENV['ACTIVESHIPPING_CANADA_POST_PWS_API_KEY'] %>
+  secret: <%= ENV['ACTIVESHIPPING_CANADA_POST_PWS_SECRET'] %>
+
+stamps:
+  integration_id: <%= ENV['ACTIVESHIPPING_STAMPS_INTEGRATION_ID'] %>
+  username: <%= ENV['ACTIVESHIPPING_STAMPS_USERNAME'] %>
+  password: <%= ENV['ACTIVESHIPPING_STAMPS_PASSWORD'] %>
+
+# fedex_freight:
+#   account: FedExFreightAccountNumber
+#   shipping_address1: FedExShippingAddress1
+#   shipping_address2: FedExShippingAddress2
+#   shipping_city: FedExShippingCity
+#   shipping_postal_code: FedExShippingPostalCode
+#   shipping_state: FedExShippingState
+#   shipping_country: FedExShippingCountry
+#   billing_address1: FedExBillingAddress1
+#   billing_address2: FedExBillingAddress2
+#   billing_city: FedExBillingCity
+#   billing_postal_code: FedExBillingPostalCode
+#   billing_state: FedExBillingState
+#   billing_country: FedExBillingCountry
+#   payment_type: SENDER
+#   freight_class: CLASS_050
+#   packaging: PALLET
+#   role: SHIPPER

--- a/test/remote/canada_post_pws_platform_test.rb
+++ b/test/remote/canada_post_pws_platform_test.rb
@@ -3,7 +3,7 @@
 require 'test_helper'
 
 # All remote tests require Canada Post development environment credentials
-class CanadaPostPWSPlatformTest < Minitest::Test
+class RemoteCanadaPostPWSPlatformTest < Minitest::Test
   include ActiveShipping::Test::Credentials
   include ActiveShipping::Test::Fixtures
 
@@ -95,6 +95,8 @@ class CanadaPostPWSPlatformTest < Minitest::Test
     @customer_number  = @login[:customer_number]
     @customer_api_key = @login[:customer_api_key]
     @customer_secret  = @login[:customer_secret]
+  rescue NoCredentialsFound => e
+    skip(e.message)
   end
 
   def build_options

--- a/test/remote/canada_post_pws_test.rb
+++ b/test/remote/canada_post_pws_test.rb
@@ -1,6 +1,6 @@
 require 'test_helper'
 
-class CanadaPostPWSTest < Minitest::Test
+class RemoteCanadaPostPWSTest < Minitest::Test
   # All remote tests require Canada Post development environment credentials
   include ActiveShipping::Test::Credentials
   include ActiveShipping::Test::Fixtures
@@ -84,6 +84,8 @@ class CanadaPostPWSTest < Minitest::Test
       :tracking_number => "11111118901234",
       :label_url => "https://ct.soa-gw.canadapost.ca/ers/artifact/#{@login[:api_key]}/20238/0"
     }
+  rescue NoCredentialsFound => e
+    skip(e.message)
   end
 
   def test_rates

--- a/test/remote/canada_post_test.rb
+++ b/test/remote/canada_post_test.rb
@@ -1,6 +1,6 @@
 require 'test_helper'
 
-class CanadaPostTest < Minitest::Test
+class RemoteCanadaPostTest < Minitest::Test
   include ActiveShipping::Test::Credentials
 
   def setup
@@ -10,6 +10,8 @@ class CanadaPostTest < Minitest::Test
     @origin      = {:address1 => "61A York St", :city => "Ottawa", :province => "Ontario", :country => "Canada", :postal_code => "K1N 5T2"}
     @destination = {:city => "Beverly Hills", :state => "CA", :country => "United States", :postal_code => "90210"}
     @line_items  = [Package.new(500, [2, 3, 4], :description => "a box full of stuff", :value => 25)]
+  rescue NoCredentialsFound => e
+    skip(e.message)
   end
 
   def test_valid_credentials

--- a/test/remote/fedex_test.rb
+++ b/test/remote/fedex_test.rb
@@ -1,11 +1,13 @@
 require 'test_helper'
 
-class FedExTest < Minitest::Test
+class RemoteFedExTest < Minitest::Test
   include ActiveShipping::Test::Credentials
   include ActiveShipping::Test::Fixtures
 
   def setup
     @carrier = FedEx.new(credentials(:fedex).merge(:test => true))
+  rescue NoCredentialsFound => e
+    skip(e.message)
   end
 
   def test_valid_credentials

--- a/test/remote/new_zealand_post_test.rb
+++ b/test/remote/new_zealand_post_test.rb
@@ -1,6 +1,6 @@
 require 'test_helper'
 
-class NewZealandPostTest < Minitest::Test
+class RemoteNewZealandPostTest < Minitest::Test
   include ActiveShipping::Test::Credentials
   include ActiveShipping::Test::Fixtures
 
@@ -9,6 +9,8 @@ class NewZealandPostTest < Minitest::Test
     @wellington = location_fixtures[:wellington]
     @auckland = location_fixtures[:auckland]
     @ottawa = location_fixtures[:ottawa]
+  rescue NoCredentialsFound => e
+    skip(e.message)
   end
 
   def test_valid_credentials

--- a/test/remote/shipwire_test.rb
+++ b/test/remote/shipwire_test.rb
@@ -9,6 +9,8 @@ class RemoteShipwireTest < Minitest::Test
     @item1 = { :sku => 'AF0001', :quantity => 2 }
     @item2 = { :sku => 'AF0002', :quantity => 1 }
     @items = [@item1, @item2]
+  rescue NoCredentialsFound => e
+    skip(e.message)
   end
 
   def test_successful_domestic_rates_request_for_single_line_item

--- a/test/remote/stamps_test.rb
+++ b/test/remote/stamps_test.rb
@@ -1,11 +1,12 @@
 require 'test_helper'
 
-class StampsTest < Minitest::Test
+class RemoteStampsTest < Minitest::Test
   include ActiveShipping::Test::Credentials
-  include ActiveShipping::Test::Fixtures
 
   def setup
     @carrier = Stamps.new(credentials(:stamps).merge(test: true))
+  rescue NoCredentialsFound => e
+    skip(e.message)
   end
 
   def test_valid_credentials

--- a/test/remote/ups_test.rb
+++ b/test/remote/ups_test.rb
@@ -1,12 +1,14 @@
 require 'test_helper'
 
-class UPSTest < Minitest::Test
+class RemoteUPSTest < Minitest::Test
   include ActiveShipping::Test::Credentials
   include ActiveShipping::Test::Fixtures
 
   def setup
     @options = credentials(:ups).merge(:test => true)
     @carrier = UPS.new(@options)
+  rescue NoCredentialsFound => e
+    skip(e.message)
   end
 
   def test_tracking

--- a/test/remote/usps_test.rb
+++ b/test/remote/usps_test.rb
@@ -1,11 +1,14 @@
 require 'test_helper'
 
-class USPSTest < Minitest::Test
+class RemoteUSPSTest < Minitest::Test
   include ActiveShipping::Test::Credentials
   include ActiveShipping::Test::Fixtures
 
   def setup
-    @carrier = USPS.new(credentials(:usps))
+    @usps_credentials = credentials(:usps)
+    @carrier = USPS.new(@usps_credentials)
+  rescue NoCredentialsFound => e
+    skip(e.message)
   end
 
   def test_tracking
@@ -199,7 +202,7 @@ class USPSTest < Minitest::Test
   end
 
   def test_valid_credentials
-    assert USPS.new(credentials(:usps).merge(:test => true)).valid_credentials?
+    assert USPS.new(@usps_credentials.merge(:test => true)).valid_credentials?
   end
 
   def test_must_provide_login_creds_when_instantiating

--- a/test/unit/carriers/canada_post_pws_rating_test.rb
+++ b/test/unit/carriers/canada_post_pws_rating_test.rb
@@ -1,7 +1,6 @@
 require 'test_helper'
 
 class CanadaPostPwsRatingTest < Minitest::Test
-  include ActiveShipping::Test::Credentials
   include ActiveShipping::Test::Fixtures
 
   def setup
@@ -38,10 +37,11 @@ class CanadaPostPwsRatingTest < Minitest::Test
 
     @customer_number = '654321'
 
-    @cp = CanadaPostPWS.new(credentials(:canada_post_pws))
+    credentials = { platform_id: 123, api_key: '456', secret: '789' }
+    @cp = CanadaPostPWS.new(credentials)
     @cp.logger = Logger.new(StringIO.new)
-    @french_cp = CanadaPostPWS.new(credentials(:canada_post_pws).merge(:language => 'fr'))
-    @cp_customer_number = CanadaPostPWS.new(credentials(:canada_post_pws).merge(:customer_number => @customer_number))
+    @french_cp = CanadaPostPWS.new(credentials.merge(language: 'fr'))
+    @cp_customer_number = CanadaPostPWS.new(credentials.merge(customer_number: @customer_number))
 
     @default_options = {:customer_number => '123456'}
   end

--- a/test/unit/carriers/canada_post_pws_register_test.rb
+++ b/test/unit/carriers/canada_post_pws_register_test.rb
@@ -1,11 +1,10 @@
 require 'test_helper'
 
 class CanadaPostPwsRegisterTest < Minitest::Test
-  include ActiveShipping::Test::Credentials
   include ActiveShipping::Test::Fixtures
 
   def setup
-    @cp = CanadaPostPWS.new(credentials(:canada_post_pws))
+    @cp = CanadaPostPWS.new(platform_id: 123, api_key: '456', secret: '789')
   end
 
   def test_register_merchant

--- a/test/unit/carriers/canada_post_pws_shipping_test.rb
+++ b/test/unit/carriers/canada_post_pws_shipping_test.rb
@@ -1,6 +1,5 @@
 require 'test_helper'
 class CanadaPostPwsShippingTest < Minitest::Test
-  include ActiveShipping::Test::Credentials
   include ActiveShipping::Test::Fixtures
 
   def setup
@@ -71,7 +70,7 @@ class CanadaPostPwsShippingTest < Minitest::Test
       :label_url => "https://ct.soa-gw.canadapost.ca/ers/artifact/c70da5ed5a0d2c32/20238/0"
     }
 
-    @cp = CanadaPostPWS.new(credentials(:canada_post_pws))
+    @cp = CanadaPostPWS.new(platform_id: 123, api_key: '456', secret: '789')
   end
 
   def test_build_shipment_customs_node

--- a/test/unit/carriers/canada_post_pws_tracking_test.rb
+++ b/test/unit/carriers/canada_post_pws_tracking_test.rb
@@ -1,6 +1,6 @@
 require 'test_helper'
+
 class CanadaPostPwsTrackingTest < Minitest::Test
-  include ActiveShipping::Test::Credentials
   include ActiveShipping::Test::Fixtures
 
   def setup
@@ -29,7 +29,7 @@ class CanadaPostPwsTrackingTest < Minitest::Test
       :zip      => '90210'
     )
 
-    @cp = CanadaPostPWS.new(credentials(:canada_post_pws))
+    @cp = CanadaPostPWS.new(platform_id: 123, api_key: '456', secret: '789')
   end
 
   def test_find_tracking_info_with_valid_pin

--- a/test/unit/carriers/canada_post_test.rb
+++ b/test/unit/carriers/canada_post_test.rb
@@ -1,14 +1,13 @@
 require 'test_helper'
 
 class CanadaPostTest < Minitest::Test
-  include ActiveShipping::Test::Credentials
   include ActiveShipping::Test::Fixtures
 
   def setup
-    login = credentials(:canada_post)
+    login = { login: 'CPC_DEMO_XML' }
 
     @carrier  = CanadaPost.new(login)
-    @french_carrier  = CanadaPost.new(login.merge(:french => true))
+    @french_carrier  = CanadaPost.new(login.merge(french: true))
 
     @request  = xml_fixture('canadapost/example_request')
     @response = xml_fixture('canadapost/example_response')

--- a/test/unit/carriers/usps_test.rb
+++ b/test/unit/carriers/usps_test.rb
@@ -2,7 +2,6 @@ require 'test_helper'
 
 class USPSTest < Minitest::Test
   include ActiveShipping::Test::Fixtures
-  include ActiveShipping::Test::Credentials
 
   def setup
     @carrier = USPS.new(:login => 'login')
@@ -365,12 +364,13 @@ class USPSTest < Minitest::Test
   end
 
   def test_domestic_commercial_base_rates
-    @carrier = USPS.new(credentials(:usps).merge(:commercial_base => true))
+    commercial_base_credentials = { key: "123", login: "user", password: "pass", commercial_base: true }
+    carrier = USPS.new(commercial_base_credentials)
 
     mock_response = xml_fixture('usps/beverly_hills_to_new_york_book_commercial_base_rate_response')
-    @carrier.expects(:commit).returns(mock_response)
+    carrier.expects(:commit).returns(mock_response)
 
-    response = @carrier.find_rates(
+    response = carrier.find_rates(
       location_fixtures[:beverly_hills],
       location_fixtures[:new_york],
       package_fixtures.values_at(:book),
@@ -385,12 +385,13 @@ class USPSTest < Minitest::Test
   end
 
   def test_intl_commercial_base_rates
-    @carrier = USPS.new(credentials(:usps).merge(:commercial_base => true))
+    commercial_base_credentials = { key: "123", login: "user", password: "pass", commercial_base: true }
+    carrier = USPS.new(commercial_base_credentials)
 
     mock_response = xml_fixture('usps/beverly_hills_to_ottawa_american_wii_commercial_base_rate_response')
-    @carrier.expects(:commit).returns(mock_response)
+    carrier.expects(:commit).returns(mock_response)
 
-    response = @carrier.find_rates(
+    response = carrier.find_rates(
       location_fixtures[:beverly_hills],
       location_fixtures[:ottawa],
       package_fixtures.values_at(:american_wii),
@@ -401,12 +402,13 @@ class USPSTest < Minitest::Test
   end
 
   def test_domestic_commercial_plus_rates
-    @carrier = USPS.new(credentials(:usps).merge(:commercial_plus => true))
+    commercial_plus_credentials = { key: "123", login: "user", password: "pass", commercial_plus: true }
+    carrier = USPS.new(commercial_plus_credentials)
 
     mock_response = xml_fixture('usps/beverly_hills_to_new_york_book_commercial_plus_rate_response')
-    @carrier.expects(:commit).returns(mock_response)
+    carrier.expects(:commit).returns(mock_response)
 
-    response = @carrier.find_rates(
+    response = carrier.find_rates(
       location_fixtures[:beverly_hills],
       location_fixtures[:new_york],
       package_fixtures.values_at(:book),
@@ -421,12 +423,13 @@ class USPSTest < Minitest::Test
   end
 
   def test_intl_commercial_plus_rates
-    @carrier = USPS.new(credentials(:usps).merge(:commercial_plus => true))
+    commercial_plus_credentials = { key: "123", login: "user", password: "pass", commercial_plus: true }
+    carrier = USPS.new(commercial_plus_credentials)
 
     mock_response = xml_fixture('usps/beverly_hills_to_ottawa_american_wii_commercial_plus_rate_response')
-    @carrier.expects(:commit).returns(mock_response)
+    carrier.expects(:commit).returns(mock_response)
 
-    response = @carrier.find_rates(
+    response = carrier.find_rates(
       location_fixtures[:beverly_hills],
       location_fixtures[:ottawa],
       package_fixtures.values_at(:american_wii),

--- a/test/unit/rate_estimate_test.rb
+++ b/test/unit/rate_estimate_test.rb
@@ -1,13 +1,11 @@
 require 'test_helper'
 
 class RateEstimateTest < Minitest::Test
-  include ActiveShipping::Test::Credentials
-
   def setup
     @origin      = {:address1 => "61A York St", :city => "Ottawa", :province => "ON", :country => "Canada", :postal_code => "K1N 5T2"}
     @destination = {:city => "Beverly Hills", :state => "CA", :country => "United States", :postal_code => "90210"}
     @line_items  = [Package.new(500, [2, 3, 4], :description => "a box full of stuff", :value => 2500)]
-    @carrier     = CanadaPost.new(credentials(:canada_post))
+    @carrier     = CanadaPost.new(login: 'test')
     @options     = {:currency => 'USD'}
 
     @rate_estimate = RateEstimate.new(@origin, @destination, @carrier, @service_name, @options)


### PR DESCRIPTION
Hello @Shopify/shipping, it's me again! :) 

- Pass credentials.yml through ERB, so we can populate it with values from environment variables.
- Skip remote tests when asking for credentials, but none are set in `credentials.yml`.
- Make sure remote test class names are prefixed with Remote, and do not clash with unit test class names.
- Set up Travis to also run remote tests.

I added the test API keys for Canada Post and New Zealand Post to the Travis environment. These credentials were already made public in `credentials.yml`, so I assume that's OK. For the other ones, we can use [Travis's encrypted environment variables](http://docs.travis-ci.com/user/environment-variables/#Secure-Variables).