### PR TITLE
Re-authenticate with stamps api on two additional faults

### DIFF
--- a/lib/active_shipping/carriers/stamps.rb
+++ b/lib/active_shipping/carriers/stamps.rb
@@ -492,7 +492,7 @@ module ActiveShipping
       end
 
       # Renew the Authenticator if it has expired and retry the request
-      if error_code && error_code.downcase == '002b0202'
+      if error_code && ['002b0202', '002b0203', '002b0204'].include?(error_code.downcase)
         request = renew_authenticator(last_request)
         commit(last_swsim_method, request)
       else


### PR DESCRIPTION
According to the Stamps API documentation re-authenticating is also a potential fix for "Conversation Out-Of-Sync" and "Invalid Conversation Token" faults
