### PR TITLE
Allow for optional FedEx package label stock type (label dimensions)

### DIFF
--- a/lib/active_shipping/carriers/fedex.rb
+++ b/lib/active_shipping/carriers/fedex.rb
@@ -134,6 +134,8 @@ module ActiveShipping
       'TR' => :transfer
     )
 
+    DEFAULT_LABEL_STOCK_TYPE = 'PAPER_7X4.75'
+
     def self.service_name_for_code(service_code)
       SERVICE_TYPES[service_code] || "FedEx #{service_code.titleize.sub(/Fedex /, '')}"
     end
@@ -218,7 +220,7 @@ module ActiveShipping
             xml.LabelSpecification do
               xml.LabelFormatType('COMMON2D')
               xml.ImageType('PNG')
-              xml.LabelStockType('PAPER_7X4.75')
+              xml.LabelStockType(options[:label_stock_type] || DEFAULT_LABEL_STOCK_TYPE)
             end
 
             xml.RateRequestTypes('ACCOUNT')

--- a/test/unit/carriers/fedex_test.rb
+++ b/test/unit/carriers/fedex_test.rb
@@ -601,6 +601,32 @@ class FedExTest < Minitest::Test
     assert_equal result.search('RequestedPackageLineItems/CustomerReferences/Value').text, "FOO-123"
   end
 
+  def test_create_shipment_default_label_stock_type
+    packages = package_fixtures.values_at(:wii)
+
+    result = Nokogiri::XML(@carrier.send(:build_shipment_request,
+                                         location_fixtures[:beverly_hills],
+                                         location_fixtures[:annapolis],
+                                         packages,
+                                         :test => true))
+
+    assert_equal result.search('RequestedShipment/LabelSpecification/LabelStockType').text, FedEx::DEFAULT_LABEL_STOCK_TYPE
+  end
+
+  def test_create_shipment_label_stock_type
+    label_stock_type = 'PAPER_4X6'
+    packages = package_fixtures.values_at(:wii)
+
+    result = Nokogiri::XML(@carrier.send(:build_shipment_request,
+                                         location_fixtures[:beverly_hills],
+                                         location_fixtures[:annapolis],
+                                         packages,
+                                         :test => true,
+                                         :label_stock_type => label_stock_type))
+
+    assert_equal result.search('RequestedShipment/LabelSpecification/LabelStockType').text, label_stock_type
+  end
+
   def test_maximum_address_field_length
     assert_equal 35, @carrier.maximum_address_field_length
   end


### PR DESCRIPTION
Currently, a hard coded value of 'PAPER_7X4.75' is supplied for every package label. The FedEx WebServices Developers Guide says:
```
When using an ImageType of PDF or PNG, these values display a thermal format label:
  PAPER_4X6
  PAPER_4X8
  PAPER_4X9
these values display a plain paper format shipping label:
  PAPER_7X4.75
  PAPER_8.5X11_BOTTOM_HALF_LABEL
  PAPER_8.5X11_TOP_HALF_LABEL
```
I've allowed for the default (no option specified) to retain the current functionality. In other words, 'PAPER_7X4.75' will be used without a specified option.

In addition to the automated tests, I've manually tested with 'PAPER_4X6' (what I need for a thermal printer)

Sample use:
```
carrier.create_shipment(location_1, location_2, [package], test: true, label_stock_type: 'PAPER_4X6')
```