### PR TITLE
UPS. Support for voiding shipments.

### DIFF
--- a/lib/active_shipping/carriers/ups.rb
+++ b/lib/active_shipping/carriers/ups.rb
@@ -828,7 +828,7 @@ module ActiveShipping
       if success
         true
       else
-        raise "Void shipment failed with message: #{message}"
+        raise ResponseError.new("Void shipment failed with message: #{message}")
       end
     end
 

--- a/lib/active_shipping/carriers/ups.rb
+++ b/lib/active_shipping/carriers/ups.rb
@@ -16,7 +16,8 @@ module ActiveShipping
       :track => 'ups.app/xml/Track',
       :ship_confirm => 'ups.app/xml/ShipConfirm',
       :ship_accept => 'ups.app/xml/ShipAccept',
-      :delivery_dates =>  'ups.app/xml/TimeInTransit'
+      :delivery_dates =>  'ups.app/xml/TimeInTransit',
+      :void =>  'ups.app/xml/Void'
     }
 
     PICKUP_CODES = HashWithIndifferentAccess.new(
@@ -144,7 +145,7 @@ module ActiveShipping
     # @return [ActiveShipping::TrackingResponse] The response from the carrier. This
     #   response should a list of shipment tracking events if successful.
     def find_tracking_info(tracking_number, options = {})
-      options = @options.update(options)
+      options = @options.merge(options)
       access_request = build_access_request
       tracking_request = build_tracking_request(tracking_number, options)
       response = commit(:track, save_request(access_request + tracking_request), options[:test])
@@ -192,6 +193,14 @@ module ActiveShipping
       dates_request = build_delivery_dates_request(origin, destination, packages, pickup_date, options)
       response = commit(:delivery_dates, save_request(access_request + dates_request), (options[:test] || false))
       parse_delivery_dates_response(origin, destination, packages, response, options)
+    end
+
+    def void_shipment(tracking, options={})
+      options = @options.merge(options)
+      access_request = build_access_request
+      void_request = build_void_request(tracking)
+      response = commit(:void, save_request(access_request + void_request), (options[:test] || false))
+      parse_void_response(response, options)
     end
 
     protected
@@ -468,6 +477,18 @@ module ActiveShipping
         end
       end
 
+      xml_builder.to_xml
+    end
+
+    def build_void_request(tracking)
+      xml_builder = Nokogiri::XML::Builder.new do |xml|
+        xml.VoidShipmentRequest do
+          xml.Request do
+            xml.RequestAction('Void')
+          end
+          xml.ShipmentIdentificationNumber(tracking)
+        end
+      end
       xml_builder.to_xml
     end
 
@@ -798,6 +819,17 @@ module ActiveShipping
         end
       end
       response = DeliveryDateEstimatesResponse.new(success, message, Hash.from_xml(response).values.first, :delivery_estimates => delivery_estimates, :xml => response, :request => last_request)
+    end
+
+    def parse_void_response(response, options={})
+      xml = build_document(response, 'VoidShipmentResponse')
+      success = response_success?(xml)
+      message = response_message(xml)
+      if success
+        true
+      else
+        raise "Void shipment failed with message: #{message}"
+      end
     end
 
     def location_from_address_node(address)

--- a/test/fixtures/xml/ups/void_shipment_response.xml
+++ b/test/fixtures/xml/ups/void_shipment_response.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0"?><VoidShipmentResponse><Response><TransactionReference></TransactionReference><ResponseStatusCode>1</ResponseStatusCode><ResponseStatusDescription>Success</ResponseStatusDescription></Response><Status>
+<StatusType>
+<Code>1</Code>
+<Description>Success</Description>
+</StatusType>
+<StatusCode>
+<Code>1</Code>
+<Description>Success</Description>
+</StatusCode>
+</Status>
+</VoidShipmentResponse>

--- a/test/remote/ups_test.rb
+++ b/test/remote/ups_test.rb
@@ -323,7 +323,7 @@ class RemoteUPSTest < Minitest::Test
     begin
       response = @carrier.void_shipment('1Z12345E8793628675')
       assert false # voiding this number should raise an error
-    rescue => e
+    rescue ResponseError => e
       assert_equal(e.message, "Void shipment failed with message: Failure: Time for voiding has expired.")
     end
   end

--- a/test/remote/ups_test.rb
+++ b/test/remote/ups_test.rb
@@ -311,4 +311,20 @@ class RemoteUPSTest < Minitest::Test
     ww_express_estimate = response.delivery_estimates.select {|de| de.service_name == "UPS Worldwide Express"}.first
     assert_equal Date.parse(1.business_day.from_now.to_s), ww_express_estimate.date
   end
+
+  def test_void_shipment
+    # this is a test tracking number from the ups docs that always returns sucess
+    response = @carrier.void_shipment('1Z12345E0390817264')
+    assert response
+  end
+
+  def test_void_beyond_time_limit
+    # this is a test tracking number from the ups docs that always returns time limit expired
+    begin
+      response = @carrier.void_shipment('1Z12345E8793628675')
+      assert false # voiding this number should raise an error
+    rescue => e
+      assert_equal(e.message, "Void shipment failed with message: Failure: Time for voiding has expired.")
+    end
+  end
 end

--- a/test/unit/carriers/ups_test.rb
+++ b/test/unit/carriers/ups_test.rb
@@ -506,4 +506,11 @@ class UPSTest < Minitest::Test
     )
     assert_equal ["UPS Ground"], response.rates.map(&:service_name)
   end
+
+  def test_void_shipment
+    mock_response = xml_fixture("ups/void_shipment_response")
+    @carrier.expects(:commit).returns(mock_response)
+    response = @carrier.void_shipment('1Z12345E0390817264')
+    assert response
+  end
 end


### PR DESCRIPTION
This adds the ability to void UPS shipments, which is the same as canceling them. It's a good thing to do if you're not going to use a label. 

I'm wondering how the community feels about the way I set up the return values for `void_shipment`. The way I've got it, you get true if the shipment is voided and otherwise it raises an error with a message about what went wrong.

I guess I could return a response object but it seemed to me like a void shipment request is going to work 99% of the time and when it fails it's probably pretty unexpected and could merit an error rather than just a response with success? == false. 
But I'm happy to make a barebones response object if that's what y'all prefer.

Oh also, side note about the switch from `update` -> `merge`. In my fork of this repo we've switched all the `update`'s to `merge`'s. I don't think calling `update` makes sense because it makes changes to the carrier's `@options` instance variable. I would think if someone passes an options hash to a method then his or her intention would be to override those options just for the method call that he or she is performing right then, not for future calls of other methods on that carrier. So... I guess I'll put up a pr to switch them all?
