### PR TITLE
Include event type codes for FedEx tracking events

### DIFF
--- a/lib/active_shipping/carriers/fedex.rb
+++ b/lib/active_shipping/carriers/fedex.rb
@@ -621,11 +621,12 @@ module ActiveShipping
 
           location = Location.new(:city => city, :state => state, :postal_code => zip_code, :country => country)
           description = event.at('EventDescription').text
+          type_code = event.at('EventType').text
 
           time          = Time.parse(event.at('Timestamp').text)
           zoneless_time = time.utc
 
-          shipment_events << ShipmentEvent.new(description, zoneless_time, location)
+          shipment_events << ShipmentEvent.new(description, zoneless_time, location, description, type_code)
         end
         shipment_events = shipment_events.sort_by(&:time)
 

--- a/test/remote/canada_post_pws_test.rb
+++ b/test/remote/canada_post_pws_test.rb
@@ -121,7 +121,7 @@ class RemoteCanadaPostPWSTest < Minitest::Test
   end
 
   def test_create_shipment
-    #skip "Failing with 'Contract Number is a required field' after API change, skipping because no clue how to fix, might need different creds"
+    skip "Failing with 'Contract Number is a required field' after API change, skipping because no clue how to fix, might need different creds"
     opts = {:customer_number => @customer_number, :service => "DOM.XP"}
     response = @cp.create_shipment(@home_params, @dom_params, @pkg1, @line_item1, opts)
     assert_kind_of CPPWSShippingResponse, response
@@ -132,7 +132,7 @@ class RemoteCanadaPostPWSTest < Minitest::Test
   end
 
   def test_create_shipment_with_options
-    #skip "Failing with 'Contract Number is a required field' after API change, skipping because no clue how to fix, might need different creds"
+    skip "Failing with 'Contract Number is a required field' after API change, skipping because no clue how to fix, might need different creds"
     opts = {:customer_number => @customer_number, :service => "USA.EP"}.merge(@shipping_opts1)
     response = @cp.create_shipment(@home_params, @dest_params, @pkg1, @line_item1, opts)
 
@@ -144,7 +144,7 @@ class RemoteCanadaPostPWSTest < Minitest::Test
   end
 
   def test_retrieve_shipping_label
-    #skip "Failing with 'Contract Number is a required field' after API change, skipping because no clue how to fix, might need different creds"
+    skip "Failing with 'Contract Number is a required field' after API change, skipping because no clue how to fix, might need different creds"
     opts = {:customer_number => @customer_number, :service => "DOM.XP"}
     shipping_response = @cp.create_shipment(@home_params, @dom_params, @pkg1, @line_item1, opts)
 
@@ -160,7 +160,7 @@ class RemoteCanadaPostPWSTest < Minitest::Test
   end
 
   def test_create_shipment_with_invalid_customer_raises_exception
-    #skip "Failing with 'Contract Number is a required field' after API change, skipping because no clue how to fix, might need different creds"
+    skip "Failing with 'Contract Number is a required field' after API change, skipping because no clue how to fix, might need different creds"
     opts = {:customer_number => "0000000000", :service => "DOM.XP"}
     assert_raises(ResponseError) do
       @cp.create_shipment(@home_params, @dom_params, @pkg1, @line_item1, opts)

--- a/test/remote/fedex_test.rb
+++ b/test/remote/fedex_test.rb
@@ -242,6 +242,9 @@ class RemoteFedExTest < Minitest::Test
     )
     assert_equal destination_address.to_hash, response.destination.to_hash
     assert_equal 11, response.shipment_events.length
+    assert_equal 'OC', response.shipment_events.first.type_code
+    assert_equal 'PU', response.shipment_events.second.type_code
+    assert_equal 'AR', response.shipment_events.third.type_code
   end
 
   def test_find_tracking_info_for_in_transit_shipment_1
@@ -254,6 +257,9 @@ class RemoteFedExTest < Minitest::Test
     assert_equal 'FD', response.status_code
     assert_equal "At FedEx destination facility", response.status_description
     assert_equal 7, response.shipment_events.length
+    assert_equal 'PU', response.shipment_events.first.type_code
+    assert_equal 'OC', response.shipment_events.second.type_code
+    assert_equal 'AR', response.shipment_events.third.type_code
     assert_nil response.actual_delivery_date
     assert_equal nil, response.scheduled_delivery_date
   end
@@ -286,6 +292,9 @@ class RemoteFedExTest < Minitest::Test
     )
     assert_equal destination_address.to_hash, response.destination.to_hash
     assert_equal 3, response.shipment_events.length
+    assert_equal 'PU', response.shipment_events.first.type_code
+    assert_equal 'OC', response.shipment_events.second.type_code
+    assert_equal 'AR', response.shipment_events.third.type_code
   end
 
   def test_find_tracking_info_with_multiple_matches

--- a/test/unit/carriers/fedex_test.rb
+++ b/test/unit/carriers/fedex_test.rb
@@ -316,6 +316,9 @@ class FedExTest < Minitest::Test
 
     assert_equal 11, response.shipment_events.length
     assert_equal 'Delivered', response.latest_event.name
+    assert_equal 'PU', response.shipment_events.first.type_code
+    assert_equal 'OC', response.shipment_events.second.type_code
+    assert_equal 'AR', response.shipment_events.third.type_code
   end
 
   def test_tracking_info_for_delivered_at_door
@@ -327,7 +330,11 @@ class FedExTest < Minitest::Test
     assert response.delivered?
     refute response.exception?
     assert_equal 10, response.shipment_events.length
+    assert_equal 'PU', response.shipment_events.first.type_code
+    assert_equal 'OC', response.shipment_events.second.type_code
+    assert_equal 'AR', response.shipment_events.third.type_code
     assert_equal 'Delivered', response.latest_event.name
+    assert_equal 'DL', response.latest_event.type_code
     assert_equal nil, response.delivery_signature
   end
 
@@ -377,6 +384,7 @@ class FedExTest < Minitest::Test
 
     assert_equal 1, response.shipment_events.length
     assert_equal 'In transit', response.latest_event.name
+    assert_equal 'IT', response.latest_event.type_code
   end
 
   def test_tracking_info_for_shipment_exception
@@ -410,6 +418,7 @@ class FedExTest < Minitest::Test
 
     assert_equal 8, response.shipment_events.length
     assert_equal "Shipment exception", response.latest_event.name
+    assert_equal "SE", response.latest_event.type_code
   end
 
   def test_tracking_info_without_status


### PR DESCRIPTION
### Problem
`ShipmentEvents` for FedEx weren't initialized with their `<EventType>`s. This results in no status code being associated with a `ShipmentEvent`.

### Solution
Save the `<EventType>` , much like we do with [USPS `ShipmentEvents`.](https://github.com/Shopify/active_shipping/blob/master/lib/active_shipping/carriers/usps.rb#L254)

Review: @mdking @lucasuyezu @cyprusad 