### PR TITLE
Rails 5 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ sudo: false
 rvm:
 - "2.0"
 - "2.1"
-- "2.2"
+- "2.2.2"
 - "2.3.1"
 
 gemfile:
@@ -13,6 +13,14 @@ gemfile:
 - Gemfile.activesupport40
 - Gemfile.activesupport41
 - Gemfile.activesupport42
+- Gemfile.activesupport50
+
+matrix:
+  exclude:
+    - rvm: "2.0"
+      gemfile: Gemfile.activesupport50
+    - rvm: "2.1"
+      gemfile: Gemfile.activesupport50
 
 env:
   global:

--- a/Gemfile.activesupport50
+++ b/Gemfile.activesupport50
@@ -1,0 +1,5 @@
+source "https://rubygems.org"
+gemspec
+
+gem 'activesupport', '~> 5.0.0'
+gem 'active_utils', '~> 3.2.2'

--- a/active_shipping.gemspec
+++ b/active_shipping.gemspec
@@ -15,7 +15,7 @@ Gem::Specification.new do |s|
   s.license     = 'MIT'
 
   s.add_dependency('quantified',    '~> 1.0.1')
-  s.add_dependency('activesupport', '>= 3.2', '< 5.0.0')
+  s.add_dependency('activesupport', '>= 3.2', '< 5.1.0')
   s.add_dependency('active_utils',  '~> 3.2.0')
   s.add_dependency('nokogiri',      '>= 1.6')
 

--- a/test/unit/carriers/ups_test.rb
+++ b/test/unit/carriers/ups_test.rb
@@ -242,17 +242,18 @@ class UPSTest < Minitest::Test
   def test_delivery_range_takes_weekend_into_consideration
     mock_response = xml_fixture('ups/test_real_home_as_residential_destination_response')
     @carrier.expects(:commit).returns(mock_response)
-    Timecop.freeze(DateTime.new(2012, 6, 15))
-    response = @carrier.find_rates( location_fixtures[:beverly_hills],
-                                    location_fixtures[:real_home_as_residential],
-                                    package_fixtures.values_at(:chocolate_stuff))
 
-    date_test = [nil, 3, 2, 1, 1, 1].map do |days|
-      DateTime.now.utc + days + 2 if days
+    Timecop.freeze(DateTime.new(2012, 6, 15)) do
+      response = @carrier.find_rates( location_fixtures[:beverly_hills],
+                                      location_fixtures[:real_home_as_residential],
+                                      package_fixtures.values_at(:chocolate_stuff))
+
+      date_test = [nil, 3, 2, 1, 1, 1].map do |days|
+        DateTime.now.utc + (days + 2).days if days
+      end
+
+      assert_equal date_test, response.rates.map(&:delivery_date)
     end
-    Timecop.return
-
-    assert_equal date_test, response.rates.map(&:delivery_date)
   end
 
   def test_maximum_weight


### PR DESCRIPTION
@garethson @jonathankwok 
cc @Sk8withaguitar @chaserx 

Closes #381 

Adds support for Rails 5.

In #383 #384 #385 I cleaned up some tests and date problems. This fixes a couple more small date math issues. Mainly it adds tests for Rails 5 and depends on the https://github.com/Shopify/active_utils/pull/69 release.

I'll do a gem release once this is merged.