### PR TITLE
Add accessor for CanadaPostPWS @@name

### DIFF
--- a/lib/active_shipping/carriers/canada_post_pws.rb
+++ b/lib/active_shipping/carriers/canada_post_pws.rb
@@ -1,5 +1,7 @@
 module ActiveShipping
   class CanadaPostPWS < Carrier
+    
+    cattr_reader :name
     @@name = "Canada Post PWS"
 
     SHIPPING_SERVICES = {

--- a/test/unit/carriers/canada_post_pws_rating_test.rb
+++ b/test/unit/carriers/canada_post_pws_rating_test.rb
@@ -53,6 +53,10 @@ class CanadaPostPwsRatingTest < Minitest::Test
     assert_equal 'en-CA', @cp.language
   end
 
+  def test_name_accessor
+    assert_equal 'Canada Post PWS', @cp.name
+  end
+
   def test_find_rates
     response = xml_fixture('canadapost_pws/rates_info')
     expected_headers = {


### PR DESCRIPTION
Add a cattr_reader to access the @@name variable provided by the class.
This is something standard in the other carriers that is missing from Canada Post Pws.