### PR TITLE
Add support for batch tracking info fetching on USPS

### DIFF
--- a/test/fixtures/xml/usps/tracking_request_batch.xml
+++ b/test/fixtures/xml/usps/tracking_request_batch.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0"?>
+<TrackFieldRequest USERID="login">
+  <Revision>1</Revision>
+  <ClientIp>127.0.0.1</ClientIp>
+  <SourceId>active_shipping</SourceId>
+  <TrackID ID="9102901000462189604217">
+    <DestinationZipCode>12345</DestinationZipCode>
+    <MailingDate>2010-01-30</MailingDate>
+  </TrackID>
+  <TrackID ID="5555555555555555555555"/>
+  <TrackID ID="9405510ee200828613653750"/>
+</TrackFieldRequest>

--- a/test/fixtures/xml/usps/tracking_response_batch.xml
+++ b/test/fixtures/xml/usps/tracking_response_batch.xml
@@ -1,0 +1,223 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<TrackResponse>
+  <TrackInfo ID="9102901000462189604217">
+    <Class>First-Class Package Service</Class>
+    <ClassOfMailCode>FC</ClassOfMailCode>
+    <DestinationCity>HANNA CITY</DestinationCity>
+    <DestinationState>IL</DestinationState>
+    <DestinationZip>61536</DestinationZip>
+    <EmailEnabled>true</EmailEnabled>
+    <ExpectedDeliveryDate>April 28, 2015</ExpectedDeliveryDate>
+    <KahalaIndicator>false</KahalaIndicator>
+    <MailTypeCode>DM</MailTypeCode>
+    <MPDATE>2015-04-24 02:08:04.000000</MPDATE>
+    <MPSUFFIX>495865558</MPSUFFIX>
+    <OriginCity>ARGYLE</OriginCity>
+    <OriginState>TX</OriginState>
+    <OriginZip>76226</OriginZip>
+    <PodEnabled>false</PodEnabled>
+    <PredictedDeliveryDate>April 28, 2015</PredictedDeliveryDate>
+    <RestoreEnabled>false</RestoreEnabled>
+    <RramEnabled>false</RramEnabled>
+    <RreEnabled>false</RreEnabled>
+    <Service>USPS Tracking&lt;SUP&gt;&amp;#153;&lt;/SUP&gt;</Service>
+    <ServiceTypeCode>001</ServiceTypeCode>
+    <Status>Delivered, In/At Mailbox</Status>
+    <StatusCategory>Delivered</StatusCategory>
+    <StatusSummary>Your item was delivered in or at the mailbox at 9:01 am on April 28, 2015 in HANNA CITY, IL 61536.</StatusSummary>
+    <TABLECODE>T</TABLECODE>
+    <TrackSummary>
+      <EventTime>9:01 am</EventTime>
+      <EventDate>April 28, 2015</EventDate>
+      <Event>Delivered, In/At Mailbox</Event>
+      <EventCity>HANNA CITY</EventCity>
+      <EventState>IL</EventState>
+      <EventZIPCode>61536</EventZIPCode>
+      <EventCountry/>
+      <FirmName/>
+      <Name/>
+      <AuthorizedAgent>false</AuthorizedAgent>
+      <EventCode>01</EventCode>
+      <DeliveryAttributeCode>01</DeliveryAttributeCode>
+    </TrackSummary>
+    <TrackDetail>
+      <EventTime>8:29 am</EventTime>
+      <EventDate>April 28, 2015</EventDate>
+      <Event>Out for Delivery</Event>
+      <EventCity>HANNA CITY</EventCity>
+      <EventState>IL</EventState>
+      <EventZIPCode>61536</EventZIPCode>
+      <EventCountry/>
+      <FirmName/>
+      <Name/>
+      <AuthorizedAgent>false</AuthorizedAgent>
+      <EventCode>OF</EventCode>
+    </TrackDetail>
+    <TrackDetail>
+      <EventTime>8:19 am</EventTime>
+      <EventDate>April 28, 2015</EventDate>
+      <Event>Sorting Complete</Event>
+      <EventCity>HANNA CITY</EventCity>
+      <EventState>IL</EventState>
+      <EventZIPCode>61536</EventZIPCode>
+      <EventCountry/>
+      <FirmName/>
+      <Name/>
+      <AuthorizedAgent>false</AuthorizedAgent>
+      <EventCode>PC</EventCode>
+    </TrackDetail>
+    <TrackDetail>
+      <EventTime>7:03 am</EventTime>
+      <EventDate>April 28, 2015</EventDate>
+      <Event>Arrived at Post Office</Event>
+      <EventCity>HANNA CITY</EventCity>
+      <EventState>IL</EventState>
+      <EventZIPCode>61536</EventZIPCode>
+      <EventCountry/>
+      <FirmName/>
+      <Name/>
+      <AuthorizedAgent>false</AuthorizedAgent>
+      <EventCode>07</EventCode>
+    </TrackDetail>
+    <TrackDetail>
+      <EventTime>4:05 am</EventTime>
+      <EventDate>April 28, 2015</EventDate>
+      <Event>Departed USPS Facility</Event>
+      <EventCity>HAZELWOOD</EventCity>
+      <EventState>MO</EventState>
+      <EventZIPCode>63042</EventZIPCode>
+      <EventCountry/>
+      <FirmName/>
+      <Name/>
+      <AuthorizedAgent>false</AuthorizedAgent>
+      <EventCode>EF</EventCode>
+    </TrackDetail>
+    <TrackDetail>
+      <EventTime>4:04 pm</EventTime>
+      <EventDate>April 27, 2015</EventDate>
+      <Event>Arrived at USPS Facility</Event>
+      <EventCity>HAZELWOOD</EventCity>
+      <EventState>MO</EventState>
+      <EventZIPCode>63042</EventZIPCode>
+      <EventCountry/>
+      <FirmName/>
+      <Name/>
+      <AuthorizedAgent>false</AuthorizedAgent>
+      <EventCode>10</EventCode>
+    </TrackDetail>
+    <TrackDetail>
+      <EventTime>12:18 am</EventTime>
+      <EventDate>April 26, 2015</EventDate>
+      <Event>Departed USPS Facility</Event>
+      <EventCity>COPPELL</EventCity>
+      <EventState>TX</EventState>
+      <EventZIPCode>75099</EventZIPCode>
+      <EventCountry/>
+      <FirmName/>
+      <Name/>
+      <AuthorizedAgent>false</AuthorizedAgent>
+      <EventCode>EF</EventCode>
+    </TrackDetail>
+    <TrackDetail>
+      <EventTime>7:19 pm</EventTime>
+      <EventDate>April 25, 2015</EventDate>
+      <Event>Arrived at USPS Origin Facility</Event>
+      <EventCity>COPPELL</EventCity>
+      <EventState>TX</EventState>
+      <EventZIPCode>75099</EventZIPCode>
+      <EventCountry/>
+      <FirmName/>
+      <Name/>
+      <AuthorizedAgent>false</AuthorizedAgent>
+      <EventCode>10</EventCode>
+    </TrackDetail>
+    <TrackDetail>
+      <EventTime>6:04 pm</EventTime>
+      <EventDate>April 25, 2015</EventDate>
+      <Event>Accepted at USPS Origin Sort Facility</Event>
+      <EventCity>ARGYLE</EventCity>
+      <EventState>TX</EventState>
+      <EventZIPCode>76226</EventZIPCode>
+      <EventCountry/>
+      <FirmName/>
+      <Name/>
+      <AuthorizedAgent>false</AuthorizedAgent>
+      <EventCode>OA</EventCode>
+    </TrackDetail>
+    <TrackDetail>
+      <EventTime>11:36 pm</EventTime>
+      <EventDate>April 23, 2015</EventDate>
+      <Event>Shipping Label Created</Event>
+      <EventCity>ARGYLE</EventCity>
+      <EventState>TX</EventState>
+      <EventZIPCode>76226</EventZIPCode>
+      <EventCountry/>
+      <FirmName/>
+      <Name/>
+      <AuthorizedAgent>false</AuthorizedAgent>
+      <EventCode>GX</EventCode>
+    </TrackDetail>
+  </TrackInfo>
+  <TrackInfo ID="5555555555555555555555">
+    <Class>First-Class Package Service</Class>
+    <ClassOfMailCode>FC</ClassOfMailCode>
+    <DestinationCity>HANNA CITY</DestinationCity>
+    <DestinationState>IL</DestinationState>
+    <DestinationZip>61536</DestinationZip>
+    <EmailEnabled>true</EmailEnabled>
+    <ExpectedDeliveryDate>April 28, 2015</ExpectedDeliveryDate>
+    <KahalaIndicator>false</KahalaIndicator>
+    <MailTypeCode>DM</MailTypeCode>
+    <MPDATE>2015-04-24 02:08:04.000000</MPDATE>
+    <MPSUFFIX>495865558</MPSUFFIX>
+    <OriginCity>ARGYLE</OriginCity>
+    <OriginState>TX</OriginState>
+    <OriginZip>76226</OriginZip>
+    <PodEnabled>false</PodEnabled>
+    <PredictedDeliveryDate>April 28, 2015</PredictedDeliveryDate>
+    <RestoreEnabled>false</RestoreEnabled>
+    <RramEnabled>false</RramEnabled>
+    <RreEnabled>false</RreEnabled>
+    <Service>USPS Tracking&lt;SUP&gt;&amp;#153;&lt;/SUP&gt;</Service>
+    <ServiceTypeCode>001</ServiceTypeCode>
+    <Status>Delivered, In/At Mailbox</Status>
+    <StatusCategory>Delivered</StatusCategory>
+    <StatusSummary>Your item was delivered in or at the mailbox at 9:01 am on April 28, 2015 in HANNA CITY, IL 61536.</StatusSummary>
+    <TABLECODE>T</TABLECODE>
+    <TrackSummary>
+      <EventTime>9:01 am</EventTime>
+      <EventDate>April 28, 2015</EventDate>
+      <Event>Delivered, In/At Mailbox</Event>
+      <EventCity>HANNA CITY</EventCity>
+      <EventState>IL</EventState>
+      <EventZIPCode>61536</EventZIPCode>
+      <EventCountry/>
+      <FirmName/>
+      <Name/>
+      <AuthorizedAgent>false</AuthorizedAgent>
+      <EventCode>01</EventCode>
+      <DeliveryAttributeCode>01</DeliveryAttributeCode>
+    </TrackSummary>
+    <TrackDetail>
+      <EventTime>11:36 pm</EventTime>
+      <EventDate>April 23, 2015</EventDate>
+      <Event>Shipping Label Created</Event>
+      <EventCity>ARGYLE</EventCity>
+      <EventState>TX</EventState>
+      <EventZIPCode>76226</EventZIPCode>
+      <EventCountry/>
+      <FirmName/>
+      <Name/>
+      <AuthorizedAgent>false</AuthorizedAgent>
+      <EventCode>GX</EventCode>
+    </TrackDetail>
+  </TrackInfo>
+  <TrackInfo ID="9405510ee200828613653750">
+    <Error>
+      <Number>-2147219302</Number>
+      <Description>The Postal Service could not locate the tracking information for your request. Please verify your tracking number and try again later.</Description>
+      <HelpFile/>
+      <HelpContext/>
+    </Error>
+  </TrackInfo>
+</TrackResponse>


### PR DESCRIPTION
Adds a method `batch_find_tracking_info` that allows fetching the tracking info for multiple numbers at a time. It accepts an array of hashes with all the info necessary to uniquely specify a shipment and returns an array of results in the same order.

USPS has two types of errors, schema errors that wreck the whole request, which are thrown as exceptions, and individual errors that only affect a certain tracker, which are just returned as unsuccessful responses.

Both the single and batched methods use the same parsing and building methods behind the scenes.

@Shopify/shipping