### PR TITLE
Fix bug with batch tracking errors

### DIFF
--- a/lib/active_shipping/carriers/usps.rb
+++ b/lib/active_shipping/carriers/usps.rb
@@ -639,7 +639,7 @@ module ActiveShipping
     end
 
     def error_description_node(node)
-      node.xpath('//Error/Description')
+      node.xpath('Error/Description')
     end
 
     def response_status_node(node)

--- a/test/fixtures/xml/usps/tracking_response_batch.xml
+++ b/test/fixtures/xml/usps/tracking_response_batch.xml
@@ -220,4 +220,12 @@
       <HelpContext/>
     </Error>
   </TrackInfo>
+  <TrackInfo ID="CJ422417033US">
+    <Error>
+      <Number>-2147219303</Number>
+      <Description>Duplicate</Description>
+      <HelpFile/>
+      <HelpContext/>
+    </Error>
+  </TrackInfo>
 </TrackResponse>

--- a/test/unit/carriers/usps_test.rb
+++ b/test/unit/carriers/usps_test.rb
@@ -173,7 +173,7 @@ class USPSTest < Minitest::Test
   def test_batch_find_tracking_info_should_return_a_tracking_response_array
     @carrier.expects(:commit).returns(@batch_tracking_response)
     responses = @carrier.batch_find_tracking_info(@tracking_infos_array, :test => true)
-    assert_equal 3, responses.length
+    assert_equal 4, responses.length
     assert responses.all? { |x| x.instance_of? ActiveShipping::TrackingResponse}
   end
 


### PR DESCRIPTION
An XPath that was designed without the idea of batched responses was giving back all the errors in a batch tracking request concatenated together instead of a specific error. This fixes the XPath and tests it.

@kmcphillips @garethson 