### PR TITLE
Correctly offset days for business days

### DIFF
--- a/lib/active_shipping/carrier.rb
+++ b/lib/active_shipping/carrier.rb
@@ -72,8 +72,8 @@ module ActiveShipping
     #
     # @note Override with whatever you need to cancel a shipping label
     #
-    # @param shipment_id [String] The unique identifier of the shipment to cancel. 
-    #  This can be shipment_id or tracking number depending on carrier. Up to you and 
+    # @param shipment_id [String] The unique identifier of the shipment to cancel.
+    #  This can be shipment_id or tracking number depending on carrier. Up to you and
     #  the carrier
     # @param options [Hash] Carrier-specific parameters.
     # @return [ActiveShipping::ShipmentResponse] The response from the carrier. This
@@ -162,12 +162,15 @@ module ActiveShipping
     def timestamp_from_business_day(days)
       return unless days
       date = DateTime.now.utc
+
       days.times do
-        begin
-          date = date + 1
-        end while [0, 6].include?(date.wday)
+        date += 1.day
+
+        date += 2.days if date.saturday?
+        date += 1.day if date.sunday?
       end
-      date
+
+      date.to_datetime
     end
   end
 end

--- a/test/unit/carrier_test.rb
+++ b/test/unit/carrier_test.rb
@@ -84,6 +84,24 @@ class CarrierTest < Minitest::Test
     end
   end
 
+  def test_timestamp_from_business_day_handles_saturday
+    current = DateTime.new(2016, 7, 9) # Saturday
+    expected = DateTime.new(2016, 7, 11)
+
+    Timecop.freeze(current) do
+      assert_equal expected, @carrier.send(:timestamp_from_business_day, 1)
+    end
+  end
+
+  def test_timestamp_from_business_day_handles_sunday
+    current = DateTime.new(2016, 7, 10) # Sunday
+    expected = DateTime.new(2016, 7, 11)
+
+    Timecop.freeze(current) do
+      assert_equal expected, @carrier.send(:timestamp_from_business_day, 1)
+    end
+  end
+
   def test_timestamp_from_business_day_returns_datetime
     Timecop.freeze(DateTime.civil(2016, 7, 19)) do
       assert_equal DateTime, @carrier.send(:timestamp_from_business_day, 1).class


### PR DESCRIPTION
@garethson @jonathankwok 

Works toward #381. Our test failures in Rails 5 are around date math, and the `Time` vs `DateTime` calculations.

This fixes assumptions about class, and cleans up some really awkward ruby syntax. Tests the weekend cases too.