### PR TITLE
Fix/skip remaining remote test failures

### DIFF
--- a/test/remote/canada_post_pws_test.rb
+++ b/test/remote/canada_post_pws_test.rb
@@ -121,6 +121,7 @@ class RemoteCanadaPostPWSTest < Minitest::Test
   end
 
   def test_create_shipment
+    skip "Failing with 'Contract Number is a required field' after API change, skipping because no clue how to fix, might need different creds"
     opts = {:customer_number => @customer_number, :service => "DOM.XP"}
     response = @cp.create_shipment(@home_params, @dom_params, @pkg1, @line_item1, opts)
     assert_kind_of CPPWSShippingResponse, response
@@ -131,6 +132,7 @@ class RemoteCanadaPostPWSTest < Minitest::Test
   end
 
   def test_create_shipment_with_options
+    skip "Failing with 'Contract Number is a required field' after API change, skipping because no clue how to fix, might need different creds"
     opts = {:customer_number => @customer_number, :service => "USA.EP"}.merge(@shipping_opts1)
     response = @cp.create_shipment(@home_params, @dest_params, @pkg1, @line_item1, opts)
 
@@ -142,6 +144,7 @@ class RemoteCanadaPostPWSTest < Minitest::Test
   end
 
   def test_retrieve_shipping_label
+    skip "Failing with 'Contract Number is a required field' after API change, skipping because no clue how to fix, might need different creds"
     opts = {:customer_number => @customer_number, :service => "DOM.XP"}
     shipping_response = @cp.create_shipment(@home_params, @dom_params, @pkg1, @line_item1, opts)
 
@@ -157,6 +160,7 @@ class RemoteCanadaPostPWSTest < Minitest::Test
   end
 
   def test_create_shipment_with_invalid_customer_raises_exception
+    skip "Failing with 'Contract Number is a required field' after API change, skipping because no clue how to fix, might need different creds"
     opts = {:customer_number => "0000000000", :service => "DOM.XP"}
     assert_raises(ResponseError) do
       @cp.create_shipment(@home_params, @dom_params, @pkg1, @line_item1, opts)

--- a/test/remote/stamps_test.rb
+++ b/test/remote/stamps_test.rb
@@ -143,7 +143,7 @@ class RemoteStampsTest < Minitest::Test
 
     assert_nil response.label_url
 
-    assert_equal "\r\nN\r\n", response.image[0..4]
+    assert_equal ";\r\n; ", response.image[0..4]
   end
 
   def test_international_shipment


### PR DESCRIPTION
This fixes a Stamps failure relating to their images now having a comment at the top. 

It also skips some Canada Post PWS tests that are failing but neither @wvanbergen or I can figure out how to fix them. They changed their API at some point but the docs haven't been updated to show the correct way, there is only a reference to the error [here](https://www.canadapost.ca/cpo/mc/business/productsservices/developers/messagescodetables.jsf). According to Willem it might have something to do with different account types. We agreed it is better to skip them for now than leave them failing as a disincentive to actually running the remote tests.

With this all the remote tests now either succeed or are skipped, given credentials.

@wvanbergen @kmcphillips 

![screen shot 2015-06-08 at 4 29 54 pm](https://cloud.githubusercontent.com/assets/887610/8044569/8dcb8fae-0dfb-11e5-8b71-c8b182e41e79.png)
