### PR TITLE
Don't include container on small packages

### DIFF
--- a/lib/active_shipping/carriers/usps.rb
+++ b/lib/active_shipping/carriers/usps.rb
@@ -343,8 +343,11 @@ module ActiveShipping
               xml.ZipDestination(strip_zip(destination_zip))
               xml.Pounds(0)
               xml.Ounces("%0.1f" % [package.ounces, 1].max)
-              xml.Container(CONTAINERS[package.options[:container]] || (package.cylinder? ? 'NONRECTANGULAR' : 'RECTANGULAR'))
-              xml.Size(USPS.size_code_for(package))
+              size_code = USPS.size_code_for(package)
+              container = CONTAINERS[package.options[:container]]
+              container ||= (package.cylinder? ? 'NONRECTANGULAR' : 'RECTANGULAR') if size_code == 'LARGE'
+              xml.Container(container)
+              xml.Size(size_code)
               xml.Width("%0.2f" % package.inches(:width))
               xml.Length("%0.2f" % package.inches(:length))
               xml.Height("%0.2f" % package.inches(:height))

--- a/test/fixtures/xml/usps/us_rate_request_large.xml
+++ b/test/fixtures/xml/usps/us_rate_request_large.xml
@@ -6,13 +6,13 @@
     <ZipOrigination>90210</ZipOrigination>
     <ZipDestination>10017</ZipDestination>
     <Pounds>0</Pounds>
-    <Ounces>8.8</Ounces>
-    <Container/>
-    <Size>REGULAR</Size>
-    <Width>5.51</Width>
-    <Length>7.48</Length>
-    <Height>0.79</Height>
-    <Girth>12.60</Girth>
-    <Machinable>TRUE</Machinable>
+    <Ounces>800.0</Ounces>
+    <Container>RECTANGULAR</Container>
+    <Size>LARGE</Size>
+    <Width>24.00</Width>
+    <Length>36.00</Length>
+    <Height>24.00</Height>
+    <Girth>96.00</Girth>
+    <Machinable>FALSE</Machinable>
   </Package>
 </RateV4Request>

--- a/test/unit/carriers/usps_test.rb
+++ b/test/unit/carriers/usps_test.rb
@@ -214,6 +214,7 @@ class USPSTest < Minitest::Test
 
   def test_build_us_rate_request_uses_proper_container
     expected_request = xml_fixture('usps/us_rate_request')
+    expected_request.gsub!('<Container/>','<Container>RECTANGULAR</Container>')
     @carrier.expects(:commit).with(:us_rates, expected_request, false).returns(expected_request)
     @carrier.expects(:parse_rate_response)
     package = package_fixtures[:book]
@@ -221,11 +222,19 @@ class USPSTest < Minitest::Test
     @carrier.find_rates(location_fixtures[:beverly_hills], location_fixtures[:new_york], package, :test => true, :container => :rectangular)
   end
 
-  def test_build_us_rate_request_uses_proper_container_when_none_is_specified
+  def test_build_us_rate_request_uses_no_container_on_small_packages
     expected_request = xml_fixture('usps/us_rate_request')
     @carrier.expects(:commit).with(:us_rates, expected_request, false).returns(expected_request)
     @carrier.expects(:parse_rate_response)
     package = package_fixtures[:book]
+    @carrier.find_rates(location_fixtures[:beverly_hills], location_fixtures[:new_york], package, :test => true)
+  end
+
+  def test_build_us_rate_request_uses_proper_container_when_none_is_specified
+    expected_request = xml_fixture('usps/us_rate_request_large')
+    @carrier.expects(:commit).with(:us_rates, expected_request, false).returns(expected_request)
+    @carrier.expects(:parse_rate_response)
+    package = package_fixtures[:big_half_pound]
     @carrier.find_rates(location_fixtures[:beverly_hills], location_fixtures[:new_york], package, :test => true)
   end
 


### PR DESCRIPTION
This PR fixes #275. According to the USPS documentation the container tag should not be included when the package isn't LARGE and it in fact gives an error. https://github.com/Shopify/active_shipping/pull/248 mistakenly added the container to every us to us rate request, causing them to fail.

This PR fixes a couple remote tests that failed because of this bug but nobody noticed because we don't have credentials in CI. 

I used credentials locally and ran the USPS remote tests, most are fixed, one still fails because of a different issue relating to packages with only a country (a rare case), I will fix that in a separate upcoming PR. I'll bump and release a new version after that PR.

@RichardBlair @kmcphillips cc @jnormore 