### PR TITLE
Fix USPS requests with only a country

### DIFF
--- a/lib/active_shipping/carriers/usps.rb
+++ b/lib/active_shipping/carriers/usps.rb
@@ -404,8 +404,10 @@ module ActiveShipping
                 xml.public_send(COMMERCIAL_FLAG_NAME.fetch(commercial_type), 'Y')
               end
               xml.OriginZip(origin.zip)
-              xml.AcceptanceDateTime((options[:acceptance_time] || Time.now.utc).iso8601)
-              xml.DestinationPostalCode(destination.zip)
+              if destination.zip.present?
+                xml.AcceptanceDateTime((options[:acceptance_time] || Time.now.utc).iso8601)
+                xml.DestinationPostalCode(destination.zip)
+              end
             end
           end
         end

--- a/test/fixtures/xml/usps/world_rate_request_only_country.xml
+++ b/test/fixtures/xml/usps/world_rate_request_only_country.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0"?>
+<IntlRateV2Request USERID="login">
+  <Revision>2</Revision>
+  <Package ID="0">
+    <Pounds>0</Pounds>
+    <Ounces>120</Ounces>
+    <MailType>Package</MailType>
+    <GXG>
+      <POBoxFlag>N</POBoxFlag>
+      <GiftFlag>N</GiftFlag>
+    </GXG>
+    <ValueOfContents>269.99</ValueOfContents>
+    <Country>Czech Republic</Country>
+    <Container>RECTANGULAR</Container>
+    <Size>LARGE</Size>
+    <Width>10.00</Width>
+    <Length>15.00</Length>
+    <Height>4.50</Height>
+    <Girth>29.00</Girth>
+    <OriginZip>90210</OriginZip>
+  </Package>
+</IntlRateV2Request>

--- a/test/unit/carriers/usps_test.rb
+++ b/test/unit/carriers/usps_test.rb
@@ -243,6 +243,13 @@ class USPSTest < Minitest::Test
     @carrier.find_rates(location_fixtures[:beverly_hills], location_fixtures[:ottawa], package_fixtures[:american_wii], :test => true, :acceptance_time => Time.parse("2015-06-01T20:34:29Z"))
   end
 
+  def test_build_world_rate_request_only_country
+    expected_request = xml_fixture('usps/world_rate_request_only_country')
+    @carrier.expects(:commit).with(:world_rates, expected_request, false).returns(expected_request)
+    @carrier.expects(:parse_rate_response)
+    @carrier.find_rates(location_fixtures[:beverly_hills], Location.new(:country => 'CZ'), package_fixtures[:american_wii], :test => true)
+  end
+
   def test_initialize_options_requirements
     assert_raises(ArgumentError) { USPS.new }
     assert USPS.new(:login => 'blah')


### PR DESCRIPTION
A failing remote test tipped me off to this. If the destination postal code was nil because only a country was provided then the API would return an error because AcceptanceDateTime is only allowed when DestinationPostalCode is present.

This PR fixes the remote test and also creates a local test for the fix.

After this and #280 are merged the USPS remote tests will all be passing and I will release a new bugfix release.

@RichardBlair @kmcphillips cc @jnormore 