### PR TITLE
Change the returned arbitrary date to epoch

### DIFF
--- a/lib/active_shipping/carriers/usps.rb
+++ b/lib/active_shipping/carriers/usps.rb
@@ -247,8 +247,8 @@ module ActiveShipping
         timestamp = "#{node.at('EventDate').text}, #{node.at('EventTime').text}"
         Time.parse(timestamp)
       else
-        # Arbitrary time in past, because we need to sort properly by time
-        Time.parse("Jan 01, 2000")
+        # Epoch time, because we need to sort properly by time
+        Time.at(0)
       end
 
       event_code = node.at('EventCode').text

--- a/test/unit/carriers/usps_test.rb
+++ b/test/unit/carriers/usps_test.rb
@@ -139,8 +139,11 @@ class USPSTest < Minitest::Test
     assert_nil response.scheduled_delivery_date
     assert_nil response.shipment_events.last.location.city
 
+    time = Time.at(0)
+    expected_utc_time = Time.utc(time.year, time.month, time.mday, time.hour, time.min, time.sec)
+
     assert_equal 'NP', response.shipment_events.first.type_code
-    assert_equal Time.parse('2000-01-01 00:00:00 UTC'), response.shipment_events.first.time
+    assert_equal expected_utc_time, response.shipment_events.first.time
 
     special_country  = xml_fixture('usps/tracking_response_alt').gsub('CANADA','TAIWAN')
     @carrier.expects(:commit).returns(special_country)


### PR DESCRIPTION
Noticed that if we don't get an EventTime in the response we return arbitrary date in the past (1/1/2000). This is a little bit confusing, it would be clearer to return something that would clearly signal that the EventTime is missing, so I'm going with Time.at(0).

Thoughts?

cc/ @kmcphillips @jonathankwok @cyprusad 