### PR TITLE
Add OriginZip to USPS

### DIFF
--- a/lib/active_shipping/carriers/usps.rb
+++ b/lib/active_shipping/carriers/usps.rb
@@ -291,7 +291,7 @@ module ActiveShipping
     end
 
     def world_rates(origin, destination, packages, options = {})
-      request = build_world_rate_request(packages, destination, options)
+      request = build_world_rate_request(origin, packages, destination, options)
       # never use test mode; rate requests just won't work on test servers
       parse_rate_response(origin, destination, packages, commit(:world_rates, request, false), options)
     end
@@ -371,12 +371,13 @@ module ActiveShipping
     #
     # package.options[:mail_type] -- one of [:package, :postcard, :matter_for_the_blind, :envelope].
     #                                 Defaults to :package.
-    def build_world_rate_request(packages, destination, options)
+    def build_world_rate_request(origin, packages, destination, options)
       country = COUNTRY_NAME_CONVERSIONS[destination.country.code(:alpha2).value] || destination.country.name
       xml_builder = Nokogiri::XML::Builder.new do |xml|
         xml.IntlRateV2Request('USERID' => @options[:login]) do
           Array(packages).each_with_index do |package, id|
             xml.Package('ID' => id) do
+              xml.OriginZip(origin.zip)
               xml.Pounds(0)
               xml.Ounces([package.ounces, 1].max.ceil) # takes an integer for some reason, must be rounded UP
               xml.MailType(MAIL_TYPES[package.options[:mail_type]] || 'Package')

--- a/lib/active_shipping/version.rb
+++ b/lib/active_shipping/version.rb
@@ -1,3 +1,3 @@
 module ActiveShipping
-  VERSION = "1.2.0"
+  VERSION = "1.2.1"
 end

--- a/test/fixtures/xml/usps/world_rate_request_with_value.xml
+++ b/test/fixtures/xml/usps/world_rate_request_with_value.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0"?>
 <IntlRateV2Request USERID="login">
   <Package ID="0">
+    <OriginZip>90210</OriginZip>
     <Pounds>0</Pounds>
     <Ounces>120</Ounces>
     <MailType>Package</MailType>

--- a/test/fixtures/xml/usps/world_rate_request_without_value.xml
+++ b/test/fixtures/xml/usps/world_rate_request_without_value.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0"?>
 <IntlRateV2Request USERID="login">
   <Package ID="0">
+    <OriginZip>90210</OriginZip>
     <Pounds>0</Pounds>
     <Ounces>9</Ounces>
     <MailType>Package</MailType>


### PR DESCRIPTION
@Shopify/shipping 

Pulls https://github.com/RichardBlair/active_shipping/pull/1 and https://github.com/RichardBlair/active_shipping/pull/2 into `master`.

Bumps version to `1.2.1`.

The change is described here in the USPS Web Tools API May release (warning: .RTF for some reason):
https://www.usps.com/business/web-tools-apis/2015-may-webtools-release-notes.rtf