### PR TITLE
Add description to rate estimates

### DIFF
--- a/lib/active_shipping/rate_estimate.rb
+++ b/lib/active_shipping/rate_estimate.rb
@@ -27,6 +27,10 @@ module ActiveShipping
   #   The code of the shipping service
   #   @return [String]
   #
+  # @!attribute description
+  #   Public description of the shipping service (e.g. "2 days delivery")
+  #   @return [String]
+  #
   # @!attribute shipping_date
   #   The date on which the shipment will be expected. Normally, this means that the
   #   delivery date range can only pe prmoised if the shipment is handed over on or
@@ -73,7 +77,7 @@ module ActiveShipping
   #
   class RateEstimate
     attr_accessor :origin, :destination, :package_rates,
-                :carrier, :service_name, :service_code,
+                :carrier, :service_name, :service_code, :description,
                 :shipping_date, :delivery_date, :delivery_range,
                 :currency, :negotiated_rate, :insurance_price,
                 :estimate_reference, :expires_at, :pickup_time,
@@ -83,6 +87,7 @@ module ActiveShipping
     def initialize(origin, destination, carrier, service_name, options = {})
       self.origin, self.destination, self.carrier, self.service_name = origin, destination, carrier, service_name
       self.service_code = options[:service_code]
+      self.description = options[:description]
       self.estimate_reference = options[:estimate_reference]
       self.pickup_time = options[:pickup_time]
       self.expires_at = options[:expires_at]

--- a/test/unit/rate_estimate_test.rb
+++ b/test/unit/rate_estimate_test.rb
@@ -26,6 +26,11 @@ class RateEstimateTest < Minitest::Test
     assert_equal false, est.phone_required
   end
 
+  def test_accepts_description_field
+    rate_estimate = RateEstimate.new(@origin, @destination, @carrier, @service_name, @options.merge(description: "It's free!"))
+    assert_equal "It's free!", rate_estimate.description
+  end
+
   def test_date_for_invalid_string_in_ruby_19
     assert_nil @rate_estimate.send(:date_for, "Up to 2 weeks") if RUBY_VERSION.include?('1.9')
   end


### PR DESCRIPTION
This adds a description field to rate estimates so that carriers
can better describe provided rates. API Carriers already support this within Shopify,
but I believe the API should be the same across the board.