### PR TITLE
Allow a failed response not to raise

### DIFF
--- a/lib/active_shipping/response.rb
+++ b/lib/active_shipping/response.rb
@@ -18,12 +18,13 @@ module ActiveShipping #:nodoc:
     #   of a request executed against the sandbox or test environment of the carrier's API.
     # @option options [String] :xml The raw XML of the response.
     # @option options [String] :request The payload of the request.
+    # @option options [Boolean] :allow_failure Allows a failed response without raising.
     def initialize(success, message, params = {}, options = {})
       @success, @message, @params = success, message, params.stringify_keys
       @test = options[:test] || false
       @xml = options[:xml]
       @request = options[:request]
-      raise ResponseError.new(self) unless success
+      raise ResponseError.new(self) unless success || options[:allow_failure]
     end
 
     # Whether the request was executed successfully or not.

--- a/test/unit/response_test.rb
+++ b/test/unit/response_test.rb
@@ -11,4 +11,9 @@ class ResponseTest < Minitest::Test
       RateResponse.new(false, "fail!", {:rate => 'Free!'}, :rates => [stub(:service_name => 'Free!', :total_price => 0)], :xml => "<rate>Free!</rate>")
     end
   end
+
+  def test_initialize_failure_no_raise
+    response = RateResponse.new(false, "fail!", {:rate => 'Free!'}, :rates => [stub(:service_name => 'Free!', :total_price => 0)], :xml => "<rate>Free!</rate>", :allow_failure => true)
+    refute response.success?
+  end
 end


### PR DESCRIPTION
### Summary
Having this class raise on initialize if `success` is `false` is a huge pain. Allow an option to safely change the behaviour for users who do not want the raise behaviour while still supporting the existing behaviour.

Review @RichardBlair @lucasuyezu @jonathankwok 