### PR TITLE
Removed flakey test

### DIFF
--- a/test/remote/usps_test.rb
+++ b/test/remote/usps_test.rb
@@ -11,14 +11,6 @@ class RemoteUSPSTest < Minitest::Test
     skip(e.message)
   end
 
-  def test_tracking
-    response = @carrier.find_tracking_info('LN757696446US', test: false)
-    assert response.success?, response.message
-    assert_equal 13,response.shipment_events.size
-    assert_equal 'DELIVERED', response.shipment_events.last.message
-    assert_equal Time.parse('2015-11-30 13:02:00 UTC'), response.actual_delivery_date
-  end
-
    def test_tracking_with_attempted_delivery
     response = @carrier.find_tracking_info('9405515901606017103876', test: false)
     assert response.success?, response.message
@@ -26,7 +18,7 @@ class RemoteUSPSTest < Minitest::Test
     assert_equal 'DELIVERED', response.shipment_events.last.message
     assert_equal Time.parse('2015-12-10 14:42:00 UTC'), response.attempted_delivery_date
     assert_equal Time.parse('2015-12-24 10:51:00 UTC'), response.actual_delivery_date
-  end 
+  end
 
   def test_tracking_with_bad_number
     assert_raises(ResponseError) do


### PR DESCRIPTION
Taking out a flakey test that fails because tools.usps.com can't give tracking information for a shipment once its handed to canada post.

Besides the test directly below it more or less tests the same thing.

cc/ @mdking @lucasuyezu @thegedge 