### PR TITLE
USPS US to US rate requests must specify a container type

### DIFF
--- a/lib/active_shipping/carriers/usps.rb
+++ b/lib/active_shipping/carriers/usps.rb
@@ -316,7 +316,7 @@ module ActiveShipping
               xml.ZipDestination(strip_zip(destination_zip))
               xml.Pounds(0)
               xml.Ounces("%0.1f" % [package.ounces, 1].max)
-              xml.Container(CONTAINERS[package.options[:container]])
+              xml.Container(CONTAINERS[package.options[:container]] || (package.cylinder? ? 'NONRECTANGULAR' : 'RECTANGULAR'))
               xml.Size(USPS.size_code_for(package))
               xml.Width("%0.2f" % package.inches(:width))
               xml.Length("%0.2f" % package.inches(:length))

--- a/test/unit/carriers/usps_test.rb
+++ b/test/unit/carriers/usps_test.rb
@@ -140,6 +140,14 @@ class USPSTest < Minitest::Test
     @carrier.find_rates(location_fixtures[:beverly_hills], location_fixtures[:new_york], package, :test => true, :container => :rectangular)
   end
 
+  def test_build_us_rate_request_uses_proper_container_when_none_is_specified
+    expected_request = xml_fixture('usps/us_rate_request')
+    @carrier.expects(:commit).with(:us_rates, expected_request, false).returns(expected_request)
+    @carrier.expects(:parse_rate_response)
+    package = package_fixtures[:book]
+    @carrier.find_rates(location_fixtures[:beverly_hills], location_fixtures[:new_york], package, :test => true)
+  end
+
   def test_build_world_rate_request
     expected_request = xml_fixture('usps/world_rate_request_without_value')
     @carrier.expects(:commit).with(:world_rates, expected_request, false).returns(expected_request)


### PR DESCRIPTION
### Problem
When no container type is specified we set the container type to `<Container/>`. On large packages (packages with at least one dimension greater than 1 foot) the rate response comes back but is incorrect.

### Solution
Choose a container type when non is specified. 

### Notes
* A container type was being specified for international rate requests

@Shopify/shipping @wvanbergen 