### PR TITLE
Remove build: true from ruby

### DIFF
--- a/dev.yml
+++ b/dev.yml
@@ -3,7 +3,6 @@ name: active_shipping
 up:
   - ruby:
       version: 2.2.4
-      build: true
   - bundler
 
 commands:


### PR DESCRIPTION
@jonathankwok @thegedge 

```
~/source/active_shipping(master ✔) dev up
🦄  the build: true option for ruby in dev.yml is obsolete and no longer has any effect.
✓ 1/2: Installing Ruby (nothing to do)
✓ 2/2: Running Bundler (nothing to do)
```