### PR TITLE
Fix dev test and leaky timezone test

### DIFF
--- a/dev.yml
+++ b/dev.yml
@@ -8,6 +8,12 @@ up:
 
 commands:
   test:
-    syntax: ""
-    desc: "run the unit tests"
-    run: bundle exec rake test
+    syntax:
+      optional: file args...
+    desc: 'run all tests or a specific test file'
+    run: |
+      if [[ $# -eq 0 ]]; then
+        bundle exec rake test
+      else
+        bundle exec ruby -Itest "$@"
+      fi

--- a/test/unit/carriers/usps_test.rb
+++ b/test/unit/carriers/usps_test.rb
@@ -140,7 +140,7 @@ class USPSTest < Minitest::Test
     assert_nil response.shipment_events.last.location.city
 
     assert_equal 'NP', response.shipment_events.first.type_code
-    assert_equal Time.parse('Jan 01, 2000'), response.shipment_events.first.time
+    assert_equal Time.parse('2000-01-01 00:00:00 UTC'), response.shipment_events.first.time
 
     special_country  = xml_fixture('usps/tracking_response_alt').gsub('CANADA','TAIWAN')
     @carrier.expects(:commit).returns(special_country)


### PR DESCRIPTION
@thegedge @garethson @jonathankwok 

Continuing work on getting the build green. :green_heart: 

Fixes `dev test test/file.rb` running an individual file.

Fixes leaky test which would fail on non UTC running locally

```
~/source/active_shipping(dev-test ✗) dev test test/unit/carriers/usps_test.rb
Run options: --seed 14038

# Running tests:

.......................F.......................

Finished tests in 0.852873s, 55.1079 tests/s, 155.9435 assertions/s.

  1) Failure:
USPSTest#test_find_tracking_info_should_handle_special_cases [test/unit/carriers/usps_test.rb:143]:
Expected: 2000-01-01 00:00:00 -0500
  Actual: 2000-01-01 00:00:00 UTC
```