### PR TITLE
UPS. Ability to Bill Third Party for Duties and Taxes

### DIFF
--- a/lib/active_shipping/carriers/ups.rb
+++ b/lib/active_shipping/carriers/ups.rb
@@ -409,12 +409,12 @@ module ActiveShipping
                   xml.Type('01')
                   build_billing_info_node(xml, options)
                 end
-                if options[:terms_of_shipment] == 'DDP'
+                if options[:terms_of_shipment] == 'DDP' && options[:international]
                   # DDP stands for delivery duty paid and means the shipper will cover duties and taxes
                   # Otherwise UPS will charge the receiver
                   xml.ShipmentCharge do
                     xml.Type('02') # Type '02' means 'Duties and Taxes'
-                    build_billing_info_node(xml, options)
+                    build_billing_info_node(xml, options.merge(bill_to_consignee: true))
                   end
                 end
               end
@@ -739,7 +739,8 @@ module ActiveShipping
     def build_billing_info_node(xml, options={})
       if options[:bill_third_party]
         xml.BillThirdParty do
-          xml.BillThirdPartyShipper do
+          node_type = options[:bill_to_consignee] ? :BillThirdPartyConsignee : :BillThirdPartyShipper
+          xml.public_send(node_type) do
             xml.AccountNumber(options[:billing_account])
             xml.ThirdParty do
               xml.Address do

--- a/test/remote/ups_test.rb
+++ b/test/remote/ups_test.rb
@@ -267,6 +267,35 @@ class RemoteUPSTest < Minitest::Test
     assert_instance_of ActiveShipping::LabelResponse, response
   end
 
+  def test_obtain_international_shipping_label_with_bill_third_party
+    begin
+      bill_third_party_credentials = credentials(:ups_third_party_billing)
+    rescue NoCredentialsFound => e
+      skip(e.message)
+    end
+
+    response = @carrier.create_shipment(
+      location_fixtures[:new_york_with_name],
+      location_fixtures[:ottawa_with_name],
+      package_fixtures.values_at(:books),
+      {
+       :service_code => '07',
+       :bill_third_party => true,
+       :billing_account => bill_third_party_credentials[:account],
+       :billing_zip => bill_third_party_credentials[:zip],
+       :billing_country => bill_third_party_credentials[:country_code],
+       :test => true,
+      }
+    )
+    assert response.success?
+
+    # All behavior specific to how a LabelResponse behaves in the
+    # context of UPS label data is a matter for unit tests.  If
+    # the data changes substantially, the create_shipment
+    # ought to raise an exception and this test will fail.
+    assert_instance_of ActiveShipping::LabelResponse, response
+  end
+
   def test_delivery_date_estimates_within_zip
     today = Date.current
 

--- a/test/unit/carriers/ups_test.rb
+++ b/test/unit/carriers/ups_test.rb
@@ -352,9 +352,9 @@ class UPSTest < Minitest::Test
                                            :billing_zip => expected_postal_code_number,
                                            :billing_country => expected_country_code)
 
-    assert_equal expected_account_number, response.search('ShipmentConfirmRequest/Shipment/PaymentInformation/BillThirdParty/BillThirdPartyShipper/AccountNumber').text
-    assert_equal expected_postal_code_number, response.search('/ShipmentConfirmRequest/Shipment/PaymentInformation/BillThirdParty/BillThirdPartyShipper/ThirdParty/Address/PostalCode').text
-    assert_equal expected_country_code, response.search('/ShipmentConfirmRequest/Shipment/PaymentInformation/BillThirdParty/BillThirdPartyShipper/ThirdParty/Address/CountryCode').text
+    assert_equal expected_account_number, response.search('ShipmentConfirmRequest/Shipment/ItemizedPaymentInformation/ShipmentCharge/BillThirdParty/BillThirdPartyShipper/AccountNumber').text
+    assert_equal expected_postal_code_number, response.search('/ShipmentConfirmRequest/Shipment/ItemizedPaymentInformation/ShipmentCharge/BillThirdParty/BillThirdPartyShipper/ThirdParty/Address/PostalCode').text
+    assert_equal expected_country_code, response.search('/ShipmentConfirmRequest/Shipment/ItemizedPaymentInformation/ShipmentCharge/BillThirdParty/BillThirdPartyShipper/ThirdParty/Address/CountryCode').text
   end
 
   def test_label_request_negotiated_rates_presence
@@ -364,7 +364,8 @@ class UPSTest < Minitest::Test
                                            package_fixtures.values_at(:chocolate_stuff),
                                            :test => true,
                                            :saturday_delivery => true,
-                                           :origin_account => 'A01B23' # without this option, a negotiated rate will not be requested
+                                           :origin_account => 'A01B23', # without this option, a negotiated rate will not be requested
+                                           :negotiated_rates => true,
                              )
 
     negotiated_rates = response.search '/ShipmentConfirmRequest/Shipment/RateInformation/NegotiatedRatesIndicator'


### PR DESCRIPTION
This adds the ability to bill duties and taxes to a third party shipping account.

Also contained in this PR is a change to actually use parameter `negotiated_rates` which was already documented above the `create_shipment` method definition. We were inferring that based on the presence of an `origin_account` but given that negotiated rates are based on who's paying, the existence of third party billing means it doesn't really make sense to do that. However this could be a breaking change for anyone relying on the `origin_account` to automatically turn on negotiated rates.
Really I think we should probably rename `origin_account` to be `shipper_account` since that's a better description of what it is.

