### PR TITLE
Error handling for FedEx unsupported multiple packages.

### DIFF
--- a/lib/active_shipping/carriers/fedex.rb
+++ b/lib/active_shipping/carriers/fedex.rb
@@ -163,12 +163,10 @@ module ActiveShipping
 
 
     # Get Shipping labels
-    # Caveats:
-    #  - Only supports singlular packages
-    #
     def create_shipment(origin, destination, packages, options = {})
       options = @options.update(options)
       packages = Array(packages)
+      raise Error, "Multiple packages are not supported yet." if packages.length > 1
 
       request = build_shipment_request(origin, destination, packages, options)
       logger.debug(request) if logger

--- a/test/remote/fedex_test.rb
+++ b/test/remote/fedex_test.rb
@@ -298,6 +298,38 @@ class RemoteFedExTest < Minitest::Test
     end
   end
 
+  def test_cant_obtain_multiple_shipping_labels
+    assert_raises(ActiveShipping::Error,"Multiple packages are not supported yet.") do
+      @carrier.create_shipment(
+        location_fixtures[:beverly_hills_with_name],
+        location_fixtures[:new_york_with_name],
+        [package_fixtures[:wii],package_fixtures[:wii]],
+        :test => true,
+        :reference_number => {
+          :value => "FOO-123",
+          :code => "PO"
+        }
+      )
+    end
+  end
+
+  def test_obtain_shipping_label_with_single_element_array
+    response = @carrier.create_shipment(
+      location_fixtures[:beverly_hills_with_name],
+      location_fixtures[:new_york_with_name],
+      [package_fixtures[:wii]],
+        :test => true,
+        :reference_number => {
+          :value => "FOO-123",
+          :code => "PO"
+        }
+    )
+
+    assert response.success?
+    refute_empty response.labels
+    refute_empty response.labels.first.img_data
+  end
+
   def test_obtain_shipping_label
     response = @carrier.create_shipment(
       location_fixtures[:beverly_hills_with_name],


### PR DESCRIPTION
As discussed in #261 the `create_shipment` interface accepts an array but the FedEx code doesn't support multiple packages yet. This just turns a comment caveat into an exception and then tests the interface.

@kmcphillips 