### PR TITLE
Support various FedEx label formats - issue #392

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # ActiveShipping CHANGELOG
 
+### v1.8.2
+- Add option for FedEx label format
+- Fix kunaki remote tests broken due to more shipping options
+
 ### v1.6.1
 - Fix FedEx ShipmentEvents to include event type
 - Skip broken Canada Post remote tests

--- a/lib/active_shipping/carriers/fedex.rb
+++ b/lib/active_shipping/carriers/fedex.rb
@@ -136,6 +136,9 @@ module ActiveShipping
 
     DEFAULT_LABEL_STOCK_TYPE = 'PAPER_7X4.75'
 
+    # Available return formats for image data when creating labels
+    LABEL_FORMATS = ['DPL', 'EPL2', 'PDF', 'ZPLII', 'PNG'] 
+
     def self.service_name_for_code(service_code)
       SERVICE_TYPES[service_code] || "FedEx #{service_code.titleize.sub(/Fedex /, '')}"
     end
@@ -219,7 +222,7 @@ module ActiveShipping
 
             xml.LabelSpecification do
               xml.LabelFormatType('COMMON2D')
-              xml.ImageType('PNG')
+              xml.ImageType(options[:label_format] || 'PNG')
               xml.LabelStockType(options[:label_stock_type] || DEFAULT_LABEL_STOCK_TYPE)
             end
 

--- a/test/remote/fedex_test.rb
+++ b/test/remote/fedex_test.rb
@@ -379,4 +379,20 @@ class RemoteFedExTest < Minitest::Test
     signature_option = response.params["ProcessShipmentReply"]["CompletedShipmentDetail"]["CompletedPackageDetails"]["SignatureOption"]
     assert_equal FedEx::SIGNATURE_OPTION_CODES[:adult], signature_option
   end
+
+  def test_obtain_shipping_label_with_label_format_option
+    response = @carrier.create_shipment(
+      location_fixtures[:beverly_hills_with_name],
+      location_fixtures[:new_york_with_name],
+      package_fixtures[:wii],
+        :test => true,
+        :label_format => 'PDF'
+    )
+
+    assert response.success?
+    refute_empty response.labels
+    data = response.labels.first.img_data 
+    refute_empty data
+    assert data[0...4] == '%PDF'
+  end
 end

--- a/test/remote/kunaki_test.rb
+++ b/test/remote/kunaki_test.rb
@@ -19,8 +19,8 @@ class RemoteKunakiTest < Minitest::Test
                )
 
     assert response.success?
-    assert_equal 3, response.rates.size
-    assert_equal ["UPS 2nd Day Air", "UPS Ground", "UPS Next Day Air Saver"], response.rates.collect(&:service_name).sort
+    assert_equal 4, response.rates.size
+    assert_equal ["UPS 2nd Day Air", "UPS Ground", "UPS Next Day Air Saver", "USPS First Class Mail"], response.rates.collect(&:service_name).sort
   end
 
   def test_send_no_items

--- a/test/unit/carriers/fedex_test.rb
+++ b/test/unit/carriers/fedex_test.rb
@@ -601,6 +601,17 @@ class FedExTest < Minitest::Test
     assert_equal result.search('RequestedPackageLineItems/CustomerReferences/Value').text, "FOO-123"
   end
 
+  def test_create_shipment_label_format_option
+    packages = package_fixtures.values_at(:chocolate_stuff)
+    result = Nokogiri::XML(@carrier.send(:build_shipment_request,
+                                         location_fixtures[:beverly_hills],
+                                         location_fixtures[:annapolis],
+                                         packages,
+                                         :label_format => 'ZPLII',
+                                         :test => true))
+    assert_equal result.search('RequestedShipment/LabelSpecification/ImageType').text, "ZPLII"
+  end
+
   def test_create_shipment_default_label_stock_type
     packages = package_fixtures.values_at(:wii)
 


### PR DESCRIPTION
Simple fix with tests to enable specifying what format a generated label should be returned in via the FedEx API.

As a side-note, what the hell is going on with the changelog file - where are the changes for version 1.6.2 until now?  What's up with all the remote test failures in the test suite?