### PR TITLE
Bump ruby to 2.3.1

### DIFF
--- a/dev.yml
+++ b/dev.yml
@@ -1,9 +1,7 @@
 name: active_shipping
 
 up:
-  - ruby:
-      package: homebrew/version/ruby22
-      version: 2.2.5p319
+  - ruby: 2.3.1
   - bundler
 
 commands:


### PR DESCRIPTION
@rwu1997 @thegedge @MalazAlamir 

Bumping the ruby version to `2.3.1`.

There's a typo in this package definition and `version` should be plural. From #373. There are bugs in any `2.2.x` versions because of conflicts with the shopify version of ruby. So no harm in bumping it to the most current.