### PR TITLE
RequestError for requests that do not adhere to the API

### DIFF
--- a/lib/active_shipping/errors.rb
+++ b/lib/active_shipping/errors.rb
@@ -2,6 +2,9 @@ module ActiveShipping
   class Error < ActiveUtils::ActiveUtilsError
   end
 
+  class RequestError < ActiveShipping::Error
+  end
+
   class ResponseError < ActiveShipping::Error
     attr_reader :response
 


### PR DESCRIPTION
### Context

It is expected that a client of an `active_shipping` API passes valid AND "business-logic correct" arguments.

E.g. An destination being passed in through `find_rates` should be a valid address, or shipment options codes being passed in must be supported by the API.

If not, a `RequestError` can be raised to highlight the incorrect request.

Review: @kmcphillips @thegedge 
cc: @RichardBlair @mdking 