### PR TITLE
UPS - add tracking_option on tracking info request

### DIFF
--- a/lib/active_shipping/carriers/ups.rb
+++ b/lib/active_shipping/carriers/ups.rb
@@ -514,6 +514,7 @@ module ActiveShipping
     def build_tracking_request(tracking_number, options = {})
       xml_builder = Nokogiri::XML::Builder.new do |xml|
         xml.TrackRequest do
+          xml.TrackingOption(options[:tracking_option]) if options[:tracking_option]
           xml.Request do
             xml.RequestAction('Track')
             xml.RequestOption('1')

--- a/test/fixtures/xml/ups/access_request.xml
+++ b/test/fixtures/xml/ups/access_request.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0"?>
+<AccessRequest>
+  <AccessLicenseNumber>key</AccessLicenseNumber>
+  <UserId>login</UserId>
+  <Password>password</Password>
+</AccessRequest>

--- a/test/fixtures/xml/ups/tracking_request.xml
+++ b/test/fixtures/xml/ups/tracking_request.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0"?>
+<TrackRequest>
+  <TrackingOption>03</TrackingOption>
+  <Request>
+    <RequestAction>Track</RequestAction>
+    <RequestOption>1</RequestOption>
+  </Request>
+  <TrackingNumber>1Z5FX0076803466397</TrackingNumber>
+</TrackRequest>

--- a/test/unit/carriers/ups_test.rb
+++ b/test/unit/carriers/ups_test.rb
@@ -21,6 +21,12 @@ class UPSTest < Minitest::Test
     assert UPS.new(:login => 'blah', :password => 'bloo', :key => 'kee')
   end
 
+  def test_find_tracking_info_should_create_correct_xml
+    xml_request = xml_fixture('ups/access_request') + xml_fixture('ups/tracking_request')
+    @carrier.expects(:commit).with(:track, xml_request, true).returns(@tracking_response)
+    @carrier.find_tracking_info('1Z5FX0076803466397', :tracking_option => '03', :test => true)
+  end
+
   def test_find_tracking_info_should_return_a_tracking_response
     @carrier.expects(:commit).returns(@tracking_response)
     assert_equal 'ActiveShipping::TrackingResponse', @carrier.find_tracking_info('1Z5FX0076803466397').class.name


### PR DESCRIPTION
In order to track a UPS Mail Innovations tracking number in the API, you must also include the TrackingOption which is 03.

Here is an example of what the request would look like:

```xml
<?xml version="1.0" encoding="UTF-8"?>
<AccessRequest xml:lang="en-US">
<AccessLicenseNumber>Your Access Key</AccessLicenseNumber>
<UserId>Your User ID</UserId>
<Password>Your Password</Password>
</AccessRequest>
<?xml version="1.0" encoding="UTF-8"?>
<TrackRequest>
<TrackingOption>03</TrackingOption>
<Request>
<TransactionReference/>
</Request>
<RequestAction>Track</RequestAction>
<RequestOption>1</RequestOption>
<TrackingNumber>1234567890</TrackingNumber>
</TrackRequest>
```