### PR TITLE
Fix USPS tracking bug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # ActiveShipping CHANGELOG
 
+### v1.1.1
+
+- Fix bug with USPS tracking not handling optional fields being absent.
+
 ### v1.1.0
 
 - USPS: Allows package tracking disambiguation and exposes predicted arrival date and event codes.

--- a/lib/active_shipping/carriers/usps.rb
+++ b/lib/active_shipping/carriers/usps.rb
@@ -238,9 +238,9 @@ module ActiveShipping
       
       timestamp = "#{node.at('EventDate').text}, #{node.at('EventTime').text}"
       event_code = node.at('EventCode').text
-      city = node.at('EventCity').text
-      state = node.at('EventState').text
-      zip_code = node.at('EventZIPCode').text
+      city = try_text(node.at('EventCity'))
+      state = try_text(node.at('EventState'))
+      zip_code = try_text(node.at('EventZIPCode'))
 
       country_node = node.at('EventCountry')
       country = country_node ? country_node.text : ''
@@ -555,7 +555,8 @@ module ActiveShipping
         tracking_details << xml.root.at('TrackInfo/TrackSummary')
 
         tracking_number = xml.root.at('TrackInfo').attributes['ID'].value
-        scheduled_delivery = Time.parse(xml.root.at('PredictedDeliveryDate').text)
+        prediction_node = xml.root.at('PredictedDeliveryDate') || xml.root.at('ExpectedDeliveryDate')
+        scheduled_delivery = prediction_node ? Time.parse(prediction_node.text) : nil
 
         tracking_details.each do |event|
           details = extract_event_details(event)
@@ -616,6 +617,10 @@ module ActiveShipping
 
     def response_message(document)
       response_status_node(document).text
+    end
+
+    def try_text(node)
+      node ? node.text : nil
     end
 
     def commit(action, request, test = false)

--- a/lib/active_shipping/carriers/usps.rb
+++ b/lib/active_shipping/carriers/usps.rb
@@ -238,9 +238,9 @@ module ActiveShipping
       
       timestamp = "#{node.at('EventDate').text}, #{node.at('EventTime').text}"
       event_code = node.at('EventCode').text
-      city = try_text(node.at('EventCity'))
-      state = try_text(node.at('EventState'))
-      zip_code = try_text(node.at('EventZIPCode'))
+      city = node.at('EventCity').try(:text)
+      state = node.at('EventState').try(:text)
+      zip_code = node.at('EventZIPCode').try(:text)
 
       country_node = node.at('EventCountry')
       country = country_node ? country_node.text : ''
@@ -617,10 +617,6 @@ module ActiveShipping
 
     def response_message(document)
       response_status_node(document).text
-    end
-
-    def try_text(node)
-      node ? node.text : nil
     end
 
     def commit(action, request, test = false)

--- a/lib/active_shipping/version.rb
+++ b/lib/active_shipping/version.rb
@@ -1,3 +1,3 @@
 module ActiveShipping
-  VERSION = "1.1.0"
+  VERSION = "1.1.1"
 end

--- a/test/fixtures/xml/usps/tracking_response_alt.xml
+++ b/test/fixtures/xml/usps/tracking_response_alt.xml
@@ -8,7 +8,6 @@
     <DestinationState>IL</DestinationState>
     <DestinationZip>61536</DestinationZip>
     <EmailEnabled>true</EmailEnabled>
-    <ExpectedDeliveryDate>April 28, 2015</ExpectedDeliveryDate>
     <KahalaIndicator>false</KahalaIndicator>
     <MailTypeCode>DM</MailTypeCode>
     <MPDATE>2015-04-24 02:08:04.000000</MPDATE>
@@ -17,7 +16,6 @@
     <OriginState>TX</OriginState>
     <OriginZip>76226</OriginZip>
     <PodEnabled>false</PodEnabled>
-    <PredictedDeliveryDate>April 28, 2015</PredictedDeliveryDate>
     <RestoreEnabled>false</RestoreEnabled>
     <RramEnabled>false</RramEnabled>
     <RreEnabled>false</RreEnabled>
@@ -31,7 +29,6 @@
       <EventTime>8:29 am</EventTime>
       <EventDate>April 28, 2015</EventDate>
       <Event>Out for Delivery, in truck</Event>
-      <EventCity>OTTAWA</EventCity>
       <EventState>ON</EventState>
       <EventZIPCode>61536</EventZIPCode>
       <EventCountry>Canada</EventCountry>

--- a/test/unit/carriers/usps_test.rb
+++ b/test/unit/carriers/usps_test.rb
@@ -123,6 +123,8 @@ class USPSTest < Minitest::Test
     response = @carrier.find_tracking_info('9102901000462189604217', :test => true)
     assert_equal 'Canada', response.shipment_events.last.location.country.name
     assert_equal :out_for_delivery, response.status
+    assert_nil response.scheduled_delivery_date
+    assert_nil response.shipment_events.last.location.city
   end
 
   def test_find_tracking_info_destination


### PR DESCRIPTION
In #260 I assumed some fields would always be present that are in fact optional. This caused errors when for example, tracking a number with no predicted delivery date yet.

This PR passes through nil values for those fields instead of throwing an error. Only the predicted delivery dates have been observed to be missing but this PR also speculatively allows the location to be optional since some more obscure events like "seized by law enforcement" may not have a location. 

@Shopify/shipping 