### PR TITLE
Use new USPS staging server, and don't use it

### DIFF
--- a/lib/active_shipping/carriers/usps.rb
+++ b/lib/active_shipping/carriers/usps.rb
@@ -22,10 +22,8 @@ module ActiveShipping
 
     TEST_DOMAINS = { # indexed by security; e.g. TEST_DOMAINS[USE_SSL[:rates]]
       true => 'secure.shippingapis.com',
-      false => 'testing.shippingapis.com'
+      false => 'stg-production.shippingapis.com'
     }
-
-    TEST_RESOURCE = 'ShippingAPITest.dll'
 
     API_CODES = {
       :us_rates => 'RateV4',
@@ -684,8 +682,7 @@ module ActiveShipping
     def request_url(action, request, test)
       scheme = USE_SSL[action] ? 'https://' : 'http://'
       host = test ? TEST_DOMAINS[USE_SSL[action]] : LIVE_DOMAIN
-      resource = test ? TEST_RESOURCE : LIVE_RESOURCE
-      "#{scheme}#{host}/#{resource}?API=#{API_CODES[action]}&XML=#{URI.encode(request)}"
+      "#{scheme}#{host}/#{LIVE_RESOURCE}?API=#{API_CODES[action]}&XML=#{URI.encode(request)}"
     end
 
     def strip_zip(zip)

--- a/test/remote/usps_test.rb
+++ b/test/remote/usps_test.rb
@@ -12,7 +12,7 @@ class RemoteUSPSTest < Minitest::Test
   end
 
   def test_tracking
-    response = @carrier.find_tracking_info('LN284529912US', :test => true)
+    response = @carrier.find_tracking_info('LN284529912US', test: false)
     assert response.success?, response.message
     assert_equal 9,response.shipment_events.size
     assert_equal 'DELIVERED', response.shipment_events.last.message
@@ -21,7 +21,7 @@ class RemoteUSPSTest < Minitest::Test
 
   def test_tracking_with_bad_number
     assert_raises(ResponseError) do
-      @carrier.find_tracking_info('abc123xyz')
+      @carrier.find_tracking_info('abc123xyz', test: false)
     end
   end
 


### PR DESCRIPTION
USPS changed their testing server, at least for insecure tracking (not sure about the others).

This fixes the error `API Disabled: TrackV2.  This test request is no longer valid. Please use http://stg-production.shippingapis.com/ShippingAPI.dll` when running tests.

The thing is the new test server can't find any of the production tracking numbers that we use for testing and I can't find any tracking numbers that work on the server. So we now use the production server for the remote tracking tests, which since it is just tracking shouldn't be a big deal.

@kmcphillips