### PR TITLE
Fix finding of error description in USPS tracking

### DIFF
--- a/lib/active_shipping/carriers/usps.rb
+++ b/lib/active_shipping/carriers/usps.rb
@@ -154,11 +154,6 @@ module ActiveShipping
       "WS" => "Western Samoa"
     }
 
-    STATUS_NODE_PATTERNS = %w(
-      Error/Description
-      */TrackInfo/Error/Description
-    )
-
     RESPONSE_ERROR_MESSAGES = [
       /There is no record of that mail item/,
       /This Information has not been included in this Test Server\./,
@@ -592,15 +587,13 @@ module ActiveShipping
     end
 
     def error_description_node(document)
-      STATUS_NODE_PATTERNS.each do |pattern|
-        if node = document.elements[pattern]
-          return node
-        end
-      end
+      document.xpath('//Error/Description')
     end
 
     def response_status_node(document)
-       track_summary_node(document) || error_description_node(document)
+       summary = track_summary_node(document)
+       return summary unless summary.empty?
+       error_description_node(document)
     end
 
     def has_error?(document)

--- a/lib/active_shipping/version.rb
+++ b/lib/active_shipping/version.rb
@@ -1,3 +1,3 @@
 module ActiveShipping
-  VERSION = "1.1.1"
+  VERSION = "1.1.2"
 end

--- a/test/unit/carriers/usps_test.rb
+++ b/test/unit/carriers/usps_test.rb
@@ -16,16 +16,18 @@ class USPSTest < Minitest::Test
 
   def test_tracking_failure_should_raise_exception
     @carrier.expects(:commit).returns(@tracking_response_failure)
-    assert_raises ResponseError do
+    e = assert_raises ResponseError do
       @carrier.find_tracking_info('abc123xyz', :test => true)
     end
+    assert_equal "The Postal Service could not locate the tracking information for your request. Please verify your tracking number and try again later.", e.message
   end
 
   def test_find_tracking_info_should_handle_not_found_error
     @carrier.expects(:commit).returns(xml_fixture('usps/tracking_response_test_error'))
-    assert_raises ResponseError do
+    e = assert_raises ResponseError do
       @carrier.find_tracking_info('9102901000462189604217', :test => true)
     end
+    assert_equal "This Information has not been included in this Test Server.", e.message
   end
 
   def test_find_tracking_info_should_handle_invalid_xml_error


### PR DESCRIPTION
The existing code for error message extraction wasn't tested, and was totally wrong.

#### Code Issues Fixed in this PR

- `document.elements[...]` doesn't search the document, it indexes an array.
- failed searches return an empty array-ish-thing not nil so `first_thing || second_thing` doesn't work
- Same thing made the checking multiple xpaths pattern not work, replaced it with a single general xpath.

I'm ashamed that I didn't have to Google the xpath syntax. I try to repress the memories of my days working with XSLT.

@Shopify/shipping 