### PR TITLE
specify homebrew 2.2.5 package as the default dev ruby version

### DIFF
--- a/dev.yml
+++ b/dev.yml
@@ -2,7 +2,8 @@ name: active_shipping
 
 up:
   - ruby:
-      version: 2.2.4
+      package: homebrew/version/ruby22
+      version: 2.2.5p319
   - bundler
 
 commands:


### PR DESCRIPTION
Specified homebrew's 2.2.5 version in dev.yml so `dev` commands work again.

cc: @jonathankwok @MalazAlamir 