### PR TITLE
[FedEx] Fix ArgumentError on parse tracking response.

### DIFF
--- a/lib/active_shipping/carriers/fedex.rb
+++ b/lib/active_shipping/carriers/fedex.rb
@@ -575,7 +575,7 @@ module ActiveShipping
           when '9040'
             raise ActiveShipping::ShipmentNotFound, first_notification.at('Message').text
           else
-            raise ActiveShipping::ResponseContentError, first_notification.at('Message').text
+            raise ActiveShipping::ResponseContentError, StandardError.new(first_notification.at('Message').text)
           end
         end
 

--- a/lib/active_shipping/errors.rb
+++ b/lib/active_shipping/errors.rb
@@ -16,8 +16,8 @@ module ActiveShipping
   end
 
   class ResponseContentError < ActiveShipping::Error
-    def initialize(exception, content_body)
-      super("#{exception.message} \n\n#{content_body}")
+    def initialize(exception, content_body = nil)
+      super([exception.message, content_body].compact.join(" \n\n"))
     end
   end
 

--- a/test/fixtures/xml/fedex/tracking_response_invalid_tracking_number.xml
+++ b/test/fixtures/xml/fedex/tracking_response_invalid_tracking_number.xml
@@ -1,0 +1,52 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<TrackReply xmlns="http:igc/fedex.com/ws/track/v7" xmlns:SOAP-ENV="http://schemas.xmlsoap.org/soap/envelope/">
+  <HighestSeverity>SUCCESS</HighestSeverity>
+  <Notifications>
+    <Severity>SUCCESS</Severity>
+    <Source>trck</Source>
+    <Code>0</Code>
+    <Message>Request was successfully processed.</Message>
+    <LocalizedMessage>Request was successfully processed.</LocalizedMessage>
+  </Notifications>
+  <TransactionDetail>
+    <CustomerTransactionId>ActiveShipping</CustomerTransactionId>
+  </TransactionDetail>
+  <Version>
+    <ServiceId>trck</ServiceId>
+    <Major>7</Major>
+    <Intermediate>0</Intermediate>
+    <Minor>0</Minor>
+  </Version>
+  <CompletedTrackDetails>
+    <HighestSeverity>SUCCESS</HighestSeverity>
+    <Notifications>
+      <Severity>SUCCESS</Severity>
+      <Source>trck</Source>
+      <Code>0</Code>
+      <Message>Request was successfully processed.</Message>
+      <LocalizedMessage>Request was successfully processed.</LocalizedMessage>
+    </Notifications>
+    <DuplicateWaybill>false</DuplicateWaybill>
+    <MoreData>false</MoreData>
+    <TrackDetails>
+      <Notification>
+        <Severity>ERROR</Severity>
+        <Source>trck</Source>
+        <Code>6035</Code>
+        <Message>Invalid tracking numbers. Please check the following numbers and resubmit.</Message>
+        <LocalizedMessage>Invalid tracking numbers. Please check the following numbers and resubmit.</LocalizedMessage>
+      </Notification>
+      <TrackingNumber>123456789013</TrackingNumber>
+      <StatusDetail>
+        <Location>
+          <Residential>false</Residential>
+        </Location>
+      </StatusDetail>
+      <PackageSequenceNumber>0</PackageSequenceNumber>
+      <PackageCount>0</PackageCount>
+      <DeliveryAttempts>0</DeliveryAttempts>
+      <TotalUniqueAddressCountInConsolidation>0</TotalUniqueAddressCountInConsolidation>
+      <RedirectToHoldEligibility>INELIGIBLE</RedirectToHoldEligibility>
+    </TrackDetails>
+  </CompletedTrackDetails>
+</TrackReply>

--- a/test/unit/carriers/fedex_test.rb
+++ b/test/unit/carriers/fedex_test.rb
@@ -445,6 +445,18 @@ class FedExTest < Minitest::Test
     end
   end
 
+  def test_tracking_info_with_uncovered_error
+    mock_response = xml_fixture('fedex/tracking_response_invalid_tracking_number')
+    @carrier.expects(:commit).returns(mock_response)
+
+    error = assert_raises(ActiveShipping::ResponseContentError) do
+      @carrier.find_tracking_info('123456789013')
+    end
+
+    msg = 'Invalid tracking numbers. Please check the following numbers and resubmit.'
+    assert_equal msg, error.message
+  end
+
   def test_create_shipment
     confirm_response = xml_fixture('fedex/create_shipment_response')
     @carrier.stubs(:commit).returns(confirm_response)


### PR DESCRIPTION
This fixes an `ArgumentError` on `ResponseContentError` initialization when trying to parse tracking response from FedEx.

The existent code for FedEx's `parse_tracking_response` raising `ResponseContentError` error when tracking details notification is an `ERROR` with code different from `9040`. But it provides only one argument for initialization when two expected.

Backtrace:
```
ArgumentError: wrong number of arguments (1 for 2)
/active_shipping-1.3.0/lib/active_shipping/errors.rb:19:in `initialize'
/active_shipping-1.3.0/lib/active_shipping/carriers/fedex.rb:578:in `exception'
/active_shipping-1.3.0/lib/active_shipping/carriers/fedex.rb:578:in `raise'
/active_shipping-1.3.0/lib/active_shipping/carriers/fedex.rb:578:in `parse_tracking_response'
/active_shipping-1.3.0/lib/active_shipping/carriers/fedex.rb:161:in `find_tracking_info'
```

With this PR second argument for `ResponseContentError` initialization becomes optional and `parse_tracking_response` raises error with correct arguments.