### PR TITLE
Skip remote Correios test, service unavailable for the informed route.

### DIFF
--- a/test/remote/correios_test.rb
+++ b/test/remote/correios_test.rb
@@ -41,6 +41,7 @@ class RemoteCorreiosTest < Minitest::Test
   end
 
   def test_book_request_with_specific_services
+    skip("Service unavailable for the informed route")
     response = @carrier.find_rates(@saopaulo, @riodejaneiro, [@book], :services => [41106, 40010, 40215])
 
     assert response.is_a?(RateResponse)


### PR DESCRIPTION
A Correios remote test is failing because the service is unavailable for the informed route. Skip it for now.

@kmcphillips @RichardBlair 