### PR TITLE
Added State to XML

### DIFF
--- a/lib/active_shipping/carriers/fedex.rb
+++ b/lib/active_shipping/carriers/fedex.rb
@@ -460,6 +460,7 @@ module ActiveShipping
           xml.StreetLines(location.address1) if location.address1
           xml.StreetLines(location.address2) if location.address2
           xml.City(location.city) if location.city
+          xml.StateOrProvinceCode(location.state)
           xml.PostalCode(location.postal_code)
           xml.CountryCode(location.country_code(:alpha2))
           xml.Residential(true) unless location.commercial?


### PR DESCRIPTION
I've been receiving the following from the FedEx server: 

> ERROR - 961: The address entered for FEDEX_FREIGHT is missing one or more required fields:  State; ; ; ; .  Please resubmit your request with all required address fields. (ActiveShipping::ResponseError).

Since the Gem didn't have the required StateOrProvinceCode, I added it. Hopefully that will clear up the error.
