### PR TITLE
Bump active_utils to v3.1.0

### DIFF
--- a/active_shipping.gemspec
+++ b/active_shipping.gemspec
@@ -16,7 +16,7 @@ Gem::Specification.new do |s|
 
   s.add_dependency('quantified',    '~> 1.0.1')
   s.add_dependency('activesupport', '>= 3.2', '< 5.0.0')
-  s.add_dependency('active_utils',  '~> 3.0.0')
+  s.add_dependency('active_utils',  '~> 3.1.0')
   s.add_dependency('nokogiri',      '>= 1.6')
 
   s.add_development_dependency('minitest')


### PR DESCRIPTION
Bump active_utils dependency to v3.1.0

Diff for active_utils https://github.com/Shopify/active_utils/compare/v3.0.0...v3.1.0

Review @kmcphillips @RichardBlair 