### PR TITLE
Bump active_utils to 3.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # ActiveShipping CHANGELOG
 
+### v1.6.0
+- Update active_utils dependency to v3.2.0
+
 ### v1.5.0
 - Fix Kunaki remote test
 - Fix credentials for Canada Post PWS remote tests

--- a/active_shipping.gemspec
+++ b/active_shipping.gemspec
@@ -16,7 +16,7 @@ Gem::Specification.new do |s|
 
   s.add_dependency('quantified',    '~> 1.0.1')
   s.add_dependency('activesupport', '>= 3.2', '< 5.0.0')
-  s.add_dependency('active_utils',  '~> 3.1.0')
+  s.add_dependency('active_utils',  '~> 3.2.0')
   s.add_dependency('nokogiri',      '>= 1.6')
 
   s.add_development_dependency('minitest')


### PR DESCRIPTION
Differences from 3.1.0 to 3.2.0: https://github.com/Shopify/active_utils/compare/v3.1.0...v3.2.0

@RichardBlair @garethson @mdking 