### PR TITLE
Add ability to ship dry ice to UPS

### DIFF
--- a/lib/active_shipping/carriers/ups.rb
+++ b/lib/active_shipping/carriers/ups.rb
@@ -727,6 +727,24 @@ module ActiveShipping
               xml.DCISType(PACKAGE_DELIVERY_CONFIRMATION_CODES[delivery_confirmation])
             end
           end
+
+          if dry_ice = package.options[:dry_ice]
+            xml.DryIce do
+              xml.RegulationSet(dry_ice[:regulation_set] || 'CFR')
+              xml.DryIceWeight do
+                xml.UnitOfMeasurement do
+                  xml.Code(options[:imperial] ? 'LBS' : 'KGS')
+                end
+                # Cannot be more than package weight.
+                # Should be more than 0.0.
+                # Valid characters are 0-9 and .(Decimal point).
+                # Limit to 1 digit after the decimal. The maximum length
+                # of the field is 5 including . and can hold up
+                # to 1 decimal place.
+                xml.Weight(dry_ice[:weight])
+              end
+            end
+          end
         end
 
         # not implemented:  * Shipment/Package/LargePackageIndicator element

--- a/test/remote/ups_test.rb
+++ b/test/remote/ups_test.rb
@@ -426,4 +426,17 @@ class RemoteUPSTest < Minitest::Test
     assert_instance_of ActiveShipping::LabelResponse, response
     assert_equal "GIF", response.params['ShipmentResults']['PackageResults']['LabelImage']['LabelImageFormat']['Code']
   end
+
+  def test_create_shipment_with_dry_ice_options
+    response = @carrier.create_shipment(
+      location_fixtures[:beverly_hills_with_name],
+      location_fixtures[:new_york_with_name],
+      package_fixtures.values_at(:frozen_stuff),
+      :service_code => '01',
+      :test => true
+    )
+
+    assert response.success?
+    assert_instance_of ActiveShipping::LabelResponse, response
+  end
 end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -85,6 +85,7 @@ module ActiveShipping::Test
         :small_half_pound => Package.new(8, [1, 1, 1], :units => :imperial),
         :big_half_pound => Package.new((16 * 50), [24, 24, 36], :units => :imperial),
         :chocolate_stuff => Package.new(80, [2, 6, 12], :units => :imperial),
+        :frozen_stuff => Package.new(80, [2, 6, 12], :units => :imperial, :dry_ice => {weight: 1.4}),
         :declared_value => Package.new(80, [2, 6, 12], :units => :imperial, :currency => 'USD', :value => 999.99),
         :tshirts => Package.new(10 * 16, nil, :units => :imperial),
         :shipping_container => Package.new(2200000, [2440, 2600, 6058], :description => '20 ft Standard Container', :units => :metric),


### PR DESCRIPTION
Adds the `DryIce` node to the purchase request when the packages have a `dry_ice` option.

Usage looks like:

```ruby
Package.new(80, [2, 6, 12], :units => :imperial, :dry_ice => {weight: 1.4})
```

and gets you a nice comment on the label

<img width="380" alt="screen shot 2015-12-04 at 2 29 27 pm" src="https://cloud.githubusercontent.com/assets/766658/11603015/888c1eee-9a93-11e5-8800-3e4d7b5d773d.png">

and I'm hoping to use the same `dry_ice` hash option for FedEx soon.