### PR TITLE
Fix tests and things up for a release.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # ActiveShipping CHANGELOG
 
+### v1.3.0
+
+- Support voiding labels on UPS
+- Parse FedEx ground delivery dates
+- Add maximum address length field
+- Fix UPS unknown country code when using SUREPOST
+
 ### v1.2.2
 
 - Fix "RECTANGULAR" errors with small USPS US->US package rate requests

--- a/lib/active_shipping/version.rb
+++ b/lib/active_shipping/version.rb
@@ -1,3 +1,3 @@
 module ActiveShipping
-  VERSION = "1.2.2"
+  VERSION = "1.3.0"
 end

--- a/test/remote/canada_post_pws_test.rb
+++ b/test/remote/canada_post_pws_test.rb
@@ -166,8 +166,4 @@ class RemoteCanadaPostPWSTest < Minitest::Test
       @cp.create_shipment(@home_params, @dom_params, @pkg1, @line_item1, opts)
     end
   end
-
-  def test_maximum_address_field_length
-    assert_equal 44, @carrier.maximum_address_field_length
-  end
 end

--- a/test/remote/canada_post_test.rb
+++ b/test/remote/canada_post_test.rb
@@ -52,8 +52,4 @@ class RemoteCanadaPostTest < Minitest::Test
       refute rates.success?
     end
   end
-
-  def test_maximum_address_field_length
-    assert_equal 44, @carrier.maximum_address_field_length
-  end
 end

--- a/test/remote/correios_test.rb
+++ b/test/remote/correios_test.rb
@@ -96,8 +96,4 @@ class RemoteCorreiosTest < Minitest::Test
     assert error.response.raw_responses.any?
     assert_equal Hash.new, error.response.params
   end
-
-  def test_maximum_address_field_length
-    assert_equal 255, @carrier.maximum_address_field_length
-  end
 end

--- a/test/remote/fedex_test.rb
+++ b/test/remote/fedex_test.rb
@@ -227,7 +227,7 @@ class RemoteFedExTest < Minitest::Test
 
     assert_equal Time.parse('2015-06-04 18:19:00 +0000'), response.ship_time
     assert_equal nil, response.scheduled_delivery_date
-    assert_equal Time.parse('2015-06-04 23:11:00 +0000'), response.actual_delivery_date
+    assert_equal Time.parse('2015-06-08 23:33:00 +0000'), response.actual_delivery_date
 
     assert_equal nil, response.origin
 
@@ -365,9 +365,5 @@ class RemoteFedExTest < Minitest::Test
 
     signature_option = response.params["ProcessShipmentReply"]["CompletedShipmentDetail"]["CompletedPackageDetails"]["SignatureOption"]
     assert_equal FedEx::SIGNATURE_OPTION_CODES[:adult], signature_option
-  end
-
-  def test_maximum_address_field_length
-    assert_equal 35, @carrier.maximum_address_field_length
   end
 end

--- a/test/remote/kunaki_test.rb
+++ b/test/remote/kunaki_test.rb
@@ -33,8 +33,4 @@ class RemoteKunakiTest < Minitest::Test
       )
     end
   end
-
-  def test_maximum_address_field_length
-    assert_equal 255, @carrier.maximum_address_field_length
-  end
 end

--- a/test/remote/new_zealand_post_test.rb
+++ b/test/remote/new_zealand_post_test.rb
@@ -146,8 +146,4 @@ class RemoteNewZealandPostTest < Minitest::Test
     assert response.success?
     assert response.rates.size > 0
   end
-
-  def test_maximum_address_field_length
-    assert_equal 255, @carrier.maximum_address_field_length
-  end
 end

--- a/test/remote/shipwire_test.rb
+++ b/test/remote/shipwire_test.rb
@@ -81,8 +81,4 @@ class RemoteShipwireTest < Minitest::Test
     )
     refute shipwire.valid_credentials?
   end
-
-  def test_maximum_address_field_length
-    assert_equal 150, @carrier.maximum_address_field_length
-  end
 end

--- a/test/remote/stamps_test.rb
+++ b/test/remote/stamps_test.rb
@@ -393,8 +393,4 @@ class RemoteStampsTest < Minitest::Test
       )
     end
   end
-
-  def test_maximum_address_field_length
-    assert_equal 150, @carrier.maximum_address_field_length
-  end
 end

--- a/test/remote/ups_test.rb
+++ b/test/remote/ups_test.rb
@@ -319,14 +319,13 @@ class RemoteUPSTest < Minitest::Test
   end
 
   def test_void_beyond_time_limit
-    # this is a test tracking number from the ups docs that always returns time limit expired
-    begin
-      response = @carrier.void_shipment('1Z12345E8793628675')
-      assert false # voiding this number should raise an error
-    rescue ResponseError => e
-      assert_equal(e.message, "Void shipment failed with message: Failure: Time for voiding has expired.")
+    e = assert_raises(ResponseError) do
+      # this is a test tracking number from the ups docs that always returns time limit expired
+      @carrier.void_shipment('1Z12345E8793628675')
     end
+    assert_equal(e.message, "Void shipment failed with message: Failure: Time for voiding has expired.")
   end
+
 
   def test_maximum_address_field_length
     assert_equal 35, @carrier.maximum_address_field_length

--- a/test/unit/carriers/canada_post_pws_shipping_test.rb
+++ b/test/unit/carriers/canada_post_pws_shipping_test.rb
@@ -251,4 +251,8 @@ class CanadaPostPwsShippingTest < Minitest::Test
 
     assert_equal 0, response[:priced_options].size
   end
+
+  def test_maximum_address_field_length
+    assert_equal 44, @cp.maximum_address_field_length
+  end
 end

--- a/test/unit/carriers/canada_post_test.rb
+++ b/test/unit/carriers/canada_post_test.rb
@@ -141,4 +141,8 @@ class CanadaPostTest < Minitest::Test
 
     assert rate_response.rates.length > 0, "Expecting rateestimates even without a value specified."
   end
+
+  def test_maximum_address_field_length
+    assert_equal 44, @carrier.maximum_address_field_length
+  end
 end

--- a/test/unit/carriers/correios_test.rb
+++ b/test/unit/carriers/correios_test.rb
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 require "test_helper"
 
 class CorreiosTest < Minitest::Test
@@ -22,7 +23,7 @@ class CorreiosTest < Minitest::Test
   def test_book_request
     @carrier.expects(:perform).returns([@response_book_success])
     response = @carrier.find_rates(@saopaulo, @patosdeminas, [@book])
-    
+
     [
       "sCepOrigem=01415000",
       "sCepDestino=38700000",
@@ -40,7 +41,7 @@ class CorreiosTest < Minitest::Test
   def test_poster_request
     @carrier.expects(:perform).returns([@response_poster_success])
     response = @carrier.find_rates(@saopaulo, @patosdeminas, [@poster])
-    
+
     [
       "sCepOrigem=01415000",
       "sCepDestino=38700000",
@@ -58,7 +59,7 @@ class CorreiosTest < Minitest::Test
   def test_poster_and_book_request
     @carrier.expects(:perform).returns([@response_poster_success, @response_book_success])
     response = @carrier.find_rates(@saopaulo, @patosdeminas, [@poster, @book])
-    
+
     [
       "sCepOrigem=01415000",
       "sCepDestino=38700000",
@@ -71,7 +72,7 @@ class CorreiosTest < Minitest::Test
     ].each do |query_param|
       assert_match query_param, response.urls.first
     end
-    
+
     [
       "sCepOrigem=01415000",
       "sCepDestino=38700000",
@@ -89,7 +90,7 @@ class CorreiosTest < Minitest::Test
   def test_book_request_with_specific_services
     @carrier.expects(:perform).returns([@response_book_success])
     response = @carrier.find_rates(@saopaulo, @patosdeminas, [@book], :services => [41106, 40010, 40215])
-    
+
     [
       "nCdServico=41106%2C40010%2C40215",
       "sCepOrigem=01415000",
@@ -241,4 +242,7 @@ class CorreiosTest < Minitest::Test
     assert_equal '(Grupo 3) e-SEDEX, com contrato', services[81850]
   end
 
+  def test_maximum_address_field_length
+    assert_equal 255, @carrier.maximum_address_field_length
+  end
 end

--- a/test/unit/carriers/fedex_test.rb
+++ b/test/unit/carriers/fedex_test.rb
@@ -485,4 +485,8 @@ class FedExTest < Minitest::Test
                                          :test => true))
     assert_equal result.search('RequestedPackageLineItems/CustomerReferences/Value').text, "FOO-123"
   end
+
+  def test_maximum_address_field_length
+    assert_equal 35, @carrier.maximum_address_field_length
+  end
 end

--- a/test/unit/carriers/kunaki_test.rb
+++ b/test/unit/carriers/kunaki_test.rb
@@ -49,4 +49,8 @@ class KunakiTest < Minitest::Test
     assert_equal ["UPS 2nd Day Air", "UPS Ground", "UPS Next Day Air Saver", "USPS Priority Mail"], response.rates.collect(&:service_name).sort
     assert_equal [800, 1234, 2186, 3605], response.rates.collect(&:total_price).sort
   end
+
+  def test_maximum_address_field_length
+    assert_equal 255, @carrier.maximum_address_field_length
+  end
 end

--- a/test/unit/carriers/new_zealand_post_test.rb
+++ b/test/unit/carriers/new_zealand_post_test.rb
@@ -171,4 +171,8 @@ class NewZealandPostTest < Minitest::Test
     response_params = { "responses" => [] }
     assert_equal response_params, error.response.params
   end
+
+  def test_maximum_address_field_length
+    assert_equal 255, @carrier.maximum_address_field_length
+  end
 end

--- a/test/unit/carriers/shipwire_test.rb
+++ b/test/unit/carriers/shipwire_test.rb
@@ -184,4 +184,8 @@ class ShipwireTest < Minitest::Test
 
     assert response.success?
   end
+
+  def test_maximum_address_field_length
+    assert_equal 255, @carrier.maximum_address_field_length
+  end
 end

--- a/test/unit/carriers/stamps_test.rb
+++ b/test/unit/carriers/stamps_test.rb
@@ -238,4 +238,8 @@ class StampsTest < Minitest::Test
   def response_chain(primary_response)
     @carrier.expects(:ssl_post).twice.returns(@authentication_response, primary_response)
   end
+
+  def test_maximum_address_field_length
+    assert_equal 255, @carrier.maximum_address_field_length
+  end
 end

--- a/test/unit/carriers/ups_test.rb
+++ b/test/unit/carriers/ups_test.rb
@@ -513,4 +513,8 @@ class UPSTest < Minitest::Test
     response = @carrier.void_shipment('1Z12345E0390817264')
     assert response
   end
+
+  def test_maximum_address_field_length
+    assert_equal 35, @carrier.maximum_address_field_length
+  end
 end


### PR DESCRIPTION
This fixes up the tests being in the wrong place from #290 and a date from #279. Also cleans up a test from #283.

Then it bumps the version number to `v1.3.0` according to semver because of the new features in this release.

This PR is mostly fixing currently broken tests in a trivial way so I'm not going to wait for review.

cc @kmcphillips 