### PR TITLE
Fix tests and add single service rates to UPS

### DIFF
--- a/active_shipping.gemspec
+++ b/active_shipping.gemspec
@@ -23,6 +23,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency('rake')
   s.add_development_dependency('mocha', '~> 1')
   s.add_development_dependency('timecop')
+  s.add_development_dependency('business_time')
 
   s.files        = `git ls-files`.split($/)
   s.executables  = s.files.grep(%r{^bin/}).map{ |f| File.basename(f) }

--- a/lib/active_shipping/carriers/ups.rb
+++ b/lib/active_shipping/carriers/ups.rb
@@ -221,9 +221,7 @@ module ActiveShipping
         xml.RatingServiceSelectionRequest do
           xml.Request do
             xml.RequestAction('Rate')
-            xml.RequestOption('Shop')
-            # not implemented: 'Rate' RequestOption to specify a single service query
-            # xml.RequestOption((options[:service].nil? or options[:service] == :all) ? 'Shop' : 'Rate')
+            xml.RequestOption((options[:service].nil?) ? 'Shop' : 'Rate')
           end
 
           pickup_type = options[:pickup_type] || :daily_pickup
@@ -252,6 +250,12 @@ module ActiveShipping
             #                   * Shipment/ScheduledDeliveryTime element
             #                   * Shipment/AlternateDeliveryTime element
             #                   * Shipment/DocumentsOnly element
+
+            unless options[:service].nil?
+              xml.Service do
+                xml.Code(options[:service])
+              end
+            end
 
             Array(packages).each do |package|
               options[:imperial] ||= IMPERIAL_COUNTRIES.include?(origin.country_code(:alpha2))

--- a/lib/active_shipping/carriers/ups.rb
+++ b/lib/active_shipping/carriers/ups.rb
@@ -771,11 +771,13 @@ module ActiveShipping
           service_name = service_summary.at('Service/Description').text
           service_code = UPS::DEFAULT_SERVICE_NAME_TO_CODE[service_name]
           date = Date.strptime(service_summary.at('EstimatedArrival/Date').text, '%Y-%m-%d')
+          business_transit_days = service_summary.at('EstimatedArrival/BusinessTransitDays').text.to_i
           delivery_estimates << DeliveryDateEstimate.new(origin, destination, self.class.class_variable_get(:@@name),
                                     service_name,
                                     :service_code => service_code,
                                     :guaranteed => service_summary.at('Guaranteed/Code').text == 'Y',
-                                    :date =>  date)
+                                    :date =>  date,
+                                    :business_transit_days => business_transit_days)
         end
       end
       response = DeliveryDateEstimatesResponse.new(success, message, Hash.from_xml(response).values.first, :delivery_estimates => delivery_estimates, :xml => response, :request => last_request)

--- a/lib/active_shipping/delivery_date_estimate.rb
+++ b/lib/active_shipping/delivery_date_estimate.rb
@@ -7,12 +7,14 @@ module ActiveShipping
     attr_reader :service_code
     attr_reader :date
     attr_reader :guaranteed
+    attr_reader :business_transit_days
 
     def initialize(origin, destination, carrier, service_name, options={})
       @origin, @destination, @carrier, @service_name = origin, destination, carrier, service_name
       @service_code = options[:service_code]
       @date = options[:date]
       @guaranteed = options[:guaranteed]
+      @business_transit_days = options[:business_transit_days]
     end
   end
 end

--- a/test/credentials.yml
+++ b/test/credentials.yml
@@ -11,8 +11,8 @@ usps:
   login: <%= ENV['ACTIVESHIPPING_USPS_LOGIN'] %>
 
 ups:
-  key: <%= ENV['ACTIVESHIPPING_UPS_LOGIN'] %>
-  login: <%= ENV['ACTIVESHIPPING_UPS_KEY'] %>
+  login: <%= ENV['ACTIVESHIPPING_UPS_LOGIN'] %>
+  key: <%= ENV['ACTIVESHIPPING_UPS_KEY'] %>
   password: <%= ENV['ACTIVESHIPPING_UPS_PASSWORD'] %>
   origin_account: <%= ENV['ACTIVESHIPPING_UPS_ORIGIN_ACCOUNT'] %>
   origin_name: <%= ENV['ACTIVESHIPPING_UPS_ORIGIN_NAME'] %>

--- a/test/fixtures/xml/ups/rate_single_service.xml
+++ b/test/fixtures/xml/ups/rate_single_service.xml
@@ -1,0 +1,54 @@
+<?xml version="1.0"?>
+<RatingServiceSelectionResponse>
+    <Response>
+        <ResponseStatusCode>1</ResponseStatusCode>
+        <ResponseStatusDescription>Success</ResponseStatusDescription>
+    </Response>
+    <RatedShipment>
+        <Service>
+            <Code>03</Code>
+        </Service>
+        <RatedShipmentWarning>Your invoice may vary from the displayed reference rates</RatedShipmentWarning>
+        <BillingWeight>
+            <UnitOfMeasurement>
+                <Code>LBS</Code>
+            </UnitOfMeasurement>
+            <Weight>1.0</Weight>
+        </BillingWeight>
+        <TransportationCharges>
+            <CurrencyCode>USD</CurrencyCode>
+            <MonetaryValue>11.86</MonetaryValue>
+        </TransportationCharges>
+        <ServiceOptionsCharges>
+            <CurrencyCode>USD</CurrencyCode>
+            <MonetaryValue>0.00</MonetaryValue>
+        </ServiceOptionsCharges>
+        <TotalCharges>
+            <CurrencyCode>USD</CurrencyCode>
+            <MonetaryValue>11.86</MonetaryValue>
+        </TotalCharges>
+        <GuaranteedDaysToDelivery />
+        <ScheduledDeliveryTime />
+        <RatedPackage>
+            <TransportationCharges>
+                <CurrencyCode>USD</CurrencyCode>
+                <MonetaryValue>11.86</MonetaryValue>
+            </TransportationCharges>
+            <ServiceOptionsCharges>
+                <CurrencyCode>USD</CurrencyCode>
+                <MonetaryValue>0.00</MonetaryValue>
+            </ServiceOptionsCharges>
+            <TotalCharges>
+                <CurrencyCode>USD</CurrencyCode>
+                <MonetaryValue>11.86</MonetaryValue>
+            </TotalCharges>
+            <Weight>0.3</Weight>
+            <BillingWeight>
+                <UnitOfMeasurement>
+                    <Code>LBS</Code>
+                </UnitOfMeasurement>
+                <Weight>1.0</Weight>
+            </BillingWeight>
+        </RatedPackage>
+    </RatedShipment>
+</RatingServiceSelectionResponse>

--- a/test/remote/ups_test.rb
+++ b/test/remote/ups_test.rb
@@ -279,4 +279,20 @@ class RemoteUPSTest < Minitest::Test
     next_day_delivery_estimate = response.delivery_estimates.select {|de| de.service_name == "UPS Next Day Air"}.first
     assert_equal monday + 1.day, next_day_delivery_estimate.date
   end
+
+  def test_rate_with_single_service
+    response = @carrier.find_rates(
+      location_fixtures[:new_york_with_name],
+      location_fixtures[:real_home_as_residential],
+      package_fixtures.values_at(:books),
+      {
+        :service => UPS::DEFAULT_SERVICE_NAME_TO_CODE["UPS Ground"],
+        :test => true
+      }
+    )
+
+    assert response.success?
+    refute response.rates.empty?
+    assert_equal ["UPS Ground"], response.rates.map(&:service_name)
+  end
 end

--- a/test/remote/ups_test.rb
+++ b/test/remote/ups_test.rb
@@ -239,14 +239,13 @@ class RemoteUPSTest < Minitest::Test
   end
 
   def test_delivery_date_estimates_within_zip
-    monday = Date.parse('0201', '%m%d') # Feb to avoid holidays http://www.ups.com/content/us/en/resources/ship/imp_exp/operation.html
-    monday += 1.day while monday.wday != 1
+    today = Date.current
 
     response = @carrier.get_delivery_date_estimates(
       location_fixtures[:new_york_with_name],
       location_fixtures[:new_york_with_name],
       package_fixtures.values_at(:books),
-      pickup_date=monday,
+      today,
       {
         :test => true
       }
@@ -255,18 +254,17 @@ class RemoteUPSTest < Minitest::Test
     assert response.success?
     refute_empty response.delivery_estimates
     ground_delivery_estimate = response.delivery_estimates.select {|de| de.service_name == "UPS Ground"}.first
-    assert_equal monday + 1.day, ground_delivery_estimate.date
+    assert_equal Date.parse(1.business_days.from_now.to_s), ground_delivery_estimate.date
   end
 
   def test_delivery_date_estimates_across_zips
-    monday = Date.parse('0201', '%m%d') # Feb to avoid holidays http://www.ups.com/content/us/en/resources/ship/imp_exp/operation.html
-    monday += 1.day while monday.wday != 1
+    today = Date.current
 
     response = @carrier.get_delivery_date_estimates(
       location_fixtures[:new_york_with_name],
       location_fixtures[:real_home_as_residential],
       package_fixtures.values_at(:books),
-      pickup_date=monday,
+      today,
       {
         :test => true
       }
@@ -275,9 +273,9 @@ class RemoteUPSTest < Minitest::Test
     assert response.success?
     refute_empty response.delivery_estimates
     ground_delivery_estimate = response.delivery_estimates.select {|de| de.service_name == "UPS Ground"}.first
-    assert_equal monday + 3.day, ground_delivery_estimate.date
+    assert_equal Date.parse(3.business_days.from_now.to_s), ground_delivery_estimate.date
     next_day_delivery_estimate = response.delivery_estimates.select {|de| de.service_name == "UPS Next Day Air"}.first
-    assert_equal monday + 1.day, next_day_delivery_estimate.date
+    assert_equal Date.parse(1.business_days.from_now.to_s), next_day_delivery_estimate.date
   end
 
   def test_rate_with_single_service

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -3,6 +3,7 @@ require 'bundler/setup'
 require 'minitest/autorun'
 require 'mocha/mini_test'
 require 'timecop'
+require 'business_time'
 
 require 'active_shipping'
 require 'logger'

--- a/test/unit/carriers/ups_test.rb
+++ b/test/unit/carriers/ups_test.rb
@@ -460,6 +460,7 @@ class UPSTest < Minitest::Test
     assert_equal 6, response.delivery_estimates.size
     ground_estimate = response.delivery_estimates.select{ |de| de.service_name == "UPS Ground"}.first
     assert_equal Date.parse('2015-02-5'), ground_estimate.date
+    assert_equal 3, ground_estimate.business_transit_days
   end
 
   def test_get_delivery_date_estimates_can_translate_service_codes

--- a/test/unit/carriers/ups_test.rb
+++ b/test/unit/carriers/ups_test.rb
@@ -483,4 +483,20 @@ class UPSTest < Minitest::Test
       assert delivery_estimate.service_name, UPS::DEFAULT_SERVICES[delivery_estimate.service_code]
     end
   end
+
+  def test_get_rates_for_single_serivce
+    mock_response = xml_fixture("ups/rate_single_service")
+    @carrier.expects(:commit).returns(mock_response)
+
+    response = @carrier.find_rates(
+      location_fixtures[:new_york_with_name],
+      location_fixtures[:real_home_as_residential],
+      package_fixtures.values_at(:books),
+      {
+        :service => UPS::DEFAULT_SERVICE_NAME_TO_CODE["UPS Ground"],
+        :test => true
+      }
+    )
+    assert_equal ["UPS Ground"], response.rates.map(&:service_name)
+  end
 end


### PR DESCRIPTION
Fixed some issues I found with how the delivery_dates tests were written. UPS would fail with an invalid pickup date exception. I also added support to get rates for only a single service from UPS.