### PR TITLE
Fix USPS tracking not parsed as 'delivered'

### DIFF
--- a/lib/active_shipping/carriers/usps.rb
+++ b/lib/active_shipping/carriers/usps.rb
@@ -13,7 +13,7 @@ module ActiveShipping
     EventDetails = Struct.new(:description, :time, :zoneless_time, :location)
     EVENT_MESSAGE_PATTERNS = [
       /^(.*), (\w+ \d{1,2}, \d{4}, \d{1,2}:\d\d [ap]m), (.*), (\w\w) (\d{5})$/i,
-      /^Your item \w{2,3} (out for delivery|delivered) at (\d{1,2}:\d\d [ap]m on \w+ \d{1,2}, \d{4}) in (.*), (\w\w) (\d{5})\.$/i
+      /^Your item \w{2,3} (out for delivery|delivered).* at (\d{1,2}:\d\d [ap]m on \w+ \d{1,2}, \d{4}) in (.*), (\w\w) (\d{5})\.$/i
     ]
     self.retry_safe = true
 

--- a/test/fixtures/xml/usps/delivered_extended_tracking_response.xml
+++ b/test/fixtures/xml/usps/delivered_extended_tracking_response.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0"?>
+<TrackResponse>
+  <TrackInfo ID="9361289949034102283511">
+    <TrackSummary>Your item was delivered to the front desk or reception area at 2:16 pm on October 12, 2013 in BROOKLYN, NY 11201.</TrackSummary>
+    <TrackDetail>Out for Delivery, October 12, 2013, 10:16 am, BROOKLYN, NY 11201</TrackDetail>
+    <TrackDetail>Sorting Complete, October 12, 2013, 10:06 am, BROOKLYN, NY 11201</TrackDetail>
+    <TrackDetail>Arrival at Post Office, October 12, 2013, 6:32 am, BROOKLYN, NY 11201</TrackDetail>
+    <TrackDetail>Acceptance, October 12, 2013, 6:26 am, BROOKLYN, NY 11201</TrackDetail>
+    <TrackDetail>Electronic Shipping Info Received, October 12, 2013</TrackDetail>
+  </TrackInfo>
+</TrackResponse>

--- a/test/unit/carriers/usps_test.rb
+++ b/test/unit/carriers/usps_test.rb
@@ -117,6 +117,12 @@ class USPSTest < Minitest::Test
     assert_equal true, response.delivered?
   end
 
+  def test_find_tracking_info_with_extended_response_format_should_have_correct_delivered
+    @carrier.expects(:commit).returns(xml_fixture('usps/delivered_extended_tracking_response'))
+    response = @carrier.find_tracking_info('9102901000462189604217')
+    assert_equal true, response.delivered?
+  end
+
   def test_size_codes
     assert_equal 'REGULAR', USPS.size_code_for(Package.new(2, [1, 12, 1], :units => :imperial))
     assert_equal 'LARGE', USPS.size_code_for(Package.new(2, [12.1, 1, 1], :units => :imperial))


### PR DESCRIPTION
USPS seem to have a different format for the `TrackSummary` element in `TrackResponse`, than the one expected by ActiveShipping.

Currently something along the lines of `Your item was delivered at 2:16 pm on October 12, 2013 in BROOKLYN, NY 11201.` is expected, however, sometimes (always?) there's extra information, i.e. `Your item was delivered to the front desk or reception area at 2:16 pm on October 12, 2013 in BROOKLYN, NY 11201.`, or `Your item was delivered in or at the mailbox at 2:16 pm on October 12, 2013 in BROOKLYN, NY 11201.`

This fixes the regex in the USPS carrier to take this into account, and should also fix #205.