### PR TITLE
Bump Quantified: 1.0.0 -> 1.0.1

### DIFF
--- a/active_shipping.gemspec
+++ b/active_shipping.gemspec
@@ -14,7 +14,7 @@ Gem::Specification.new do |s|
   s.description = "Get rates and tracking info from various shipping carriers. Extracted from Shopify."
   s.license     = 'MIT'
 
-  s.add_dependency('quantified',    '~> 1.0')
+  s.add_dependency('quantified',    '~> 1.0.1')
   s.add_dependency('activesupport', '>= 3.2', '< 5.0.0')
   s.add_dependency('active_utils',  '~> 3.0.0')
   s.add_dependency('nokogiri',      '>= 1.6')


### PR DESCRIPTION
Bumping Quantified version to pull changes introduced in https://github.com/Shopify/quantified/pull/4

cc. @wvanbergen 