### PR TITLE
UPS: Add Weight to delivery dates request so it works internationally.

### DIFF
--- a/lib/active_shipping/carriers/ups.rb
+++ b/lib/active_shipping/carriers/ups.rb
@@ -443,6 +443,18 @@ module ActiveShipping
           build_address_artifact_format_location(xml, 'TransitFrom', origin)
           build_address_artifact_format_location(xml, 'TransitTo', destination)
 
+          xml.ShipmentWeight do
+            xml.UnitOfMeasurement do
+              xml.Code(options[:imperial] ? 'LBS' : 'KGS')
+            end
+
+            value = packages.inject(0) do |sum, package|
+              sum + (options[:imperial] ? package.lbs.to_f : package.kgs.to_f )
+            end
+
+            xml.Weight([value.round(3), 0.1].max)
+          end
+
           xml.InvoiceLineTotal do
             xml.CurrencyCode('USD')
             total_value = packages.inject(0) {|sum, package| sum + package.value}

--- a/test/remote/ups_test.rb
+++ b/test/remote/ups_test.rb
@@ -293,4 +293,22 @@ class RemoteUPSTest < Minitest::Test
     refute response.rates.empty?
     assert_equal ["UPS Ground"], response.rates.map(&:service_name)
   end
+
+  def test_delivery_date_estimates_intl
+    today = Date.current
+    response = @carrier.get_delivery_date_estimates(
+      location_fixtures[:new_york_with_name],
+      location_fixtures[:ottawa_with_name],
+      package_fixtures.values_at(:books),
+      pickup_date=today,
+      {
+        :test => true
+      }
+    )
+
+    assert response.success?
+    refute_empty response.delivery_estimates
+    ww_express_estimate = response.delivery_estimates.select {|de| de.service_name == "UPS Worldwide Express"}.first
+    assert_equal Date.parse(1.business_day.from_now.to_s), ww_express_estimate.date
+  end
 end


### PR DESCRIPTION
The time in transit API requires weight info when you're using it for international shipments.

Also, tests were failing for UPS because I hardcoded February 1st into the tests in a few places not realizing that UPS doesn't not permit you to make requests about dates that are more than 60 days (I think?) in the future or past. This fixes that. Although I think these tests will still fail right around holidays, that's a problem to be fixed at some point I suppose.