### PR TITLE
add phone required to rate estimate

### DIFF
--- a/lib/active_shipping/rate_estimate.rb
+++ b/lib/active_shipping/rate_estimate.rb
@@ -55,6 +55,10 @@ module ActiveShipping
   #   The comparable price in cents
   #   @return [Integer]
   #
+  # @!attribute phone_required
+  #   Specifies if a phone number is required for the shipping rate.
+  #   @return [Boolean]
+  #
   # @!attribute insurance_price
   #   The price of insurance in cents.
   #   @return [Integer]
@@ -64,7 +68,7 @@ module ActiveShipping
                 :shipping_date, :delivery_date, :delivery_range,
                 :currency, :negotiated_rate, :insurance_price,
                 :estimate_reference, :expires_at, :pickup_time,
-                :compare_price
+                :compare_price, :phone_required
 
     def initialize(origin, destination, carrier, service_name, options = {})
       @origin, @destination, @carrier, @service_name = origin, destination, carrier, service_name
@@ -80,6 +84,7 @@ module ActiveShipping
       @total_price = Package.cents_from(options[:total_price])
       @negotiated_rate = options[:negotiated_rate] ? Package.cents_from(options[:negotiated_rate]) : nil
       @compare_price = options[:compare_price] ? Package.cents_from(options[:compare_price]) : nil
+      @phone_required = !!options[:phone_required]
       @currency = ActiveUtils::CurrencyCode.standardize(options[:currency])
       @delivery_range = options[:delivery_range] ? options[:delivery_range].map { |date| date_for(date) }.compact : []
       @shipping_date = date_for(options[:shipping_date])

--- a/test/unit/rate_estimate_test.rb
+++ b/test/unit/rate_estimate_test.rb
@@ -15,6 +15,17 @@ class RateEstimateTest < Minitest::Test
     assert_nil @rate_estimate.send(:date_for, nil)
   end
 
+  def test_phone_required
+    est = RateEstimate.new(@origin, @destination, @carrier, @service_name, @options.merge(phone_required: true))
+    assert_equal true, est.phone_required
+
+    est = RateEstimate.new(@origin, @destination, @carrier, @service_name, @options.merge(phone_required: nil))
+    assert_equal false, est.phone_required
+
+    est = RateEstimate.new(@origin, @destination, @carrier, @service_name, @options.merge(phone_required: false))
+    assert_equal false, est.phone_required
+  end
+
   def test_date_for_invalid_string_in_ruby_19
     assert_nil @rate_estimate.send(:date_for, "Up to 2 weeks") if RUBY_VERSION.include?('1.9')
   end


### PR DESCRIPTION
### Problem

Some shipping rates require a phone number.

### Solution

Add phone required to the shipping estimate.

Review: @kmcphillips @mdking 
cc: @jnormore 