### PR TITLE
Add ResponseContentError for raised UPS error

### DIFF
--- a/lib/active_shipping/carriers/ups.rb
+++ b/lib/active_shipping/carriers/ups.rb
@@ -194,7 +194,7 @@ module ActiveShipping
       xml = parse_ship_confirm(confirm_response)
       success = response_success?(xml)
       message = response_message(xml)
-      raise message unless success
+      raise ActiveShipping::ResponseContentError, StandardError.new(message) unless success
       digest  = response_digest(xml)
 
       # STEP 2: Accept. Use shipment digest in first response to get the actual label.


### PR DESCRIPTION
Errors from UPS were getting thrown as runtime errors which are harder to catch. This change mirrors how [errors are thrown in the FedEx carrier](https://github.com/Shopify/active_shipping/blob/master/lib/active_shipping/carriers/fedex.rb#L606).