### PR TITLE
Prepare for release of v1.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,22 @@
 # ActiveShipping CHANGELOG
 
+### v1.0.0
+
+- **BREAKING CHANGE:** Change namespace from `ActiveMerchant::Shipping` to `ActiveShipping`
+- Drop support for Ruby 1.8 and Ruby 1.9.
+- Drop support for ActiveSupport < 3.2, support up to ActiveSupport 4.2.
+- Updated Fedex to use latest API version for tracking
+- Various improvements to UPS carrier implementation.
+- Small bugfixes in USPS carrier implementation.
+- Various small bugfixes in XML handling for several carriers.
+- Rewite all carriers to use nokogiri for XML parsing and generating.
+- Bump `active_utils` dependency to require 3.x to avoid conflicts with `ActiveMerchant`.
+- Extracted `quantified` into separate gem.
+- Removed vendored `XmlNode` library.
+- Removed `builder` dependency.
+- Improved test setup that allows running functional tests on CI.
+- Improved documentation of the abstraction API.
+
 ### v0.10.1
 
  - Canada Post PWS: Makes wrapper act more consistently with the rest of the API [jnormore]

--- a/README.md
+++ b/README.md
@@ -97,7 +97,7 @@ Active Shipping is currently being used and improved in a production environment
 
 ## Running the tests
 
-After installing dependencies with `bundle install`, you can run the unit tests with `rake test:units` and the remote tests with `rake test:remote`. The unit tests mock out requests and responses so that everything runs locally, while the remote tests actually hit the carrier servers. For the remote tests, you'll need valid test credentials for any carriers' tests you want to run. The credentials should go in ~/.active_shipping/credentials.yml, and the format of that file can be seen in the included [credentials.yml](https://github.com/Shopify/active_shipping/blob/master/test/credentials.yml).
+After installing dependencies with `bundle install`, you can run the unit tests with `rake test:units` and the remote tests with `rake test:remote`. The unit tests mock out requests and responses so that everything runs locally, while the remote tests actually hit the carrier servers. For the remote tests, you'll need valid test credentials for any carriers' tests you want to run. The credentials should go in ~/.active_shipping/credentials.yml, and the format of that file can be seen in the included [credentials.yml](https://github.com/Shopify/active_shipping/blob/master/test/credentials.yml). For some carriers, we have public credentials you can use for testing: see `.travis.yml`.
 
 ## Development
 

--- a/lib/active_shipping/version.rb
+++ b/lib/active_shipping/version.rb
@@ -1,3 +1,3 @@
 module ActiveShipping
-  VERSION = "1.0.0.pre4"
+  VERSION = "1.0.0"
 end


### PR DESCRIPTION
@Shopify/shipping Let's get this out of the door so people stop complaining about the latest ActiveMerchant and ActiveShipping causing naming conflicts.