### PR TITLE
Save description for UPS shipment event in message

### DIFF
--- a/lib/active_shipping/carriers/ups.rb
+++ b/lib/active_shipping/carriers/ups.rb
@@ -850,7 +850,7 @@ module ActiveShipping
             type_code = activity.at('Status/StatusType/Code').text
             zoneless_time = parse_ups_datetime(:time => activity.at('Time'), :date => activity.at('Date'))
             location = location_from_address_node(activity.at('ActivityLocation/Address'))
-            ShipmentEvent.new(description, zoneless_time, location, nil, type_code)
+            ShipmentEvent.new(description, zoneless_time, location, description, type_code)
           end
 
           shipment_events = shipment_events.sort_by(&:time)

--- a/test/unit/carriers/ups_test.rb
+++ b/test/unit/carriers/ups_test.rb
@@ -128,6 +128,19 @@ class UPSTest < Minitest::Test
                   "DELIVERED"], response.shipment_events.map(&:name)
   end
 
+  def test_find_tracking_info_should_have_messages_for_shipment_events
+    @carrier.expects(:commit).returns(@tracking_response)
+    response = @carrier.find_tracking_info('1Z5FX0076803466397')
+    assert_equal ["BILLING INFORMATION RECEIVED",
+                  "IMPORT SCAN",
+                  "LOCATION SCAN",
+                  "LOCATION SCAN",
+                  "DEPARTURE SCAN",
+                  "ARRIVAL SCAN",
+                  "OUT FOR DELIVERY",
+                  "DELIVERED"], response.shipment_events.map(&:message)
+  end
+
   def test_find_tracking_info_should_have_correct_type_codes_for_shipment_events
     @carrier.expects(:commit).returns(@tracking_response)
     response = @carrier.find_tracking_info('1Z5FX0076803466397')


### PR DESCRIPTION
## About
For the other carrier adapters, we always save something for the `message` of a `ShipmentEvent` - 
 - [USPS does it here, storing the event's `Event` in `message`](https://github.com/Shopify/active_shipping/blob/master/lib/active_shipping/carriers/usps.rb#L627)
 - [FedEx also does it here, saving `EventDescription`](https://github.com/Shopify/active_shipping/blob/master/lib/active_shipping/carriers/fedex.rb#L664)
 - [Canada Post saves the `event-description` in `message`](https://github.com/Shopify/active_shipping/blob/master/lib/active_shipping/carriers/canada_post_pws.rb#L328)

UPS doesn't do anything, and just [gives it a `nil` value](https://github.com/Shopify/active_shipping/blob/master/lib/active_shipping/carriers/ups.rb#L853). Rather than `nil` the value, we can do what USPS and FedEx do and pass in the event description.

This change will keep the carriers consistent with each other.

## Changes
Simply store the text in the `'Status/StatusType/Description')` node in `message` for each `ShipmentEvent`.

## Testing
Added another unit test in `test/unit/ups_test.rb` to verify the existence of `message` for each shipment event in a response.

@kmcphillips @mdking @RichardBlair @MalazAlamir 