### PR TITLE
Allow access to package dimensions

### DIFF
--- a/lib/active_shipping/shipping/package.rb
+++ b/lib/active_shipping/shipping/package.rb
@@ -83,7 +83,7 @@ module ActiveMerchant #:nodoc:
       include Quantified
       
       cattr_accessor :default_options
-      attr_reader :options, :value, :currency
+      attr_reader :options, :value, :currency, :dimensions
 
       # Package.new(100, [10, 20, 30], :units => :metric)
       # Package.new(Mass.new(100, :grams), [10, 20, 30].map {|m| Length.new(m, :centimetres)})


### PR DESCRIPTION
In working with packages in my application, it would be helpful to have these exposed in a way that doesn't require grabbing instance variables.
