### PR TITLE
Handle ZIP+4 by trimming.

### DIFF
--- a/lib/active_shipping/carriers/usps.rb
+++ b/lib/active_shipping/carriers/usps.rb
@@ -256,7 +256,8 @@ module ActiveShipping
           xml.ClientIp { xml.text(@options[:client_ip] || '127.0.0.1') }
           xml.SourceId { xml.text(@options[:source_id] || 'active_shipping') }
           xml.TrackID('ID' => tracking_number) do
-            xml.DestinationZipCode { xml.text(@options[:destination_zip])} if @options[:destination_zip]
+            # take the first 5 digits if available, API can't handle ZIP+4
+            xml.DestinationZipCode { xml.text(@options[:destination_zip][0..4])} if @options[:destination_zip]
             if @options[:mailing_date]
               formatted_date = @options[:mailing_date].strftime('%Y-%m-%d')
               xml.MailingDate { xml.text(formatted_date)} 

--- a/lib/active_shipping/carriers/usps.rb
+++ b/lib/active_shipping/carriers/usps.rb
@@ -256,8 +256,7 @@ module ActiveShipping
           xml.ClientIp { xml.text(@options[:client_ip] || '127.0.0.1') }
           xml.SourceId { xml.text(@options[:source_id] || 'active_shipping') }
           xml.TrackID('ID' => tracking_number) do
-            # take the first 5 digits if available, API can't handle ZIP+4
-            xml.DestinationZipCode { xml.text(@options[:destination_zip][0..4])} if @options[:destination_zip]
+            xml.DestinationZipCode { xml.text(strip_zip(@options[:destination_zip]))} if @options[:destination_zip]
             if @options[:mailing_date]
               formatted_date = @options[:mailing_date].strftime('%Y-%m-%d')
               xml.MailingDate { xml.text(formatted_date)} 

--- a/lib/active_shipping/version.rb
+++ b/lib/active_shipping/version.rb
@@ -1,3 +1,3 @@
 module ActiveShipping
-  VERSION = "1.1.2"
+  VERSION = "1.1.3"
 end

--- a/test/unit/carriers/usps_test.rb
+++ b/test/unit/carriers/usps_test.rb
@@ -14,6 +14,11 @@ class USPSTest < Minitest::Test
     @carrier.find_tracking_info('9102901000462189604217', :destination_zip => '12345', :mailing_date => Date.new(2010,1,30))
   end
 
+  def test_tracking_request_should_handle_9_digit_zip
+    @carrier.expects(:commit).with(:track, xml_fixture('usps/tracking_request'),false).returns(@tracking_response)
+    @carrier.find_tracking_info('9102901000462189604217', :destination_zip => '12345-4444', :mailing_date => Date.new(2010,1,30))
+  end
+
   def test_tracking_failure_should_raise_exception
     @carrier.expects(:commit).returns(@tracking_response_failure)
     e = assert_raises ResponseError do


### PR DESCRIPTION
Currently tracking API calls fail in an invalid-schema kind of way if the zip code format is invalid. [ZIP+4](https://en.wikipedia.org/wiki/ZIP_code#ZIP.2B4) is considered an invalid format. This PR trims the first 5 digits to turn a ZIP+4 into a valid normal ZIP.

@Shopify/shipping 