### PR TITLE
Handle FedEx tracking response failure code 9045

### DIFF
--- a/lib/active_shipping/carriers/fedex.rb
+++ b/lib/active_shipping/carriers/fedex.rb
@@ -605,6 +605,11 @@ module ActiveShipping
           else
             raise ActiveShipping::ResponseContentError, StandardError.new(first_notification.at('Message').text)
           end
+        elsif first_notification.at('Severity').text == 'FAILURE'
+          case first_notification.at('Code').text
+          when '9045'
+            raise ActiveShipping::ResponseContentError, StandardError.new(first_notification.at('Message').text)
+          end
         end
 
         tracking_number = tracking_details.at('TrackingNumber').text

--- a/test/fixtures/xml/fedex/tracking_response_failure_code_9045.xml
+++ b/test/fixtures/xml/fedex/tracking_response_failure_code_9045.xml
@@ -1,0 +1,52 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<TrackReply xmlns="http://fedex.com/ws/track/v7" xmlns:SOAP-ENV="http://schemas.xmlsoap.org/soap/envelope/">
+  <HighestSeverity>SUCCESS</HighestSeverity>
+  <Notifications>
+    <Severity>SUCCESS</Severity>
+    <Source>trck</Source>
+    <Code>0</Code>
+    <Message>Request was successfully processed.</Message>
+    <LocalizedMessage>Request was successfully processed.</LocalizedMessage>
+  </Notifications>
+  <TransactionDetail>
+    <CustomerTransactionId>ActiveShipping</CustomerTransactionId>
+  </TransactionDetail>
+  <Version>
+    <ServiceId>trck</ServiceId>
+    <Major>7</Major>
+    <Intermediate>0</Intermediate>
+    <Minor>0</Minor>
+  </Version>
+  <CompletedTrackDetails>
+    <HighestSeverity>SUCCESS</HighestSeverity>
+    <Notifications>
+      <Severity>SUCCESS</Severity>
+      <Source>trck</Source>
+      <Code>0</Code>
+      <Message>Request was successfully processed.</Message>
+      <LocalizedMessage>Request was successfully processed.</LocalizedMessage>
+    </Notifications>
+    <DuplicateWaybill>false</DuplicateWaybill>
+    <MoreData>false</MoreData>
+    <TrackDetails>
+      <Notification>
+        <Severity>FAILURE</Severity>
+        <Source>trck</Source>
+        <Code>9045</Code>
+        <Message>Sorry, we are unable to process your tracking request.  Please retry later, or contact Customer Service at 1.800.Go.FedEx(R) 800.463.3339.</Message>
+        <LocalizedMessage>Sorry, we are unable to process your tracking request.  Please retry later, or contact Customer Service at 1.800.Go.FedEx(R) 800.463.3339.</LocalizedMessage>
+      </Notification>
+      <TrackingNumber>020207021381215</TrackingNumber>
+      <StatusDetail>
+        <Location>
+          <Residential>false</Residential>
+        </Location>
+      </StatusDetail>
+      <PackageSequenceNumber>0</PackageSequenceNumber>
+      <PackageCount>0</PackageCount>
+      <DeliveryAttempts>0</DeliveryAttempts>
+      <TotalUniqueAddressCountInConsolidation>0</TotalUniqueAddressCountInConsolidation>
+      <RedirectToHoldEligibility>INELIGIBLE</RedirectToHoldEligibility>
+    </TrackDetails>
+  </CompletedTrackDetails>
+</TrackReply>

--- a/test/unit/carriers/fedex_test.rb
+++ b/test/unit/carriers/fedex_test.rb
@@ -327,6 +327,18 @@ class FedExTest < Minitest::Test
     end
   end
 
+  def test_response_failure_code_9045
+    mock_response = xml_fixture('fedex/tracking_response_failure_code_9045')
+    @carrier.expects(:commit).returns(mock_response)
+
+    error = assert_raises(ActiveShipping::ResponseContentError) do
+      @carrier.find_tracking_info('123456789013')
+    end
+
+    msg = 'Sorry, we are unable to process your tracking request.  Please retry later, or contact Customer Service at 1.800.Go.FedEx(R) 800.463.3339.'
+    assert_equal msg, error.message
+  end
+
   def test_parsing_response_without_notifications
     mock_response = xml_fixture('fedex/reply_without_notifications')
 


### PR DESCRIPTION
I'm not sure of the source of this failure. I accidentally left a 6 second interval polling task open in a terminal for most of the day to the FedEx test endpoint, so maybe FedEx cut me off. It's also possible their test service is not functioning correctly at the moment. At any rate, it's better to handle the code because the error message and class which were returned to me weren't helpful.

If we don't handle this error, we get:
```
ActiveShipping::Error: Tracking response does not contain status code
```

If we do handle this error, we get:
```
ActiveShipping::ResponseContentError: Sorry, we are unable to process your tracking request.  Please retry later, or contact Customer Service at 1.800.Go.FedEx(R) 800.463.3339.
```

I dumped the response xml from a pry session to use as a test fixture and red/greened the fix. Here is the red output before it went green.

```
2) Failure:
FedExTest#test_response_failure_code_9045 [/Users/adacosta/projects/forks/active_shipping/test/unit/carriers/fedex_test.rb:334]:
[ActiveShipping::ResponseContentError] exception expected, not
Class: <ActiveShipping::Error>
Message: <"Tracking response does not contain status code">
---Backtrace---
/Users/adacosta/projects/forks/active_shipping/lib/active_shipping/carriers/fedex.rb:618:in `parse_tracking_response'
/Users/adacosta/projects/forks/active_shipping/lib/active_shipping/carriers/fedex.rb:161:in `find_tracking_info'
/Users/adacosta/projects/forks/active_shipping/test/unit/carriers/fedex_test.rb:335:in `block in test_response_failure_code_9045'
---------------
```