### PR TITLE
Add more options to UPS create_shipment

### DIFF
--- a/lib/active_shipping/carriers/ups.rb
+++ b/lib/active_shipping/carriers/ups.rb
@@ -144,8 +144,8 @@ module ActiveShipping
         xml = parse_ship_confirm(confirm_response)
         success = response_success?(xml)
         message = response_message(xml)
-        digest  = response_digest(xml)
         raise message unless success
+        digest  = response_digest(xml)
 
         # STEP 2: Accept. Use shipment digest in first response to get the actual label.
         accept_request = build_accept_request(digest, options)
@@ -182,7 +182,7 @@ module ActiveShipping
       xml_builder = Nokogiri::XML::Builder.new do |xml|
         xml.AccessRequest do
           xml.AccessLicenseNumber(@options[:key])
-          xml.UserId(@options[:password])
+          xml.UserId(@options[:login])
           xml.Password(@options[:password])
         end
       end
@@ -251,18 +251,29 @@ module ActiveShipping
     # * shipper: who is sending the package and where it should be returned
     #     if it is undeliverable.
     # * ship_from: where the package is picked up.
-    # * service_code: default to '14'
-    # * service_descriptor: default to 'Next Day Air Early AM'
+    # * service_code: default to '03'
     # * saturday_delivery: any truthy value causes this element to exist
     # * optional_processing: 'validate' (blank) or 'nonvalidate' or blank
-    #
-    def build_shipment_request(origin, destination, packages, options = {})
-      # There are a lot of unimplemented elements, documenting all of them
-      # wouldprobably be unhelpful.
+    # * paperless_invoice: set to truthy if using paperless invoice to ship internationally
+    # * terms_of_shipment: used with paperless invoice to specify who pays duties and taxes
+    # * reference_numbers: Array of hashes with :value => a reference number value and optionally :code => reference number type
+    # * prepay: if truthy the shipper will be bill immediatly. Otherwise the shipper is billed when the label is used.
+    def build_shipment_request(origin, destination, packages, options={})
+      packages = Array(packages)
+      options[:international] = origin.country.name != destination.country.name
+      options[:imperial] ||= IMPERIAL_COUNTRIES.include?(origin.country_code(:alpha2))
+      if allow_package_level_reference_numbers(origin, destination)
+        if options[:reference_numbers]
+          packages.each do |package|
+            package.options[:reference_numbers] = options[:reference_numbers]
+          end
+        end
+        options[:reference_numbers] = []
+      end
+
       xml_builder = Nokogiri::XML::Builder.new do |xml|
         xml.ShipmentConfirmRequest do
           xml.Request do
-            # Required element and the text must be "ShipConfirm"
             xml.RequestAction('ShipConfirm')
             # Required element cotnrols level of address validation.
             xml.RequestOption(options[:optional_processing] || 'validate')
@@ -275,54 +286,71 @@ module ActiveShipping
           end
 
           xml.Shipment do
-            # Required element.
             xml.Service do
-              xml.Code(options[:service_code] || '14')
-              xml.Description(options[:service_description] || 'Next Day Air Early AM')
+              xml.Code(options[:service_code] || '03')
             end
 
-            # Required element. The delivery destination.
-            build_location_node(xml, 'ShipTo', destination, {})
+            build_location_node(xml, 'ShipTo', destination, options)
+            build_location_node(xml, 'ShipFrom', origin, options)
             # Required element. The company whose account is responsible for the label(s).
-            build_location_node(xml, 'Shipper', options[:shipper] || origin, {})
-            # Required if pickup is different different from shipper's address.
-            build_location_node(xml, 'ShipFrom', options[:ship_from], {}) if options[:ship_from]
+            build_location_node(xml, 'Shipper', options[:shipper] || origin, options)
 
-            # Optional.
             if options[:saturday_delivery]
               xml.ShipmentServiceOptions do
                 xml.SaturdayDelivery
               end
             end
 
-            # Optional.
             if options[:origin_account]
               xml.RateInformation do
                 xml.NegotiatedRatesIndicator
               end
             end
 
-            # Optional.
-            if options[:shipment] && options[:shipment][:reference_number]
+            Array(options[:reference_numbers]).each do |reference_num_info|
               xml.ReferenceNumber do
-                xml.Code(options[:shipment][:reference_number][:code] || "")
-                xml.Value(options[:shipment][:reference_number][:value])
+                xml.Code(reference_num_info[:code] || "")
+                xml.Value(reference_num_info[:value])
               end
             end
 
-            # Conditionally required.  Either this element or an ItemizedPaymentInformation
-            # is needed.  However, only PaymentInformation is not implemented.
-            xml.PaymentInformation do
-              xml.Prepaid do
-                xml.BillShipper do
-                  xml.AccountNumber(options[:origin_account])
+            if options[:prepay]
+              xml.PaymentInformation do
+                xml.Prepaid do
+                  xml.BillShipper do
+                    xml.AccountNumber(options[:origin_account])
+                  end
+                end
+              end
+            else
+              xml.ItemizedPaymentInformation do
+                xml.ShipmentCharge do
+                  # Type '01' means 'Transportation'
+                  # This node specifies who will be billed for transportation.
+                  xml.Type('01')
+                  xml.BillShipper do
+                    xml.AccountNumber(options[:origin_account])
+                  end
+                end
+                if options[:terms_of_shipment] == 'DDP'
+                  # DDP stands for delivery duty paid and means the shipper will cover duties and taxes
+                  # Otherwise UPS will charge the receiver
+                  xml.ShipmentCharge do
+                    xml.Type('02') # Type '02' means 'Duties and Taxes'
+                    xml.BillShipper do
+                      xml.AccountNumber(options[:origin_account])
+                    end
+                  end
                 end
               end
             end
 
+            if options[:international]
+              build_international_shipment_request_options(xml, origin, destination, packages, options)
+            end
+
             # A request may specify multiple packages.
-            options[:imperial] ||= IMPERIAL_COUNTRIES.include?(origin.country_code(:alpha2))
-            Array(packages).each do |package|
+            packages.each do |package|
               build_package_node(xml, package, options)
             end
           end
@@ -341,6 +369,53 @@ module ActiveShipping
         end
       end
       xml_builder.to_xml
+    end
+
+    def build_international_shipment_request_options(xml, origin, destination, packages, options)
+      build_location_node(xml, 'SoldTo', options[:sold_to] || destination, options)
+      if options[:paperless_invoice]
+        xml.ShipmentServiceOptions do
+          xml.InternationalForms do
+            xml.FormType('01') # 01 is "Invoice"
+            xml.InvoiceDate(options[:invoice_date] || Date.today.strftime('%Y%m%d'))
+            xml.ReasonForExport(options[:reason_for_export] || 'SALE')
+            xml.CurrencyCode(options[:currency_code] || 'USD')
+
+            if options[:terms_of_shipment]
+              xml.TermsOfShipment(options[:terms_of_shipment])
+            end
+
+            packages.each do |package|
+              xml.Product do |xml|
+                xml.Description(package.options[:description])
+                xml.CommodityCode(package.options[:commodity_code])
+                xml.OriginCountryCode(origin.country_code(:alpha2))
+                xml.Unit do |xml|
+                  xml.Value(package.value / (package.options[:item_count] || 1))
+                  xml.Number((package.options[:item_count] || 1))
+                  xml.UnitOfMeasurement do |xml|
+                    # NMB = number. You can specify units in barrels, boxes, etc. Codes are in the api docs.
+                    xml.Code(package.options[:unit_of_item_count] || 'NMB')
+                  end
+                end
+              end
+            end
+          end
+        end
+      end
+
+      if origin.country_code(:alpha2) == 'US' && ['CA', 'PR'].include?(destination.country_code(:alpha2))
+        # Required for shipments from the US to Puerto Rico or Canada
+        xml.InvoiceLineTotal do
+          total_value = packages.inject(0) {|sum, package| sum + (package.value || 0)}
+          xml.MonetaryValue(total_value)
+        end
+      end
+
+      contents_description = packages.map {|p| p.options[:description]}.compact.join(',')
+      unless contents_description.empty?
+        xml.Description(contents_description)
+      end
     end
 
     def build_accept_request(digest, options = {})
@@ -374,8 +449,7 @@ module ActiveShipping
       #                   * Shipment/(Shipper|ShipTo|ShipFrom)/AttentionName element
       #                   * Shipment/(Shipper|ShipTo|ShipFrom)/TaxIdentificationNumber element
       xml.public_send(name) do
-        # You must specify the shipper name when creating labels.
-        if shipper_name = (options[:origin_name] || @options[:origin_name])
+        if shipper_name = (location.name || location.company_name || options[:origin_name])
           xml.Name(shipper_name)
         end
         xml.PhoneNumber(location.phone.gsub(/[^\d]/, '')) unless location.phone.blank?
@@ -387,7 +461,7 @@ module ActiveShipping
           xml.ShipperAssignedIdentificationNumber(destination_account)
         end
 
-        if name = location.company_name || location.name
+        if name = (location.company_name || location.name || options[:origin_name])
           xml.CompanyName(name)
         end
 
@@ -443,15 +517,28 @@ module ActiveShipping
           xml.Weight([value, 0.1].max)
         end
 
-        if options[:package] && options[:package][:reference_number]
+
+        Array(package.options[:reference_numbers]).each do |reference_number_info|
           xml.ReferenceNumber do
-            xml.Code(options[:package][:reference_number][:code] || "")
-            xml.Value(options[:package][:reference_number][:value])
+            xml.Code(reference_number_info[:code] || "")
+            xml.Value(reference_number_info[:value])
+          end
+        end
+
+        unless options[:international]
+          xml.PackageServiceOptions do
+            if package.options[:signature_required]
+              # Package level delivery confirmation is only available when shipping US -> US or PR -> PR
+              xml.DeliveryConfirmation do
+                xml.DCISType(2) # 2 = signature required.
+              end
+            elsif
+              xml.ShipperReleaseIndicator
+            end
           end
         end
 
         # not implemented:  * Shipment/Package/LargePackageIndicator element
-        #                   * Shipment/Package/PackageServiceOptions element
         #                   * Shipment/Package/AdditionalHandling element
       end
     end
@@ -667,6 +754,12 @@ module ActiveShipping
 
       name ||= OTHER_NON_US_ORIGIN_SERVICES[code] unless name == 'US'
       name || DEFAULT_SERVICES[code]
+    end
+
+    def allow_package_level_reference_numbers(origin, destination)
+      # if the package is US -> US or PR -> PR the only type of reference numbers that are allowed are package-level
+      # Otherwise the only type of reference numbers that are allowed are shipment-level
+      [['US','US'],['PR', 'PR']].include?([origin,destination].map(&:country_code))
     end
   end
 end

--- a/lib/active_shipping/carriers/ups.rb
+++ b/lib/active_shipping/carriers/ups.rb
@@ -232,7 +232,7 @@ module ActiveShipping
             end
 
             # not implemented:  * Shipment/ShipmentServiceOptions element
-            if options[:origin_account]
+            if options[:negotiated_rates]
               xml.RateInformation do
                 xml.NegotiatedRatesIndicator
               end
@@ -258,6 +258,7 @@ module ActiveShipping
     # * terms_of_shipment: used with paperless invoice to specify who pays duties and taxes
     # * reference_numbers: Array of hashes with :value => a reference number value and optionally :code => reference number type
     # * prepay: if truthy the shipper will be bill immediatly. Otherwise the shipper is billed when the label is used.
+    # * negotiated_rates: if truthy negotiated rates will be requested from ups. Only valid if shipper account has negotiated rates.
     def build_shipment_request(origin, destination, packages, options={})
       packages = Array(packages)
       options[:international] = origin.country.name != destination.country.name

--- a/test/credentials.yml
+++ b/test/credentials.yml
@@ -14,6 +14,8 @@ ups:
   key: <%= ENV['ACTIVESHIPPING_UPS_LOGIN'] %>
   login: <%= ENV['ACTIVESHIPPING_UPS_KEY'] %>
   password: <%= ENV['ACTIVESHIPPING_UPS_PASSWORD'] %>
+  origin_account: <%= ENV['ACTIVESHIPPING_UPS_ORIGIN_ACCOUNT'] %>
+  origin_name: <%= ENV['ACTIVESHIPPING_UPS_ORIGIN_NAME'] %>
 
 fedex:
   account: <%= ENV['ACTIVESHIPPING_FEDEX_ACCOUNT'] %>

--- a/test/remote/ups_test.rb
+++ b/test/remote/ups_test.rb
@@ -52,8 +52,6 @@ class RemoteUPSTest < Minitest::Test
   end
 
   def test_just_country_given
-    skip if @options[:origin_account]
-
     response = @carrier.find_rates(
       location_fixtures[:beverly_hills],
       Location.new(:country => 'CA'),
@@ -61,17 +59,6 @@ class RemoteUPSTest < Minitest::Test
     )
 
     refute response.rates.empty?
-  end
-
-  def test_just_country_given_with_origin_account_fails
-    skip unless @options[:origin_account]
-    assert_raises(ResponseError) do
-      @carrier.find_rates(
-        location_fixtures[:beverly_hills],
-        Location.new(:country => 'CA'),
-        Package.new(100, [5, 10, 20])
-      )
-    end
   end
 
   def test_ottawa_to_beverly_hills
@@ -109,19 +96,6 @@ class RemoteUPSTest < Minitest::Test
     assert_nil package_rate[:rate]
   end
 
-  def test_ottawa_to_us_fails_with_only_zip_and_origin_account
-    skip unless @options[:origin_account]
-
-    assert_raises ResponseError do
-      @carrier.find_rates(
-        location_fixtures[:ottawa],
-        Location.new(:country => 'US', :zip => 90210),
-        package_fixtures.values_at(:book, :wii),
-        :test => true
-      )
-    end
-  end
-
   def test_ottawa_to_us_fails_without_zip
     assert_raises(ResponseError) do
       response = @carrier.find_rates(
@@ -134,8 +108,6 @@ class RemoteUPSTest < Minitest::Test
   end
 
   def test_ottawa_to_us_succeeds_with_only_zip
-    skip if @options[:origin_account]
-
     response = @carrier.find_rates(
       location_fixtures[:ottawa],
       Location.new(:country => 'US', :zip => 90210),
@@ -212,14 +184,6 @@ class RemoteUPSTest < Minitest::Test
   end
 
   def test_obtain_shipping_label
-    skip '<#<RuntimeError: Could not obtain shipping label. Invalid Access License number.>>.'
-
-    # I want to provide some helpful information if this test fails.
-    # Perhaps it is better to skip and warn than to make an *assertion*
-    # about configuration?
-    assert @options[:origin_account].present?, "test/fixtures.yml must have a valid ups/origin_account for this test to run"
-
-
     response = @carrier.create_shipment(
       location_fixtures[:beverly_hills],
       location_fixtures[:new_york_with_name],
@@ -238,8 +202,6 @@ class RemoteUPSTest < Minitest::Test
   end
 
   def test_obtain_shipping_label_without_dimensions
-    skip '<#<RuntimeError: Could not obtain shipping label. Invalid Access License number.>>.'
-
     response = @carrier.create_shipment(
       location_fixtures[:beverly_hills],
       location_fixtures[:new_york_with_name],
@@ -257,10 +219,6 @@ class RemoteUPSTest < Minitest::Test
   end
 
   def test_obtain_international_shipping_label
-    skip '<#<RuntimeError: Could not obtain shipping label. Invalid Access License number.>>.'
-
-    assert @options[:origin_account].present?, "test/fixtures.yml must have a valid ups/origin_account for this test to run"
-
     response = @carrier.create_shipment(
       location_fixtures[:new_york_with_name],
       location_fixtures[:ottawa_with_name],

--- a/test/remote/ups_test.rb
+++ b/test/remote/ups_test.rb
@@ -217,14 +217,13 @@ class RemoteUPSTest < Minitest::Test
     # I want to provide some helpful information if this test fails.
     # Perhaps it is better to skip and warn than to make an *assertion*
     # about configuration?
-    assert @options[:origin_name].present?, "test/fixtures.yml must have a valid ups/origin_name for this test to run"
     assert @options[:origin_account].present?, "test/fixtures.yml must have a valid ups/origin_account for this test to run"
 
 
     response = @carrier.create_shipment(
       location_fixtures[:beverly_hills],
       location_fixtures[:new_york_with_name],
-      package_fixtures.values_at(:chocolate_stuff, :book, :american_wii),
+      package_fixtures.values_at(:chocolate_stuff, :small_half_pound, :american_wii),
       :test => true,
       :reference_number => { :value => "FOO-123", :code => "PO" }
     )
@@ -246,6 +245,30 @@ class RemoteUPSTest < Minitest::Test
       location_fixtures[:new_york_with_name],
       package_fixtures.values_at(:tshirts),
       :test => true
+    )
+
+    assert response.success?
+
+    # All behavior specific to how a LabelResponse behaves in the
+    # context of UPS label data is a matter for unit tests.  If
+    # the data changes substantially, the create_shipment
+    # ought to raise an exception and this test will fail.
+    assert_instance_of ActiveShipping::LabelResponse, response
+  end
+
+  def test_obtain_international_shipping_label
+    skip '<#<RuntimeError: Could not obtain shipping label. Invalid Access License number.>>.'
+
+    assert @options[:origin_account].present?, "test/fixtures.yml must have a valid ups/origin_account for this test to run"
+
+    response = @carrier.create_shipment(
+      location_fixtures[:new_york_with_name],
+      location_fixtures[:ottawa_with_name],
+      package_fixtures.values_at(:books),
+      {
+       :service_code => '07',
+       :test => true,
+      }
     )
 
     assert response.success?

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -87,7 +87,8 @@ module ActiveShipping::Test
         :declared_value => Package.new(80, [2, 6, 12], :units => :imperial, :currency => 'USD', :value => 999.99),
         :tshirts => Package.new(10 * 16, nil, :units => :imperial),
         :shipping_container => Package.new(2200000, [2440, 2600, 6058], :description => '20 ft Standard Container', :units => :metric),
-        :largest_gold_bar => Package.new(250000, [45.5, 22.5, 17], :value => 15300000)
+        :largest_gold_bar => Package.new(250000, [45.5, 22.5, 17], :value => 15300000),
+        :books => Package.new(64, [4, 8, 6], :units => :imperial, :value => 15300000, :description => 'Books')
       }
     end
 
@@ -102,6 +103,14 @@ module ActiveShipping::Test
                                  :postal_code => 'K1P 1J1',
                                  :phone => '1-613-580-2400',
                                  :fax => '1-613-580-2495'),
+        :ottawa_with_name => Location.new( :country => 'CA',
+                                           :province => 'ON',
+                                           :city => 'Ottawa',
+                                           :name => 'Paul Ottawa',
+                                           :address1 => '110 Laurier Avenue West',
+                                           :postal_code => 'K1P 1J1',
+                                           :phone => '1-613-580-2400',
+                                           :fax => '1-613-580-2495'),
         :beverly_hills => Location.new(
                                       :country => 'US',
                                       :state => 'CA',

--- a/test/unit/carriers/ups_test.rb
+++ b/test/unit/carriers/ups_test.rb
@@ -341,7 +341,7 @@ class UPSTest < Minitest::Test
     assert_equal ref_vals.first.text, 'REF_NUM'
   end
 
-  def test_label_request_domestic_reference_numbers
+  def test_label_request_international_reference_numbers
     # International Shipments use shipment level reference numbers
     response = Nokogiri::XML @carrier.send(:build_shipment_request,
                                            location_fixtures[:beverly_hills],


### PR DESCRIPTION
This adds some more options to create_shipment for UPS.
I believe these options are necessary for shipping internationally.
They are definitely necessary for making use of paperless_invoice which allows one to ship commercial packages internationally without printing out a customs invoice.