### PR TITLE
Ability to create a UPS return label

### DIFF
--- a/test/remote/ups_test.rb
+++ b/test/remote/ups_test.rb
@@ -359,4 +359,43 @@ class RemoteUPSTest < Minitest::Test
   def test_maximum_address_field_length
     assert_equal 35, @carrier.maximum_address_field_length
   end
+
+  def test_obtain_return_label
+    response = @carrier.create_shipment(
+      location_fixtures[:beverly_hills_with_name],
+      location_fixtures[:real_google_as_commercial],
+      #package descriptions are required for returns
+      package_fixtures.values_at(:books),
+      {
+        :shipper => location_fixtures[:new_york],
+        :return_service_code => '9',
+        :test => true
+      }
+    )
+
+    assert response.success?
+
+    assert_instance_of ActiveShipping::LabelResponse, response
+  end
+
+  def test_obtain_international_return_label
+    response = @carrier.create_shipment(
+      location_fixtures[:ottawa_with_name],
+      #international return requires destination to have: phone number, name
+      location_fixtures[:real_google_with_name_phone],
+      #package descriptions are required for returns
+      package_fixtures.values_at(:books),
+      {
+        #international return requires shipper to have: phone, name
+        :shipper => location_fixtures[:new_york_with_name],
+        :service_code => '07',
+        :return_service_code => '9',
+        :test => true,
+      }
+    )
+
+    assert response.success?
+
+    assert_instance_of ActiveShipping::LabelResponse, response
+  end
 end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -152,6 +152,15 @@ module ActiveShipping::Test
                                       :address1 => '1600 Amphitheatre Parkway',
                                       :zip => '94043',
                                       :address_type => 'commercial'),
+        :real_google_with_name_phone => Location.new(
+                                      :name => 'Sergey Brin',
+                                      :country => 'US',
+                                      :city => 'Mountain View',
+                                      :state => 'CA',
+                                      :address1 => '1600 Amphitheatre Parkway',
+                                      :zip => '94043',
+                                      :phone => '1-650-253-0000',
+                                      :address_type => 'commercial'),
         :real_google_as_residential => Location.new(
                                       :country => 'US',
                                       :city => 'Mountain View',


### PR DESCRIPTION
- Create a return label by setting the return_service_code
  - list of return service codes for reference
  - units used are now always based on shipper's country,
    allows international return from a different country than shipper
  - don't include SoldTo when it's a return
  - return requires a description at the package level