### PR TITLE
Use multiple attempted delivery codes for USPS tracking

### DIFF
--- a/lib/active_shipping/carriers/usps.rb
+++ b/lib/active_shipping/carriers/usps.rb
@@ -113,6 +113,8 @@ module ActiveShipping
       :package_service => 'PACKAGESERVICE'
     }
 
+    ATTEMPTED_DELIVERY_CODES = %w(02 53 54 55 56 H0)
+
     # Array of U.S. possessions according to USPS: https://www.usps.com/ship/official-abbreviations.htm
     US_POSSESSIONS = %w(AS FM GU MH MP PW PR VI)
 
@@ -630,8 +632,7 @@ module ActiveShipping
 
         shipment_events = shipment_events.sort_by(&:time)
 
-        # USPS defines a delivery attempt with code 55
-        attempted_delivery_date = shipment_events.detect{ |shipment_event| shipment_event.type_code=="55" }.try(:time)
+        attempted_delivery_date = shipment_events.detect{ |shipment_event| ATTEMPTED_DELIVERY_CODES.include?(shipment_event.type_code) }.try(:time)
 
         if last_shipment = shipment_events.last
           status = last_shipment.status

--- a/test/remote/usps_test.rb
+++ b/test/remote/usps_test.rb
@@ -12,12 +12,12 @@ class RemoteUSPSTest < Minitest::Test
   end
 
    def test_tracking_with_attempted_delivery
-    response = @carrier.find_tracking_info('9405515901606017103876', test: false)
+    response = @carrier.find_tracking_info('CJ509046330US', test: false)
     assert response.success?, response.message
-    assert_equal 9,response.shipment_events.size
+    assert_equal 10,response.shipment_events.size
     assert_equal 'DELIVERED', response.shipment_events.last.message
-    assert_equal Time.parse('2015-12-10 14:42:00 UTC'), response.attempted_delivery_date
-    assert_equal Time.parse('2015-12-24 10:51:00 UTC'), response.actual_delivery_date
+    assert_equal Time.parse('2016-04-21 13:46:00 UTC'), response.attempted_delivery_date
+    assert_equal Time.parse('2016-04-25 17:13:00 UTC'), response.actual_delivery_date
   end
 
   def test_tracking_with_bad_number


### PR DESCRIPTION
## About
There are multiple possible `attempted_delivery` codes - see page 335 of [this](https://ribbs.usps.gov/intelligentmail_package/documents/tech_guides/PUB199IMPBImpGuide.pdf), or look at this screenshot:

![image](https://cloud.githubusercontent.com/assets/4521864/14832745/cbe5cec2-0bc9-11e6-99f2-f59e5ba4389e.png)

There are multiple codes for "Notice Left"/Attempted Delivery - rather than just use code 55, use all of the ones in the appendix. Code H0 came from me finding responses manually through a database of tracking codes, seems to also be Attempted Delivery (unsurprisingly not documented).

## Changes
Add an array of known `ATTEMPTED_DELIVERY_CODES` and check for inclusion when saving the `attempted_delivery_date`.

This fixes part of the red build, which doesn't actually depend on this fix - it was just an outdated tracking number. The other half is fixed by https://github.com/Shopify/active_shipping/pull/362

Review: @kmcphillips @RichardBlair @mdking @MalazAlamir 