### PR TITLE
Handle service specific USPS rate errors more gracefully

### DIFF
--- a/lib/active_shipping/carriers/usps.rb
+++ b/lib/active_shipping/carriers/usps.rb
@@ -416,7 +416,7 @@ module ActiveShipping
 
       xml = Nokogiri.XML(response)
 
-      if error = xml.at('/Error')
+      if error = xml.at_xpath('/Error | //ServiceErrors/ServiceError')
         success = false
         message = error.at('Description').text
       else

--- a/test/fixtures/xml/usps/api_error_rate_response.xml
+++ b/test/fixtures/xml/usps/api_error_rate_response.xml
@@ -1,0 +1,53 @@
+<?xml version="1.0"?>
+<IntlRateV2Response>
+  <Package ID="0">
+    <!-- Other successful Services, Prohibitions, etc were here -->
+    <Service ID="15">
+      <Pounds>0</Pounds>
+      <Ounces>9</Ounces>
+      <MailType>Package</MailType>
+      <Container>RECTANGULAR</Container>
+      <Size>REGULAR</Size>
+      <Width>5.51</Width>
+      <Length>7.48</Length>
+      <Height>0.79</Height>
+      <Girth>12.60</Girth>
+      <Country>CANADA</Country>
+      <Postage>10.30</Postage>
+      <ExtraServices/>
+      <ValueOfContents>0.00</ValueOfContents>
+      <InsComment>SERVICE</InsComment>
+      <SvcCommitments>Varies by destination</SvcCommitments>
+      <SvcDescription>First-Class Package International Service&amp;lt;sup&amp;gt;&amp;#8482;&amp;lt;/sup&amp;gt;</SvcDescription>
+      <MaxDimensions>Other than rolls: Max. length 24", max length, height and depth (thickness) combined 36"&lt;br&gt;Rolls: Max. length 36". Max length and twice the diameter combined 42"</MaxDimensions>
+      <MaxWeight>4</MaxWeight>
+    </Service>
+    <Service ID="2">
+      <Pounds>0</Pounds>
+      <Ounces>9</Ounces>
+      <MailType>Package</MailType>
+      <Container>RECTANGULAR</Container>
+      <Size>REGULAR</Size>
+      <Width>5.51</Width>
+      <Length>7.48</Length>
+      <Height>0.79</Height>
+      <Girth>12.60</Girth>
+      <Country>CANADA</Country>
+      <Postage>0.00</Postage>
+      <ExtraServices>
+        <ExtraService>
+          <ServiceID/>
+          <ServiceName/>
+          <Available>False</Available>
+          <Price/>
+        </ExtraService>
+      </ExtraServices>
+      <ServiceErrors>
+        <ServiceError>
+          <Id>50050</Id>
+          <Description>This is a test response with the format of a real error.</Description>
+        </ServiceError>
+      </ServiceErrors>
+    </Service>
+  </Package>
+</IntlRateV2Response>

--- a/test/unit/carriers/usps_test.rb
+++ b/test/unit/carriers/usps_test.rb
@@ -281,6 +281,21 @@ class USPSTest < Minitest::Test
     assert_equal ordered_service_names, response.rates.map(&:service_name).sort
   end
 
+  def test_parse_international_rate_response_errors
+    fixture_xml = xml_fixture('usps/api_error_rate_response')
+    @carrier.expects(:commit).returns(fixture_xml)
+
+    error = assert_raises(ResponseError) do
+      @carrier.find_rates(
+        location_fixtures[:beverly_hills], # imperial (U.S. origin)
+        location_fixtures[:ottawa],
+        package_fixtures[:american_wii],
+        :test => true
+      )
+    end
+    assert_equal 'This is a test response with the format of a real error.', error.message
+  end
+
   def test_parse_max_dimension_sentences
     limits = {
       "Max. length 46\", width 35\", height 46\" and max. length plus girth 108\"" =>


### PR DESCRIPTION
When USPS changed their API the error being bubbled up was very unhelpful and not properly an active_shipping error. The reason for this is that the code for handling errors in rate response was missing a matcher for a specific type of error that was specific to a service.

@RichardBlair @kmcphillips 