### PR TITLE
[WIP] Add support for both contract and non-contract for Canada Post

### DIFF
--- a/test/credentials.yml
+++ b/test/credentials.yml
@@ -50,6 +50,7 @@ new_zealand_post:
   key: <%= ENV['ACTIVESHIPPING_NEW_ZEALAND_POST_KEY'] %>
 
 canada_post_pws:
+  contract_id: <%= ENV['ACTIVESHIPPING_CANADA_POST_PWS_CONTRACT_ID'] %>
   customer_number: <%= ENV['ACTIVESHIPPING_CANADA_POST_PWS_CUSTOMER_NUMBER'] %>
   api_key: <%= ENV['ACTIVESHIPPING_CANADA_POST_PWS_API_KEY'] %>
   secret: <%= ENV['ACTIVESHIPPING_CANADA_POST_PWS_SECRET'] %>

--- a/test/remote/canada_post_pws_test.rb
+++ b/test/remote/canada_post_pws_test.rb
@@ -121,7 +121,13 @@ class RemoteCanadaPostPWSTest < Minitest::Test
   end
 
   def test_create_shipment
-    skip "Failing with 'Contract Number is a required field' after API change, skipping because no clue how to fix, might need different creds"
+    create_shipment(true)
+    create_shipment(false)
+  end
+
+  def create_shipment(use_contract)
+    @login.delete(:contract_id) unless use_contract
+
     opts = {:customer_number => @customer_number, :service => "DOM.XP"}
     response = @cp.create_shipment(@home_params, @dom_params, @pkg1, @line_item1, opts)
     assert_kind_of CPPWSShippingResponse, response
@@ -132,7 +138,13 @@ class RemoteCanadaPostPWSTest < Minitest::Test
   end
 
   def test_create_shipment_with_options
-    skip "Failing with 'Contract Number is a required field' after API change, skipping because no clue how to fix, might need different creds"
+    create_shipment_with_options(true)
+    create_shipment_with_options(false)
+  end
+
+  def create_shipment_with_options(use_contract)
+    @login.delete(:contract_id) unless use_contract
+
     opts = {:customer_number => @customer_number, :service => "USA.EP"}.merge(@shipping_opts1)
     response = @cp.create_shipment(@home_params, @dest_params, @pkg1, @line_item1, opts)
 
@@ -144,7 +156,13 @@ class RemoteCanadaPostPWSTest < Minitest::Test
   end
 
   def test_retrieve_shipping_label
-    skip "Failing with 'Contract Number is a required field' after API change, skipping because no clue how to fix, might need different creds"
+    retrieve_shipping_label(true)
+    retrieve_shipping_label(false)
+  end
+
+  def retrieve_shipping_label(use_contract)
+    @login.delete(:contract_id) unless use_contract
+
     opts = {:customer_number => @customer_number, :service => "DOM.XP"}
     shipping_response = @cp.create_shipment(@home_params, @dom_params, @pkg1, @line_item1, opts)
 
@@ -160,7 +178,13 @@ class RemoteCanadaPostPWSTest < Minitest::Test
   end
 
   def test_create_shipment_with_invalid_customer_raises_exception
-    skip "Failing with 'Contract Number is a required field' after API change, skipping because no clue how to fix, might need different creds"
+    create_shipment_with_invalid_customer_raises_exception(true)
+    create_shipment_with_invalid_customer_raises_exception(false)
+  end
+
+  def create_shipment_with_invalid_customer_raises_exception(use_contract)
+    @login.delete(:contract_id) unless use_contract
+
     opts = {:customer_number => "0000000000", :service => "DOM.XP"}
     assert_raises(ResponseError) do
       @cp.create_shipment(@home_params, @dom_params, @pkg1, @line_item1, opts)


### PR DESCRIPTION
Summary of changes:
- Removed constants throughout the code and changed them for small helper methods that know which value to return.
- `@options[:contract_id]` will tell which version of the payload must be generated.
- Added conditional base on `contract?` to have both implementations on the same file.

TODO:
Implement tests for both scenarios.

review @Shopify/shipping 
