### PR TITLE
Handle upper case country names in tracking

### DIFF
--- a/lib/active_shipping/carriers/usps.rb
+++ b/lib/active_shipping/carriers/usps.rb
@@ -246,7 +246,9 @@ module ActiveShipping
 
       country_node = node.at('EventCountry')
       country = country_node ? country_node.text : ''
-      country = 'USA' if country.empty?
+      country = 'UNITED STATES' if country.empty?
+      # USPS returns upcased country names which ActiveUtils doesn't recognize without translation
+      country = find_country_code_case_insensitive(country)
 
       time = Time.parse(timestamp)
       zoneless_time = Time.utc(time.year, time.month, time.mday, time.hour, time.min, time.sec)
@@ -640,6 +642,13 @@ module ActiveShipping
 
     def response_message(document)
       response_status_node(document).text
+    end
+
+    def find_country_code_case_insensitive(name)
+      upcase_name = name.upcase
+      country = ActiveUtils::Country::COUNTRIES.detect { |c| c[:name].upcase == upcase_name }
+      raise ActiveShipping::Error, "No country found for #{name}" unless country
+      country[:alpha2]
     end
 
     def commit(action, request, test = false)

--- a/test/fixtures/xml/usps/tracking_response_alt.xml
+++ b/test/fixtures/xml/usps/tracking_response_alt.xml
@@ -31,7 +31,7 @@
       <Event>Out for Delivery, in truck</Event>
       <EventState>ON</EventState>
       <EventZIPCode>61536</EventZIPCode>
-      <EventCountry>Canada</EventCountry>
+      <EventCountry>CANADA</EventCountry>
       <FirmName/>
       <Name/>
       <AuthorizedAgent>false</AuthorizedAgent>

--- a/test/remote/usps_test.rb
+++ b/test/remote/usps_test.rb
@@ -12,10 +12,11 @@ class RemoteUSPSTest < Minitest::Test
   end
 
   def test_tracking
-    skip '<#<ActiveShipping::ResponseError: There is no record of that mail item. If it was mailed recently, it may not yet be tracked. Please try again later.>>.'
-
-    @carrier.find_tracking_info('EJ958083578US', :test => true)
+    response = @carrier.find_tracking_info('LN284529912US', :test => true)
     assert response.success?, response.message
+    assert_equal 9,response.shipment_events.size
+    assert_equal 'DELIVERED', response.shipment_events.last.message
+    assert_equal Time.parse('2015-06-01 13:36:00 UTC'), response.actual_delivery_date
   end
 
   def test_tracking_with_bad_number


### PR DESCRIPTION
This PR adds a remote test for USPS tracking using a tracking number of my own which I am okay with releasing. It also fixes a bug I found in the process of actually running this remote test which is that USPS returns upper case country names, which `ActiveUtils::Country` can't find. Thus this PR adds code for finding country names in a case insensitive way.

@kmcphillips @RichardBlair 