### PR TITLE
Add rake console command with handy things

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,6 +116,10 @@ To log requests and responses, just set the `logger` on your carrier class to so
 
 (This logging functionality is provided by the [`PostsData` module](https://github.com/Shopify/active_utils/blob/master/lib/active_utils/posts_data.rb) in the `active_utils` dependency.)
 
+To debug API requests and your code you can run `rake console` to start a Pry session with `ActiveShipping` included
+and instances of the various carriers set up with your test credentials.
+Look at the file `test/console.rb` to see the other goodies it provides.
+
 After you've pushed your well-tested changes to your github fork, make a pull request and we'll take it from there! For more information, see CONTRIBUTING.md.
 
 ## Legal Mumbo Jumbo

--- a/Rakefile
+++ b/Rakefile
@@ -24,4 +24,9 @@ namespace :test do
   end
 end
 
+desc "Open a pry session preloaded with this library"
+task :console do
+  sh 'ruby -Ilib -Itest test/console.rb'
+end
+
 task :default => 'test'

--- a/active_shipping.gemspec
+++ b/active_shipping.gemspec
@@ -24,6 +24,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency('mocha', '~> 1')
   s.add_development_dependency('timecop')
   s.add_development_dependency('business_time')
+  s.add_development_dependency('pry')
 
   s.files        = `git ls-files`.split($/)
   s.executables  = s.files.grep(%r{^bin/}).map{ |f| File.basename(f) }

--- a/test/console.rb
+++ b/test/console.rb
@@ -1,0 +1,40 @@
+require 'pry'
+require 'active_shipping'
+require 'test_helper'
+
+include ActiveShipping
+include ActiveShipping::Test::Credentials
+include ActiveShipping::Test::Fixtures
+
+def create_carrier(klass, creds)
+  options = credentials(creds).merge(:test => true)
+  klass.new(options)
+rescue NoCredentialsFound
+  STDERR.puts "No credentials found for #{creds}"
+  nil
+end
+
+def px(xml_s)
+  puts Nokogiri.XML(xml_s)
+end
+
+def reload!
+  # Supress a billion constant redefinition warnings
+  warn_level = $VERBOSE
+  $VERBOSE = nil
+
+  files = $LOADED_FEATURES.select { |feat| feat =~ /\/active_shipping\// }
+  files.each { |file| load file }
+
+  $VERBOSE = warn_level
+  files
+end
+
+# Prebuilt objects for most common carriers
+@canpo    = create_carrier(CanadaPost,:canada_post)
+@fedex    = create_carrier(FedEx,:fedex)
+@shipwire = create_carrier(Shipwire,:shipwire)
+@ups      = create_carrier(UPS,:ups)
+@usps     = create_carrier(USPS,:usps)
+# Tips: call reload! to reload all the active_shipping files, use fixtures from test_helpers for parameters
+binding.pry


### PR DESCRIPTION
This adds a console for debugging ActiveShipping code and also more importantly the APIs of the carriers. 

In the past when I'm trying to figure out something about a carrier's API I have used an IRB session with a bunch of stuff loaded and had to copy-paste a bunch of things from tests and load a bajillion files.

This PR adds a `rake console` command based on pry that has a bunch of handy things pre-defined and included:
- ActiveShipping and testing fixtures and credentials modules included
- An equivalent to the `reload!` method from 'rails console` that reloads all of the active_shipping code
- A bunch of predefined carrier objects using the local test credentials from the remote tests
- A method for pretty-printing XML strings (unfortunately too commonly needed)

@kmcphillips @wvanbergen cc @RichardBlair because he could have used this in his weekend debugging session