### PR TITLE
Add names for UPS SurePost services

### DIFF
--- a/lib/active_shipping/carriers/ups.rb
+++ b/lib/active_shipping/carriers/ups.rb
@@ -65,8 +65,11 @@ module ActiveShipping
       "83" => "UPS Today Dedicated Courier",
       "84" => "UPS Today Intercity",
       "85" => "UPS Today Express",
-      "86" => "UPS Today Express Saver"
-
+      "86" => "UPS Today Express Saver",
+      "92" => "UPS SurePost (USPS) < 1lb",
+      "93" => "UPS SurePost (USPS) > 1lb",
+      "94" => "UPS SurePost (USPS) BPM",
+      "95" => "UPS SurePost (USPS) Media",
     }
 
     CANADA_ORIGIN_SERVICES = {


### PR DESCRIPTION
This should be all that is required to support USPS SurePost rate fetching on accounts that have a contract for it.

I can't test that this works without an account but I have some evidence from the interwebs:
- http://stackoverflow.com/questions/27231907/ups-surepost-api
- https://github.com/typefoo/node-shipping-ups/commit/08ecb7003867f3db915f267127cbfc2d80bd7a81
- https://github.com/pullingshots/Shipment/commit/5523534a6c43adef580fc78290d17af597ed49f4

@kmcphillips cc @louiskearns @shawnfrancis 