### PR TITLE
Hook for adding customized "Customs" info.

### DIFF
--- a/lib/active_shipping/carriers/fedex.rb
+++ b/lib/active_shipping/carriers/fedex.rb
@@ -220,6 +220,8 @@ module ActiveShipping
               end
             end
 
+            options[:customs].call xml if options[:customs]
+
             xml.LabelSpecification do
               xml.LabelFormatType('COMMON2D')
               xml.ImageType(options[:label_format] || 'PNG')


### PR DESCRIPTION
When doing an international shipment fields in the customs section becomes required. There is currently no option or hook for adding those specifications.

This change provides that hook. It is very basic. Just executes a proc with the xml builder as the argument. I hate to expose the XML to the calling code and it sort of goes against the idea of ActiveShipping being an abstraction but it's the most straight forward solution I can see.

Initially I thought about using the options hash (like many other carrier specific options). But the customs declaration is not simple. It's a complex set of tags what is needed depends on the calling code needs as well as the countries being shipped to and from. The simplicity of the ActiveShipping interface (a few params and an options hash) just doesn't cut it.

I did consider a option has value which is basically transformed into the XML tags. I.E. something like:

```
   options[:customs] = {
     {duties_payment: {payment_type: :recipient, ....},
     {customs_value: {currency: 'USD', amount: 10}},
     ....
   }
```

But all this just seemed like an unncessary layer that is pretty much going to mimic the XML only it's not quite the same as the FedEx docs. It seemed much simpler to just have a hook that passed off the XML
builder.

It is assumed someone using this option will have to dig into the Fedex documentation to know what customs info they want to provide. I.E. I are not making it easy for them just making it possible.
