### PR TITLE
[Canada Post PWS] Fix remote platform tests

### DIFF
--- a/lib/active_shipping/carriers/canada_post_pws.rb
+++ b/lib/active_shipping/carriers/canada_post_pws.rb
@@ -222,7 +222,7 @@ module ActiveShipping
       prereqs = option_node.elements['prerequisite-options'].elements.collect('option-code') { |node| node.get_text.to_s } unless option_node.elements['prerequisite-options'].blank?
       option = {
         :code => option_node.get_text('option-code').to_s,
-        :name => option_node.get_text('option-name').to_s,
+        :name => REXML::Text.unnormalize(option_node.get_text('option-name').to_s),
         :class => option_node.get_text('option-class').to_s,
         :prints_on_label => option_node.get_text('prints-on-label').to_s == "false" ? false : true,
         :qualifier_required => option_node.get_text('qualifier-required').to_s == "false" ? false : true


### PR DESCRIPTION
Now also the platform tests work again.

I had to reinstate an `unnormalize` call, because REXML doesn't deal with characters encoding using entities well (e.g. `&#123;` => `à`. I will fix this when moving to Nokogiri.