### PR TITLE
Update USPS rates API - Fix errors

### DIFF
--- a/lib/active_shipping/carriers/usps.rb
+++ b/lib/active_shipping/carriers/usps.rb
@@ -404,7 +404,7 @@ module ActiveShipping
                 xml.public_send(COMMERCIAL_FLAG_NAME.fetch(commercial_type), 'Y')
               end
               xml.OriginZip(origin.zip)
-              xml.AcceptanceDateTime(DateTime.now.iso8601)
+              xml.AcceptanceDateTime(Time.now.utc.iso8601)
               xml.DestinationPostalCode(destination.zip)
             end
           end

--- a/lib/active_shipping/carriers/usps.rb
+++ b/lib/active_shipping/carriers/usps.rb
@@ -291,7 +291,7 @@ module ActiveShipping
     end
 
     def world_rates(origin, destination, packages, options = {})
-      request = build_world_rate_request(packages, destination, options)
+      request = build_world_rate_request(origin, packages, destination, options)
       # never use test mode; rate requests just won't work on test servers
       parse_rate_response(origin, destination, packages, commit(:world_rates, request, false), options)
     end
@@ -371,10 +371,11 @@ module ActiveShipping
     #
     # package.options[:mail_type] -- one of [:package, :postcard, :matter_for_the_blind, :envelope].
     #                                 Defaults to :package.
-    def build_world_rate_request(packages, destination, options)
+    def build_world_rate_request(origin, packages, destination, options)
       country = COUNTRY_NAME_CONVERSIONS[destination.country.code(:alpha2).value] || destination.country.name
       xml_builder = Nokogiri::XML::Builder.new do |xml|
         xml.IntlRateV2Request('USERID' => @options[:login]) do
+          xml.Revision(2)
           Array(packages).each_with_index do |package, id|
             xml.Package('ID' => id) do
               xml.Pounds(0)
@@ -402,6 +403,9 @@ module ActiveShipping
               if commercial_type = commercial_type(options)
                 xml.public_send(COMMERCIAL_FLAG_NAME.fetch(commercial_type), 'Y')
               end
+              xml.OriginZip(origin.zip)
+              xml.AcceptanceDateTime(DateTime.now.iso8601)
+              xml.DestinationPostalCode(destination.zip)
             end
           end
         end

--- a/lib/active_shipping/carriers/usps.rb
+++ b/lib/active_shipping/carriers/usps.rb
@@ -404,7 +404,7 @@ module ActiveShipping
                 xml.public_send(COMMERCIAL_FLAG_NAME.fetch(commercial_type), 'Y')
               end
               xml.OriginZip(origin.zip)
-              xml.AcceptanceDateTime(Time.now.utc.iso8601)
+              xml.AcceptanceDateTime((options[:acceptance_time] || Time.now.utc).iso8601)
               xml.DestinationPostalCode(destination.zip)
             end
           end

--- a/lib/active_shipping/version.rb
+++ b/lib/active_shipping/version.rb
@@ -1,3 +1,3 @@
 module ActiveShipping
-  VERSION = "1.2.0"
+  VERSION = "1.2.1"
 end

--- a/test/fixtures/xml/usps/world_rate_request_with_value.xml
+++ b/test/fixtures/xml/usps/world_rate_request_with_value.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0"?>
 <IntlRateV2Request USERID="login">
+  <Revision>2</Revision>
   <Package ID="0">
     <Pounds>0</Pounds>
     <Ounces>120</Ounces>
@@ -16,5 +17,8 @@
     <Length>15.00</Length>
     <Height>4.50</Height>
     <Girth>29.00</Girth>
+    <OriginZip>90210</OriginZip>
+    <AcceptanceDateTime>2015-06-01T20:34:29Z</AcceptanceDateTime>
+    <DestinationPostalCode>K1P 1J1</DestinationPostalCode>
   </Package>
 </IntlRateV2Request>

--- a/test/fixtures/xml/usps/world_rate_request_without_value.xml
+++ b/test/fixtures/xml/usps/world_rate_request_without_value.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0"?>
 <IntlRateV2Request USERID="login">
+  <Revision>2</Revision>
   <Package ID="0">
     <Pounds>0</Pounds>
     <Ounces>9</Ounces>
@@ -16,5 +17,8 @@
     <Length>7.48</Length>
     <Height>0.79</Height>
     <Girth>12.60</Girth>
+    <OriginZip>90210</OriginZip>
+    <AcceptanceDateTime>2015-06-01T20:34:29Z</AcceptanceDateTime>
+    <DestinationPostalCode>K1P 1J1</DestinationPostalCode>
   </Package>
 </IntlRateV2Request>

--- a/test/unit/carriers/usps_test.rb
+++ b/test/unit/carriers/usps_test.rb
@@ -233,14 +233,14 @@ class USPSTest < Minitest::Test
     expected_request = xml_fixture('usps/world_rate_request_without_value')
     @carrier.expects(:commit).with(:world_rates, expected_request, false).returns(expected_request)
     @carrier.expects(:parse_rate_response)
-    @carrier.find_rates(location_fixtures[:beverly_hills], location_fixtures[:ottawa], package_fixtures[:book], :test => true)
+    @carrier.find_rates(location_fixtures[:beverly_hills], location_fixtures[:ottawa], package_fixtures[:book], :test => true, :acceptance_time => Time.parse("2015-06-01T20:34:29Z"))
   end
 
   def test_build_world_rate_request_with_package_value
     expected_request = xml_fixture('usps/world_rate_request_with_value')
     @carrier.expects(:commit).with(:world_rates, expected_request, false).returns(expected_request)
     @carrier.expects(:parse_rate_response)
-    @carrier.find_rates(location_fixtures[:beverly_hills], location_fixtures[:ottawa], package_fixtures[:american_wii], :test => true)
+    @carrier.find_rates(location_fixtures[:beverly_hills], location_fixtures[:ottawa], package_fixtures[:american_wii], :test => true, :acceptance_time => Time.parse("2015-06-01T20:34:29Z"))
   end
 
   def test_initialize_options_requirements


### PR DESCRIPTION
This fixes the issues introduced by the USPS WEBTOOLS upgrade on May 31. This patch has been tested to work in retrieving international rates from the US to Canada.

Unlike the earlier attempt in #272 this patch passes format validation by including all the required fields and *having them in the correct order*. Also note that the `AcceptanceDateTime` field does not accept any time with a positive timezone, this is worked around by always converting to UTC.

@Shopify/shipping 
cc @mleglise because he noted that Spree was affected
cc @eboswort because Casper is on the list of Spree users and he might have encountered this