### PR TITLE
Fix bugs in USPS tracking

### DIFF
--- a/lib/active_shipping/carriers/usps.rb
+++ b/lib/active_shipping/carriers/usps.rb
@@ -243,7 +243,14 @@ module ActiveShipping
         description = prefix
       end
 
-      timestamp = "#{node.at('EventDate').text}, #{node.at('EventTime').text}"
+      if node.at('EventDate').text.present?
+        timestamp = "#{node.at('EventDate').text}, #{node.at('EventTime').text}"
+        time = Time.parse(timestamp)
+      else
+        # Arbitrary time in past, because we need to sort and this is just dumb
+        time = Time.parse("Jan 01, 2000")
+      end
+
       event_code = node.at('EventCode').text
       city = node.at('EventCity').try(:text)
       state = node.at('EventState').try(:text)
@@ -255,7 +262,6 @@ module ActiveShipping
       # USPS returns upcased country names which ActiveUtils doesn't recognize without translation
       country = find_country_code_case_insensitive(country)
 
-      time = Time.parse(timestamp)
       zoneless_time = Time.utc(time.year, time.month, time.mday, time.hour, time.min, time.sec)
       location = Location.new(city: city, state: state, postal_code: zip_code, country: country)
       EventDetails.new(description, time, zoneless_time, location, event_code)

--- a/lib/active_shipping/carriers/usps.rb
+++ b/lib/active_shipping/carriers/usps.rb
@@ -156,7 +156,9 @@ module ActiveShipping
 
     TRACKING_ODD_COUNTRY_NAMES = {
       'TAIWAN' => 'TW',
-      'KOREA  REPUBLIC OF'=> 'KR'
+      'MACEDONIA THE FORMER YUGOSLAV REPUBLIC OF'=> 'MK',
+      'MICRONESIA FEDERATED STATES OF' => 'FM',
+      'MOLDOVA REPUBLIC OF' => 'MD',
     }
 
     RESPONSE_ERROR_MESSAGES = [
@@ -243,12 +245,12 @@ module ActiveShipping
         description = prefix
       end
 
-      if node.at('EventDate').text.present?
+      time = if node.at('EventDate').text.present?
         timestamp = "#{node.at('EventDate').text}, #{node.at('EventTime').text}"
-        time = Time.parse(timestamp)
+        Time.parse(timestamp)
       else
-        # Arbitrary time in past, because we need to sort and this is just dumb
-        time = Time.parse("Jan 01, 2000")
+        # Arbitrary time in past, because we need to sort properly by time
+        Time.parse("Jan 01, 2000")
       end
 
       event_code = node.at('EventCode').text
@@ -666,7 +668,7 @@ module ActiveShipping
     end
 
     def find_country_code_case_insensitive(name)
-      upcase_name = name.upcase
+      upcase_name = name.upcase.gsub('  ', ', ')
       if special = TRACKING_ODD_COUNTRY_NAMES[upcase_name]
         return special
       end

--- a/lib/active_shipping/carriers/usps.rb
+++ b/lib/active_shipping/carriers/usps.rb
@@ -156,6 +156,7 @@ module ActiveShipping
 
     TRACKING_ODD_COUNTRY_NAMES = {
       'TAIWAN' => 'TW',
+      'KOREA  REPUBLIC OF'=> 'KR'
     }
 
     RESPONSE_ERROR_MESSAGES = [

--- a/lib/active_shipping/carriers/usps.rb
+++ b/lib/active_shipping/carriers/usps.rb
@@ -154,6 +154,10 @@ module ActiveShipping
       "WS" => "Western Samoa"
     }
 
+    TRACKING_ODD_COUNTRY_NAMES = {
+      'TAIWAN' => 'TW',
+    }
+
     RESPONSE_ERROR_MESSAGES = [
       /There is no record of that mail item/,
       /This Information has not been included in this Test Server\./,
@@ -656,6 +660,9 @@ module ActiveShipping
 
     def find_country_code_case_insensitive(name)
       upcase_name = name.upcase
+      if special = TRACKING_ODD_COUNTRY_NAMES[upcase_name]
+        return special
+      end
       country = ActiveUtils::Country::COUNTRIES.detect { |c| c[:name].upcase == upcase_name }
       raise ActiveShipping::Error, "No country found for #{name}" unless country
       country[:alpha2]

--- a/test/fixtures/xml/usps/tracking_response_alt.xml
+++ b/test/fixtures/xml/usps/tracking_response_alt.xml
@@ -37,5 +37,17 @@
       <AuthorizedAgent>false</AuthorizedAgent>
       <EventCode>OF</EventCode>
     </TrackSummary>
+    <TrackDetail>
+      <EventTime/><EventDate/>
+      <Event>Origin Post is Preparing Shipment</Event>
+      <EventCity/>
+      <EventState/>
+      <EventZIPCode/>
+      <EventCountry/>
+      <FirmName/>
+      <Name/>
+      <AuthorizedAgent>false</AuthorizedAgent>
+      <EventCode>NP</EventCode>
+    </TrackDetail>
   </TrackInfo>
 </TrackResponse>

--- a/test/unit/carriers/usps_test.rb
+++ b/test/unit/carriers/usps_test.rb
@@ -146,6 +146,11 @@ class USPSTest < Minitest::Test
     @carrier.expects(:commit).returns(special_country)
     response = @carrier.find_tracking_info('9102901000462189604217', :test => true)
     assert_equal 'Taiwan, Province of China', response.shipment_events.last.location.country.name
+
+    special_country  = xml_fixture('usps/tracking_response_alt').gsub('CANADA','KOREA  REPUBLIC OF')
+    @carrier.expects(:commit).returns(special_country)
+    response = @carrier.find_tracking_info('9102901000462189604217', :test => true)
+    assert_equal 'Korea, Republic of', response.shipment_events.last.location.country.name
   end
 
   def test_find_tracking_info_destination

--- a/test/unit/carriers/usps_test.rb
+++ b/test/unit/carriers/usps_test.rb
@@ -139,6 +139,9 @@ class USPSTest < Minitest::Test
     assert_nil response.scheduled_delivery_date
     assert_nil response.shipment_events.last.location.city
 
+    assert_equal 'NP', response.shipment_events.first.type_code
+    assert_equal Time.parse('Jan 01, 2000'), response.shipment_events.first.time
+
     special_country  = xml_fixture('usps/tracking_response_alt').gsub('CANADA','TAIWAN')
     @carrier.expects(:commit).returns(special_country)
     response = @carrier.find_tracking_info('9102901000462189604217', :test => true)

--- a/test/unit/carriers/usps_test.rb
+++ b/test/unit/carriers/usps_test.rb
@@ -138,6 +138,11 @@ class USPSTest < Minitest::Test
     assert_equal :out_for_delivery, response.status
     assert_nil response.scheduled_delivery_date
     assert_nil response.shipment_events.last.location.city
+
+    special_country  = xml_fixture('usps/tracking_response_alt').gsub('CANADA','TAIWAN')
+    @carrier.expects(:commit).returns(special_country)
+    response = @carrier.find_tracking_info('9102901000462189604217', :test => true)
+    assert_equal 'Taiwan, Province of China', response.shipment_events.last.location.country.name
   end
 
   def test_find_tracking_info_destination


### PR DESCRIPTION
While running batch processing on tracking numbers I discovered a few bugs in active_shipping USPS tracking. This PR fixes two of them:
- Some country names aren't the same as they are in ActiveUtils and have to be mapped separately. I only found 2 out of the 6000 numbers I tested but I have emailed someone at USPS asking if they have a full list.
- One type of event ("Origin Post is Preparing Shipment") doesn't have a time, even though it really should. This currently causes an exception. I handled this by returning an arbitrary date in the past (Jan 1, 2000).

I'm definitely open to discussion on how I handled the lack of date. I imagine lots of code would assume that all events have a time, which is true for everything except this rare event type, which is why I still return a time rather than nil. I chose an arbitrary past date rather than the current date so that the sort by time would do the right thing and put this event in the past.

@kmcphillips @garethson 