### PR TITLE
fix null pointer exception in usps validate

### DIFF
--- a/lib/active_shipping/carriers/usps.rb
+++ b/lib/active_shipping/carriers/usps.rb
@@ -286,7 +286,7 @@ module ActiveShipping
       </CarrierPickupAvailabilityRequest>
       EOF
       xml = Nokogiri.XML(commit(:test, request, true)) { |config| config.strict }
-      xml.at('/CarrierPickupAvailabilityResponse/City').text == 'SAN FRANCISCO' && xml.at('/CarrierPickupAvailabilityResponse/Address2').text == '18 FAIR AVE'
+      xml.at('/CarrierPickupAvailabilityResponse/City').try(:text) == 'SAN FRANCISCO' && xml.at('/CarrierPickupAvailabilityResponse/Address2').try(:text) == '18 FAIR AVE'
     end
 
     # options[:service] --    One of [:first_class, :priority, :express, :bpm, :parcel,

--- a/test/remote/usps_test.rb
+++ b/test/remote/usps_test.rb
@@ -201,8 +201,20 @@ class RemoteUSPSTest < Minitest::Test
     end
   end
 
-  def test_valid_credentials
+  def test_correct_login_passes_valid_credentials?
     assert USPS.new(@usps_credentials.merge(:test => true)).valid_credentials?
+  end
+
+  def test_wrong_login_fails_in_valid_credentials?
+    refute USPS.new(:login => 'ABCDEFGHIJKL', :test => true).valid_credentials?
+  end
+
+  def test_blank_login_fails_in_valid_credentials?
+    refute USPS.new(:login => '', :test => true).valid_credentials?
+  end
+
+  def test_nil_login_fails_in_valid_credentials?
+    refute USPS.new(:login => nil, :test => true).valid_credentials?
   end
 
   def test_must_provide_login_creds_when_instantiating


### PR DESCRIPTION
### Problem
* Refactoring caused a NPE by calling .text on a non-existant XML path

### Solution
* Add test coverage to the validation method
* Fix the NPE

@Shopify/shipping @wvanbergen 