### PR TITLE
Force TLS 1.2 for UPS

### DIFF
--- a/lib/active_shipping/carriers/ups.rb
+++ b/lib/active_shipping/carriers/ups.rb
@@ -3,6 +3,7 @@
 module ActiveShipping
   class UPS < Carrier
     self.retry_safe = true
+    self.ssl_version = :TLSv1_2
 
     cattr_accessor :default_options
     cattr_reader :name


### PR DESCRIPTION
@garethson @jonathankwok @thegedge 

Get this damn build :green_heart: again.

We got this warning a while back:
<img width="614" alt="security_upgrade_required_for_ups_developer_kit_apis_-_kevin_mcphillips_shopify_com_-_shopify_mail" src="https://cloud.githubusercontent.com/assets/84159/13889337/7c110e28-ed1c-11e5-97fd-53bdfb5b8ee5.png">

Our servers and environment default to the proper TLS version, but TravisCI is not apparently. So we are forcing `:TLSv1_2` and that gets our build passing again.