### PR TITLE
Shipwire delivery date test cleanup

### DIFF
--- a/test/unit/carriers/shipwire_test.rb
+++ b/test/unit/carriers/shipwire_test.rb
@@ -24,67 +24,65 @@ class ShipwireTest < Minitest::Test
 
   def test_successfully_get_international_rates
     date = DateTime.new(2011, 8, 1)
-    DateTime.expects(:now).returns(date).at_least_once
     @carrier.expects(:ssl_post).returns(xml_fixture('shipwire/international_rates_response'))
 
-    response = @carrier.find_rates(
-                 location_fixtures[:ottawa],
-                 location_fixtures[:london],
-                 package_fixtures.values_at(:book, :wii),
-                 :order_id => '#1000',
-                 :items => @items
-               )
+    Timecop.freeze(date) do
+      response = @carrier.find_rates(
+                   location_fixtures[:ottawa],
+                   location_fixtures[:london],
+                   package_fixtures.values_at(:book, :wii),
+                   :order_id => '#1000',
+                   :items => @items
+                 )
 
-    assert response.success?
+      assert response.success?
 
-    assert_equal 1, response.rates.size
+      assert_equal 1, response.rates.size
 
-    assert international = response.rates.first
-    assert_equal "INTL", international.service_code
-    assert_equal "UPS", international.carrier
-    assert_equal "UPS Standard", international.service_name
-    assert_equal 2806, international.total_price
-    assert_equal date + 7, international.delivery_date
-    assert_equal [date + 1, date + 7], international.delivery_range
+      assert international = response.rates.first
+      assert_equal "INTL", international.service_code
+      assert_equal "UPS", international.carrier
+      assert_equal "UPS Standard", international.service_name
+      assert_equal 2806, international.total_price
+      assert_equal [date + 1.day, date + 7.days], international.delivery_range
+    end
   end
 
   def test_successfully_get_domestic_rates
     date = DateTime.new(2011, 8, 1)
-    DateTime.expects(:now).returns(date).at_least_once
     @carrier.expects(:ssl_post).returns(xml_fixture('shipwire/rates_response'))
 
-    response = @carrier.find_rates(
-                 location_fixtures[:ottawa],
-                 location_fixtures[:beverly_hills],
-                 package_fixtures.values_at(:book, :wii),
-                 :order_id => '#1000',
-                 :items => @items
-               )
+    Timecop.freeze(date) do
+      response = @carrier.find_rates(
+                   location_fixtures[:ottawa],
+                   location_fixtures[:beverly_hills],
+                   package_fixtures.values_at(:book, :wii),
+                   :order_id => '#1000',
+                   :items => @items
+                 )
 
-    assert response.success?
+      assert response.success?
 
-    assert_equal 3, response.rates.size
+      assert_equal 3, response.rates.size
 
-    assert ground  = response.rates.find { |r| r.service_code == "GD" }
-    assert_equal "UPS", ground.carrier
-    assert_equal "UPS Ground", ground.service_name
-    assert_equal 773, ground.total_price
-    assert_equal date + 7, ground.delivery_date
-    assert_equal [date + 1, date + 7], ground.delivery_range
+      assert ground  = response.rates.find { |r| r.service_code == "GD" }
+      assert_equal "UPS", ground.carrier
+      assert_equal "UPS Ground", ground.service_name
+      assert_equal 773, ground.total_price
+      assert_equal [date + 1.day, date + 7.days], ground.delivery_range
 
-    assert two_day = response.rates.find { |r| r.service_code == "2D" }
-    assert_equal "UPS", two_day.carrier
-    assert_equal "UPS Second Day Air", two_day.service_name
-    assert_equal 1364, two_day.total_price
-    assert_equal date + 2, two_day.delivery_date
-    assert_equal [date + 2, date + 2], two_day.delivery_range
+      assert two_day = response.rates.find { |r| r.service_code == "2D" }
+      assert_equal "UPS", two_day.carrier
+      assert_equal "UPS Second Day Air", two_day.service_name
+      assert_equal 1364, two_day.total_price
+      assert_equal [date + 2.days, date + 2.days], two_day.delivery_range
 
-    assert one_day = response.rates.find { |r| r.service_code == "1D" }
-    assert_equal "USPS", one_day.carrier
-    assert_equal "USPS Express Mail", one_day.service_name
-    assert_equal 2525, one_day.total_price
-    assert_equal date + 1, one_day.delivery_date
-    assert_equal [date + 1, date + 1], one_day.delivery_range
+      assert one_day = response.rates.find { |r| r.service_code == "1D" }
+      assert_equal "USPS", one_day.carrier
+      assert_equal "USPS Express Mail", one_day.service_name
+      assert_equal 2525, one_day.total_price
+      assert_equal [date + 1.day, date + 1.day], one_day.delivery_range
+    end
   end
 
   def test_gracefully_handle_new_carrier
@@ -167,7 +165,6 @@ class ShipwireTest < Minitest::Test
 
     assert response.success?
     assert_equal [], response.rates[0].delivery_range
-    assert_nil response.rates[0].delivery_date
   end
 
   def test_rate_request_includes_company_if_provided

--- a/test/unit/rate_estimate_test.rb
+++ b/test/unit/rate_estimate_test.rb
@@ -2,11 +2,11 @@ require 'test_helper'
 
 class RateEstimateTest < Minitest::Test
   def setup
-    @origin      = {:address1 => "61A York St", :city => "Ottawa", :province => "ON", :country => "Canada", :postal_code => "K1N 5T2"}
-    @destination = {:city => "Beverly Hills", :state => "CA", :country => "United States", :postal_code => "90210"}
-    @line_items  = [Package.new(500, [2, 3, 4], :description => "a box full of stuff", :value => 2500)]
+    @origin      = {address1: "61A York St", city: "Ottawa", province: "ON", country: "Canada", postal_code: "K1N 5T2"}
+    @destination = {city: "Beverly Hills", state: "CA", country: "United States", postal_code: "90210"}
+    @line_items  = [Package.new(500, [2, 3, 4], description: "a box full of stuff", value: 2500)]
     @carrier     = CanadaPost.new(login: 'test')
-    @options     = {:currency => 'USD'}
+    @options     = {currency: 'USD', delivery_range: [DateTime.new(2016, 7, 1), DateTime.new(2016, 7, 3)]}
 
     @rate_estimate = RateEstimate.new(@origin, @destination, @carrier, @service_name, @options)
   end
@@ -31,13 +31,13 @@ class RateEstimateTest < Minitest::Test
   end
 
   def test_rate_estimate_converts_noniso_to_iso
-    rate_estimate = RateEstimate.new(@origin, @destination, @carrier, @service_name, @options.merge(:currency => 'UKL'))
+    rate_estimate = RateEstimate.new(@origin, @destination, @carrier, @service_name, @options.merge(currency: 'UKL'))
     assert_equal 'GBP', rate_estimate.currency
   end
 
   def test_creating_an_estimate_with_an_invalid_currency_raises
     assert_raises(ActiveUtils::InvalidCurrencyCodeError) do
-      RateEstimate.new(nil, nil, nil, nil, :currency => 'FAKE')
+      RateEstimate.new(nil, nil, nil, nil, currency: 'FAKE')
     end
   end
 
@@ -58,4 +58,8 @@ class RateEstimateTest < Minitest::Test
     assert_equal "local_delivery", est.delivery_category
   end
 
+  def test_delivery_date_pulls_from_delivery_range
+    assert_equal [DateTime.new(2016, 7, 1), DateTime.new(2016, 7, 3)], @rate_estimate.delivery_range
+    assert_equal DateTime.new(2016, 7, 3), @rate_estimate.delivery_date
+  end
 end


### PR DESCRIPTION
@garethson @jonathankwok 

Related to #381 and follows #383. 

Our Rails 5 test failures are all involved in date arithmetic and Shipwire. This does a few things to clean up how we test dates and delivery estimates to continue to narrow in on the problem.