### PR TITLE
Added support for USPS attempted delivery dates

### DIFF
--- a/lib/active_shipping/carriers/usps.rb
+++ b/lib/active_shipping/carriers/usps.rb
@@ -630,6 +630,9 @@ module ActiveShipping
 
         shipment_events = shipment_events.sort_by(&:time)
 
+        # USPS defines a delivery attempt with code 55
+        attempted_delivery_date = shipment_events.detect{ |shipment_event| shipment_event.type_code=="55" }.try(:time)
+
         if last_shipment = shipment_events.last
           status = last_shipment.status
           actual_delivery_date = last_shipment.time if last_shipment.delivered?
@@ -645,6 +648,7 @@ module ActiveShipping
                            :tracking_number => tracking_number,
                            :status => status,
                            :actual_delivery_date => actual_delivery_date,
+                           :attempted_delivery_date => attempted_delivery_date,
                            :scheduled_delivery_date => scheduled_delivery
       )
     end

--- a/lib/active_shipping/tracking_response.rb
+++ b/lib/active_shipping/tracking_response.rb
@@ -29,6 +29,9 @@ module ActiveShipping
   # @!attribute actual_delivery_date
   #   @return [Date, Time]
   #
+  # @!attribute attempted_delivery_date
+  #   @return [Date, Time]
+  #  
   # @!attribute delivery_signature
   #   @return [String]
   #
@@ -49,7 +52,7 @@ module ActiveShipping
   class TrackingResponse < Response
     attr_reader :carrier,:carrier_name,
                 :status,:status_code, :status_description,
-                :ship_time, :scheduled_delivery_date, :actual_delivery_date,
+                :ship_time, :scheduled_delivery_date, :actual_delivery_date, :attempted_delivery_date,
                 :delivery_signature, :tracking_number, :shipment_events,
                 :shipper_address, :origin, :destination
 
@@ -63,6 +66,7 @@ module ActiveShipping
       @ship_time = options[:ship_time]
       @scheduled_delivery_date = options[:scheduled_delivery_date]
       @actual_delivery_date = options[:actual_delivery_date]
+      @attempted_delivery_date = options[:attempted_delivery_date]
       @delivery_signature = options[:delivery_signature]
       @tracking_number = options[:tracking_number]
       @shipment_events = Array(options[:shipment_events])
@@ -96,5 +100,6 @@ module ActiveShipping
     alias_method :exception?, :has_exception?
     alias_method :scheduled_delivery_time, :scheduled_delivery_date
     alias_method :actual_delivery_time, :actual_delivery_date
+    alias_method :attempted_delivery_time, :attempted_delivery_date
   end
 end

--- a/test/remote/usps_test.rb
+++ b/test/remote/usps_test.rb
@@ -19,6 +19,15 @@ class RemoteUSPSTest < Minitest::Test
     assert_equal Time.parse('2015-11-30 13:02:00 UTC'), response.actual_delivery_date
   end
 
+   def test_tracking_with_attempted_delivery
+    response = @carrier.find_tracking_info('9405515901606017103876', test: false)
+    assert response.success?, response.message
+    assert_equal 9,response.shipment_events.size
+    assert_equal 'DELIVERED', response.shipment_events.last.message
+    assert_equal Time.parse('2015-12-10 14:42:00 UTC'), response.attempted_delivery_date
+    assert_equal Time.parse('2015-12-24 10:51:00 UTC'), response.actual_delivery_date
+  end 
+
   def test_tracking_with_bad_number
     assert_raises(ResponseError) do
       @carrier.find_tracking_info('abc123xyz', test: false)


### PR DESCRIPTION
We had a requirement to determine the first delivery attempt on a shipment as opposed to the actual delivery date.

For USPS, we pull the first event which is a failed delivery attempt.