### PR TITLE
[FedEx] Raise an error on invalid status code in response.

### DIFF
--- a/lib/active_shipping/carriers/fedex.rb
+++ b/lib/active_shipping/carriers/fedex.rb
@@ -585,7 +585,11 @@ module ActiveShipping
           raise ActiveShipping::Error, "Tracking response does not contain status information"
         end
 
-        status_code = status_detail.at('Code').text
+        status_code = status_detail.at('Code').try(:text)
+        if status_code.nil?
+          raise ActiveShipping::Error, "Tracking response does not contain status code"
+        end
+
         status_description = (status_detail.at('AncillaryDetails/ReasonDescription') || status_detail.at('Description')).text
         status = TRACKING_STATUS_CODES[status_code]
 

--- a/test/fixtures/xml/fedex/tracking_response_empty_status_detail.xml
+++ b/test/fixtures/xml/fedex/tracking_response_empty_status_detail.xml
@@ -1,0 +1,84 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<TrackReply xmlns="http://fedex.com/ws/track/v7" xmlns:SOAP-ENV="http://schemas.xmlsoap.org/soap/envelope/">
+  <HighestSeverity>SUCCESS</HighestSeverity>
+  <Notifications>
+    <Severity>SUCCESS</Severity>
+    <Source>trck</Source>
+    <Code>0</Code>
+    <Message>Request was successfully processed.</Message>
+    <LocalizedMessage>Request was successfully processed.</LocalizedMessage>
+  </Notifications>
+  <TransactionDetail>
+    <CustomerTransactionId>ActiveShipping</CustomerTransactionId>
+  </TransactionDetail>
+  <Version>
+    <ServiceId>trck</ServiceId>
+    <Major>7</Major>
+    <Intermediate>0</Intermediate>
+    <Minor>0</Minor>
+  </Version>
+  <CompletedTrackDetails>
+    <HighestSeverity>SUCCESS</HighestSeverity>
+    <Notifications>
+      <Severity>SUCCESS</Severity>
+      <Source>trck</Source>
+      <Code>0</Code>
+      <Message>Request was successfully processed.</Message>
+      <LocalizedMessage>Request was successfully processed.</LocalizedMessage>
+    </Notifications>
+    <DuplicateWaybill>false</DuplicateWaybill>
+    <MoreData>false</MoreData>
+    <TrackDetails>
+      <Notification>
+        <Severity>SUCCESS</Severity>
+        <Source>trck</Source>
+        <Code>0</Code>
+        <Message>Request was successfully processed.</Message>
+        <LocalizedMessage>Request was successfully processed.</LocalizedMessage>
+      </Notification>
+      <TrackingNumber>123456789012</TrackingNumber>
+      <TrackingNumberUniqueIdentifier>123456789012~123456789012~FX</TrackingNumberUniqueIdentifier>
+      <CarrierCode>FDXE</CarrierCode>
+      <OperatingCompanyOrCarrierDescription>FedEx Express</OperatingCompanyOrCarrierDescription>
+      <Service>
+        <Type>STANDARD_OVERNIGHT</Type>
+        <Description>FedEx Standard Overnight</Description>
+      </Service>
+      <PackageSequenceNumber>0</PackageSequenceNumber>
+      <PackageCount>0</PackageCount>
+      <SpecialHandlings>
+        <Type>DELIVER_WEEKDAY</Type>
+        <Description>Deliver Weekday</Description>
+        <PaymentType>OTHER</PaymentType>
+      </SpecialHandlings>
+      <SpecialHandlings>
+        <Type>RESIDENTIAL_DELIVERY</Type>
+        <Description>Residential Delivery</Description>
+        <PaymentType>OTHER</PaymentType>
+      </SpecialHandlings>
+      <SpecialHandlings>
+        <Type>DIRECT_SIGNATURE_OPTION</Type>
+        <Description>Direct Signature Required</Description>
+        <PaymentType>OTHER</PaymentType>
+      </SpecialHandlings>
+      <ShipTimestamp>2014-05-30T12:19:00+00:00</ShipTimestamp>
+      <DestinationAddress>
+        <City>COLUMBIA</City>
+        <StateOrProvinceCode>SC</StateOrProvinceCode>
+        <CountryCode>US</CountryCode>
+        <CountryName>United States</CountryName>
+        <Residential>false</Residential>
+      </DestinationAddress>
+      <ActualDeliveryAddress>
+        <City>COLUMBIA</City>
+        <StateOrProvinceCode>SC</StateOrProvinceCode>
+        <CountryCode>US</CountryCode>
+        <CountryName>United States</CountryName>
+        <Residential>false</Residential>
+      </ActualDeliveryAddress>
+      <DeliveryAttempts>0</DeliveryAttempts>
+      <TotalUniqueAddressCountInConsolidation>0</TotalUniqueAddressCountInConsolidation>
+      <RedirectToHoldEligibility>INELIGIBLE</RedirectToHoldEligibility>
+    </TrackDetails>
+  </CompletedTrackDetails>
+</TrackReply>

--- a/test/fixtures/xml/fedex/tracking_response_invalid_status_code.xml
+++ b/test/fixtures/xml/fedex/tracking_response_invalid_status_code.xml
@@ -1,0 +1,89 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<TrackReply xmlns="http://fedex.com/ws/track/v7" xmlns:SOAP-ENV="http://schemas.xmlsoap.org/soap/envelope/">
+  <HighestSeverity>SUCCESS</HighestSeverity>
+  <Notifications>
+    <Severity>SUCCESS</Severity>
+    <Source>trck</Source>
+    <Code>0</Code>
+    <Message>Request was successfully processed.</Message>
+    <LocalizedMessage>Request was successfully processed.</LocalizedMessage>
+  </Notifications>
+  <TransactionDetail>
+    <CustomerTransactionId>ActiveShipping</CustomerTransactionId>
+  </TransactionDetail>
+  <Version>
+    <ServiceId>trck</ServiceId>
+    <Major>7</Major>
+    <Intermediate>0</Intermediate>
+    <Minor>0</Minor>
+  </Version>
+  <CompletedTrackDetails>
+    <HighestSeverity>SUCCESS</HighestSeverity>
+    <Notifications>
+      <Severity>SUCCESS</Severity>
+      <Source>trck</Source>
+      <Code>0</Code>
+      <Message>Request was successfully processed.</Message>
+      <LocalizedMessage>Request was successfully processed.</LocalizedMessage>
+    </Notifications>
+    <DuplicateWaybill>false</DuplicateWaybill>
+    <MoreData>false</MoreData>
+    <TrackDetails>
+      <Notification>
+        <Severity>SUCCESS</Severity>
+        <Source>trck</Source>
+        <Code>0</Code>
+        <Message>Request was successfully processed.</Message>
+        <LocalizedMessage>Request was successfully processed.</LocalizedMessage>
+      </Notification>
+      <TrackingNumber>123456789012</TrackingNumber>
+      <TrackingNumberUniqueIdentifier>123456789012~123456789012~FX</TrackingNumberUniqueIdentifier>
+      <StatusDetail>
+        <Location>
+          <Residential>false</Residential>
+        </Location>
+      </StatusDetail>
+      <CarrierCode>FDXE</CarrierCode>
+      <OperatingCompanyOrCarrierDescription>FedEx Express</OperatingCompanyOrCarrierDescription>
+      <Service>
+        <Type>STANDARD_OVERNIGHT</Type>
+        <Description>FedEx Standard Overnight</Description>
+      </Service>
+      <PackageSequenceNumber>0</PackageSequenceNumber>
+      <PackageCount>0</PackageCount>
+      <SpecialHandlings>
+        <Type>DELIVER_WEEKDAY</Type>
+        <Description>Deliver Weekday</Description>
+        <PaymentType>OTHER</PaymentType>
+      </SpecialHandlings>
+      <SpecialHandlings>
+        <Type>RESIDENTIAL_DELIVERY</Type>
+        <Description>Residential Delivery</Description>
+        <PaymentType>OTHER</PaymentType>
+      </SpecialHandlings>
+      <SpecialHandlings>
+        <Type>DIRECT_SIGNATURE_OPTION</Type>
+        <Description>Direct Signature Required</Description>
+        <PaymentType>OTHER</PaymentType>
+      </SpecialHandlings>
+      <ShipTimestamp>2014-05-30T12:19:00+00:00</ShipTimestamp>
+      <DestinationAddress>
+        <City>COLUMBIA</City>
+        <StateOrProvinceCode>SC</StateOrProvinceCode>
+        <CountryCode>US</CountryCode>
+        <CountryName>United States</CountryName>
+        <Residential>false</Residential>
+      </DestinationAddress>
+      <ActualDeliveryAddress>
+        <City>COLUMBIA</City>
+        <StateOrProvinceCode>SC</StateOrProvinceCode>
+        <CountryCode>US</CountryCode>
+        <CountryName>United States</CountryName>
+        <Residential>false</Residential>
+      </ActualDeliveryAddress>
+      <DeliveryAttempts>0</DeliveryAttempts>
+      <TotalUniqueAddressCountInConsolidation>0</TotalUniqueAddressCountInConsolidation>
+      <RedirectToHoldEligibility>INELIGIBLE</RedirectToHoldEligibility>
+    </TrackDetails>
+  </CompletedTrackDetails>
+</TrackReply>

--- a/test/unit/carriers/fedex_test.rb
+++ b/test/unit/carriers/fedex_test.rb
@@ -457,6 +457,30 @@ class FedExTest < Minitest::Test
     assert_equal msg, error.message
   end
 
+  def test_tracking_info_with_empty_status_detail
+    mock_response = xml_fixture('fedex/tracking_response_empty_status_detail')
+    @carrier.expects(:commit).returns(mock_response)
+
+    error = assert_raises(ActiveShipping::Error) do
+      @carrier.find_tracking_info('123456789012')
+    end
+
+    msg = 'Tracking response does not contain status information'
+    assert_equal msg, error.message
+  end
+
+  def test_tracking_info_with_invalid_status_code
+    mock_response = xml_fixture('fedex/tracking_response_invalid_status_code')
+    @carrier.expects(:commit).returns(mock_response)
+
+    error = assert_raises(ActiveShipping::Error) do
+      @carrier.find_tracking_info('123456789012')
+    end
+
+    msg = 'Tracking response does not contain status code'
+    assert_equal msg, error.message
+  end
+
   def test_create_shipment
     confirm_response = xml_fixture('fedex/create_shipment_response')
     @carrier.stubs(:commit).returns(confirm_response)


### PR DESCRIPTION
It allows to rescue situations where status detail has no code when trying to parse tracking info from FedEx.

Backtrace:
```
NoMethodError: undefined method `text' for nil:NilClass
/active_shipping-1.4.0/lib/active_shipping/carriers/fedex.rb:588 in parse_tracking_response
/active_shipping-1.4.0/lib/active_shipping/carriers/fedex.rb:161 in find_tracking_info
```