### PR TITLE
Add maximum address field length to carriers

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,7 +98,7 @@ Active Shipping is currently being used and improved in a production environment
 
 ## Running the tests
 
-After installing dependencies with `bundle install`, you can run the unit tests with `rake test:units` and the remote tests with `rake test:remote`. The unit tests mock out requests and responses so that everything runs locally, while the remote tests actually hit the carrier servers. For the remote tests, you'll need valid test credentials for any carriers' tests you want to run. The credentials should go in ~/.active_shipping/credentials.yml, and the format of that file can be seen in the included [credentials.yml](https://github.com/Shopify/active_shipping/blob/master/test/credentials.yml). For some carriers, we have public credentials you can use for testing: see `.travis.yml`.
+After installing dependencies with `bundle install`, you can run the unit tests with `rake test:unit` and the remote tests with `rake test:remote`. The unit tests mock out requests and responses so that everything runs locally, while the remote tests actually hit the carrier servers. For the remote tests, you'll need valid test credentials for any carriers' tests you want to run. The credentials should go in ~/.active_shipping/credentials.yml, and the format of that file can be seen in the included [credentials.yml](https://github.com/Shopify/active_shipping/blob/master/test/credentials.yml). For some carriers, we have public credentials you can use for testing: see `.travis.yml`.
 
 ## Development
 

--- a/lib/active_shipping/carrier.rb
+++ b/lib/active_shipping/carrier.rb
@@ -102,6 +102,12 @@ module ActiveShipping
       Mass.new(150, :pounds)
     end
 
+    # The address field maximum length accepted by the carrier
+    # @return [Integer]
+    def maximum_address_field_length
+      255
+    end
+
     protected
 
     include ActiveUtils::RequiresParameters

--- a/lib/active_shipping/carriers/canada_post.rb
+++ b/lib/active_shipping/carriers/canada_post.rb
@@ -89,6 +89,11 @@ module ActiveShipping
       Mass.new(30, :kilograms)
     end
 
+    def maximum_address_field_length
+      # https://www.canadapost.ca/cpo/mc/business/productsservices/developers/services/shippingmanifest/createshipment.jsf
+      44
+    end
+
     def self.default_location
       {
         :country     => 'CA',

--- a/lib/active_shipping/carriers/canada_post_pws.rb
+++ b/lib/active_shipping/carriers/canada_post_pws.rb
@@ -155,6 +155,11 @@ module ActiveShipping
       Mass.new(MAX_WEIGHT, :kilograms)
     end
 
+    def maximum_address_field_length
+      # https://www.canadapost.ca/cpo/mc/business/productsservices/developers/services/shippingmanifest/createshipment.jsf
+      44
+    end
+
     # service discovery
 
     def parse_services_response(response)

--- a/lib/active_shipping/carriers/fedex.rb
+++ b/lib/active_shipping/carriers/fedex.rb
@@ -177,6 +177,11 @@ module ActiveShipping
       parse_ship_response(response)
     end
 
+    def maximum_address_field_length
+      # See Fedex Developper Guide
+      35
+    end
+
     protected
 
     def build_shipment_request(origin, destination, packages, options = {})

--- a/lib/active_shipping/carriers/ups.rb
+++ b/lib/active_shipping/carriers/ups.rb
@@ -194,6 +194,11 @@ module ActiveShipping
       parse_delivery_dates_response(origin, destination, packages, response, options)
     end
 
+    def maximum_address_field_length
+      # http://www.ups.com/worldshiphelp/WS12/ENU/AppHelp/CONNECT/Shipment_Data_Field_Descriptions.htm
+      35
+    end
+
     protected
 
     def upsified_location(location)

--- a/lib/active_shipping/carriers/usps.rb
+++ b/lib/active_shipping/carriers/usps.rb
@@ -256,6 +256,11 @@ module ActiveShipping
       EventDetails.new(description, time, zoneless_time, location, event_code)
     end
 
+    def maximum_address_field_length
+      # https://www.usps.com/business/web-tools-apis/address-information-api.pdf
+      38
+    end
+
     protected
 
     def build_tracking_request(tracking_number, options = {})

--- a/test/remote/canada_post_pws_test.rb
+++ b/test/remote/canada_post_pws_test.rb
@@ -166,4 +166,8 @@ class RemoteCanadaPostPWSTest < Minitest::Test
       @cp.create_shipment(@home_params, @dom_params, @pkg1, @line_item1, opts)
     end
   end
+
+  def test_maximum_address_field_length
+    assert_equal 44, @carrier.maximum_address_field_length
+  end
 end

--- a/test/remote/canada_post_test.rb
+++ b/test/remote/canada_post_test.rb
@@ -52,4 +52,8 @@ class RemoteCanadaPostTest < Minitest::Test
       refute rates.success?
     end
   end
+
+  def test_maximum_address_field_length
+    assert_equal 44, @carrier.maximum_address_field_length
+  end
 end

--- a/test/remote/correios_test.rb
+++ b/test/remote/correios_test.rb
@@ -96,4 +96,8 @@ class RemoteCorreiosTest < Minitest::Test
     assert error.response.raw_responses.any?
     assert_equal Hash.new, error.response.params
   end
+
+  def test_maximum_address_field_length
+    assert_equal 255, @carrier.maximum_address_field_length
+  end
 end

--- a/test/remote/fedex_test.rb
+++ b/test/remote/fedex_test.rb
@@ -366,4 +366,8 @@ class RemoteFedExTest < Minitest::Test
     signature_option = response.params["ProcessShipmentReply"]["CompletedShipmentDetail"]["CompletedPackageDetails"]["SignatureOption"]
     assert_equal FedEx::SIGNATURE_OPTION_CODES[:adult], signature_option
   end
+
+  def test_maximum_address_field_length
+    assert_equal 35, @carrier.maximum_address_field_length
+  end
 end

--- a/test/remote/kunaki_test.rb
+++ b/test/remote/kunaki_test.rb
@@ -33,4 +33,8 @@ class RemoteKunakiTest < Minitest::Test
       )
     end
   end
+
+  def test_maximum_address_field_length
+    assert_equal 255, @carrier.maximum_address_field_length
+  end
 end

--- a/test/remote/new_zealand_post_test.rb
+++ b/test/remote/new_zealand_post_test.rb
@@ -146,4 +146,8 @@ class RemoteNewZealandPostTest < Minitest::Test
     assert response.success?
     assert response.rates.size > 0
   end
+
+  def test_maximum_address_field_length
+    assert_equal 255, @carrier.maximum_address_field_length
+  end
 end

--- a/test/remote/shipwire_test.rb
+++ b/test/remote/shipwire_test.rb
@@ -81,4 +81,8 @@ class RemoteShipwireTest < Minitest::Test
     )
     refute shipwire.valid_credentials?
   end
+
+  def test_maximum_address_field_length
+    assert_equal 150, @carrier.maximum_address_field_length
+  end
 end

--- a/test/remote/stamps_test.rb
+++ b/test/remote/stamps_test.rb
@@ -393,4 +393,8 @@ class RemoteStampsTest < Minitest::Test
       )
     end
   end
+
+  def test_maximum_address_field_length
+    assert_equal 150, @carrier.maximum_address_field_length
+  end
 end

--- a/test/remote/ups_test.rb
+++ b/test/remote/ups_test.rb
@@ -311,4 +311,8 @@ class RemoteUPSTest < Minitest::Test
     ww_express_estimate = response.delivery_estimates.select {|de| de.service_name == "UPS Worldwide Express"}.first
     assert_equal Date.parse(1.business_day.from_now.to_s), ww_express_estimate.date
   end
+
+  def test_maximum_address_field_length
+    assert_equal 35, @carrier.maximum_address_field_length
+  end
 end

--- a/test/unit/carriers/usps_test.rb
+++ b/test/unit/carriers/usps_test.rb
@@ -565,6 +565,10 @@ class USPSTest < Minitest::Test
     assert_equal [3767, 5526, 7231, 7231], response.rates.map(&:price)
   end
 
+  def test_maximum_address_field_length
+    assert_equal 38, @carrier.maximum_address_field_length
+  end
+
   private
 
   def build_service_node(options = {})


### PR DESCRIPTION
Certain carriers limit the address field to a certain amount of characters which cuts off the address coming from checkout when it is longer.

With this PR we'll be able to validate before that happens.

Also ```s/test:units/test:unit```

r: @trishume 