### PR TITLE
Avoid exception during delivery date request

### DIFF
--- a/lib/active_shipping/carriers/ups.rb
+++ b/lib/active_shipping/carriers/ups.rb
@@ -532,10 +532,12 @@ module ActiveShipping
             xml.Weight([value.round(3), 0.1].max)
           end
 
-          xml.InvoiceLineTotal do
-            xml.CurrencyCode('USD')
-            total_value = packages.inject(0) {|sum, package| sum + package.value}
-            xml.MonetaryValue(total_value)
+          if packages.any? {|package| package.value.present?}
+            xml.InvoiceLineTotal do
+              xml.CurrencyCode('USD')
+              total_value = packages.inject(0) {|sum, package| sum + package.value.to_i}
+              xml.MonetaryValue(total_value)
+            end
           end
 
           xml.PickupDate(pickup_date.strftime('%Y%m%d'))

--- a/test/remote/ups_test.rb
+++ b/test/remote/ups_test.rb
@@ -286,6 +286,25 @@ class RemoteUPSTest < Minitest::Test
     assert_equal Date.parse(1.business_days.from_now.to_s), ground_delivery_estimate.date
   end
 
+  def test_delivery_date_estimates_within_zip_with_no_value
+    today = Date.current
+
+    response = @carrier.get_delivery_date_estimates(
+      location_fixtures[:new_york_with_name],
+      location_fixtures[:new_york_with_name],
+      package_fixtures.values_at(:book),
+      today,
+      {
+        :test => true
+      }
+    )
+
+    assert response.success?
+    refute_empty response.delivery_estimates
+    ground_delivery_estimate = response.delivery_estimates.select {|de| de.service_name == "UPS Ground"}.first
+    assert_equal Date.parse(1.business_days.from_now.to_s), ground_delivery_estimate.date
+  end
+
   def test_delivery_date_estimates_across_zips
     today = Date.current
 


### PR DESCRIPTION
Which occurs when one or more packages' value is nil.

Should fix https://github.com/Shopify/active_shipping/issues/341

If no packages have a value, then the entire block is
avoided to avoid an accidental 0 value. According to the
docs, `InvoiceLineTotal` is only required for "International
non-document shipments."