### PR TITLE
Add dev.yml

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ test/fixtures/live_credentials.yml
 .yardoc/
 doc/
 .idea
+.bundle

--- a/dev.yml
+++ b/dev.yml
@@ -1,0 +1,13 @@
+name: active_shipping
+
+up:
+  - ruby:
+      version: 2.2.4
+      build: true
+  - bundler
+
+commands:
+  test:
+    syntax: ""
+    desc: "run the unit tests"
+    run: bundle exec rake test


### PR DESCRIPTION
@garethson @jonathankwok @RichardBlair 
cc @burke 

Adds support for Shopify's `dev-up` to this gem. Supports:

* `dev cd active_shipping`
* `dev up`
* `dev test`
* etc.