### PR TITLE
Add InsuredValue option for UPS packages

### DIFF
--- a/lib/active_shipping/carriers/ups.rb
+++ b/lib/active_shipping/carriers/ups.rb
@@ -748,6 +748,13 @@ module ActiveShipping
               end
             end
           end
+
+          if package_value = package.options[:insured_value]
+            xml.InsuredValue do
+              xml.CurrencyCode(package.options[:currency] || 'USD')
+              xml.MonetaryValue(package_value.to_f)
+            end
+          end
         end
 
         # not implemented:  * Shipment/Package/LargePackageIndicator element

--- a/test/remote/ups_test.rb
+++ b/test/remote/ups_test.rb
@@ -458,4 +458,16 @@ class RemoteUPSTest < Minitest::Test
     assert response.success?
     assert_instance_of ActiveShipping::LabelResponse, response
   end
+
+  def test_create_shipment_with_insured_value
+    response = @carrier.create_shipment(
+      location_fixtures[:beverly_hills_with_name],
+      location_fixtures[:new_york_with_name],
+      package_fixtures.values_at(:insured_value),
+      :test => true
+    )
+
+    assert response.success?
+    assert_instance_of ActiveShipping::LabelResponse, response
+  end
 end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -87,6 +87,7 @@ module ActiveShipping::Test
         :chocolate_stuff => Package.new(80, [2, 6, 12], :units => :imperial),
         :frozen_stuff => Package.new(80, [2, 6, 12], :units => :imperial, :dry_ice => {weight: 1.4}),
         :declared_value => Package.new(80, [2, 6, 12], :units => :imperial, :currency => 'USD', :value => 999.99),
+        :insured_value => Package.new(80, [2, 6, 12], :units => :imperial, :currency => 'USD', :insured_value => 999.99),
         :tshirts => Package.new(10 * 16, nil, :units => :imperial),
         :shipping_container => Package.new(2200000, [2440, 2600, 6058], :description => '20 ft Standard Container', :units => :metric),
         :largest_gold_bar => Package.new(250000, [45.5, 22.5, 17], :value => 15300000),


### PR DESCRIPTION
Fixes #52 

Adds an optional `:insured_value` option to packages for use with UPS.