### PR TITLE
Fix USPS international prices for Commercial Base and Commercial Plus.

### DIFF
--- a/lib/active_shipping/carriers/usps.rb
+++ b/lib/active_shipping/carriers/usps.rb
@@ -423,10 +423,10 @@ module ActiveShipping
               xml.Length("%0.2f" % [package.inches(:length), 0.01].max)
               xml.Height("%0.2f" % [package.inches(:height), 0.01].max)
               xml.Girth("%0.2f" % [package.inches(:girth), 0.01].max)
+              xml.OriginZip(origin.zip)
               if commercial_type = commercial_type(options)
                 xml.public_send(COMMERCIAL_FLAG_NAME.fetch(commercial_type), 'Y')
               end
-              xml.OriginZip(origin.zip)
               if destination.zip.present?
                 xml.AcceptanceDateTime((options[:acceptance_time] || Time.now.utc).iso8601)
                 xml.DestinationPostalCode(destination.zip)


### PR DESCRIPTION
The `OriginZip` xml element (added for the May 31, 2015 USPS Web Tools API update) was out of order in comparison to the Commercial flags, causing the request to fail. This change simply corrects the parameter order to match the USPS API docs.

https://www.usps.com/business/web-tools-apis/rate-calculator-api.htm

Fixes #303