### PR TITLE
Initialize FedEx ShipmentEvents with maximum specificity

### DIFF
--- a/lib/active_shipping/carriers/fedex.rb
+++ b/lib/active_shipping/carriers/fedex.rb
@@ -137,7 +137,7 @@ module ActiveShipping
     DEFAULT_LABEL_STOCK_TYPE = 'PAPER_7X4.75'
 
     # Available return formats for image data when creating labels
-    LABEL_FORMATS = ['DPL', 'EPL2', 'PDF', 'ZPLII', 'PNG'] 
+    LABEL_FORMATS = ['DPL', 'EPL2', 'PDF', 'ZPLII', 'PNG']
 
     def self.service_name_for_code(service_code)
       SERVICE_TYPES[service_code] || "FedEx #{service_code.titleize.sub(/Fedex /, '')}"
@@ -660,8 +660,15 @@ module ActiveShipping
           country  = address.at('CountryCode').try(:text)
 
           location = Location.new(:city => city, :state => state, :postal_code => zip_code, :country => country)
-          description = event.at('EventDescription').text
-          type_code = event.at('EventType').text
+
+          event_description = event.at('EventDescription').text
+          event_type_code = event.at('EventType').text
+
+          exception_status_code = event.at('StatusExceptionCode').try(:text)
+          exception_description = event.at('StatusExceptionDescription').try(:text)
+
+          description = exception_description.presence || event_description
+          type_code = exception_status_code.presence || event_type_code
 
           time          = Time.parse(event.at('Timestamp').text)
           zoneless_time = time.utc

--- a/lib/active_shipping/carriers/fedex.rb
+++ b/lib/active_shipping/carriers/fedex.rb
@@ -137,7 +137,7 @@ module ActiveShipping
     DEFAULT_LABEL_STOCK_TYPE = 'PAPER_7X4.75'
 
     # Available return formats for image data when creating labels
-    LABEL_FORMATS = ['DPL', 'EPL2', 'PDF', 'ZPLII', 'PNG']
+    LABEL_FORMATS = ['DPL', 'EPL2', 'PDF', 'ZPLII', 'PNG'].freeze
 
     def self.service_name_for_code(service_code)
       SERVICE_TYPES[service_code] || "FedEx #{service_code.titleize.sub(/Fedex /, '')}"

--- a/test/unit/carriers/fedex_test.rb
+++ b/test/unit/carriers/fedex_test.rb
@@ -403,8 +403,8 @@ class FedExTest < Minitest::Test
     assert_equal 'PU', response.shipment_events.first.type_code
     assert_equal 'OC', response.shipment_events.second.type_code
     assert_equal 'AR', response.shipment_events.third.type_code
-    assert_equal 'Delivered', response.latest_event.name
-    assert_equal 'DL', response.latest_event.type_code
+    assert_equal 'Left at front door. Signature Service not requested.', response.latest_event.name
+    assert_equal '014', response.latest_event.type_code
     assert_equal nil, response.delivery_signature
   end
 
@@ -453,8 +453,8 @@ class FedExTest < Minitest::Test
     assert_equal destination_address.to_hash, response.destination.to_hash
 
     assert_equal 1, response.shipment_events.length
-    assert_equal 'In transit', response.latest_event.name
-    assert_equal 'IT', response.latest_event.type_code
+    assert_equal 'Package available for clearance', response.latest_event.name
+    assert_equal '72', response.latest_event.type_code
   end
 
   def test_tracking_info_for_shipment_exception
@@ -487,8 +487,8 @@ class FedExTest < Minitest::Test
     assert_equal destination_address.to_hash, response.destination.to_hash
 
     assert_equal 8, response.shipment_events.length
-    assert_equal "Shipment exception", response.latest_event.name
-    assert_equal "SE", response.latest_event.type_code
+    assert_equal "Unable to deliver", response.latest_event.name
+    assert_equal "099", response.latest_event.type_code
   end
 
   def test_tracking_info_without_status


### PR DESCRIPTION
[This is the reference doc used for all events/codes FedEx.](https://www.fedex.com/us/developer/WebHelp/ws/2014/dvg/WS_DVG_WebHelp/Appendix_Q_Track_Service_Scan_Codes.htm)
### Summary

This changes the attributes `ShipmentEvent` will initialize with for `FedEx` tracking responses to be the more specific version. In a given `<Events>` node, it will always have the `EventType` and `EventDescription`, which in the doc are the Scan Event Code and Scan Event Message. However, in exceptional cases (and even non-exceptional cases for some reason), sometimes a more detailed `StatusExceptionCode` and `StatusExceptionDescription` will be given, which is _always_ more descriptive than the non-`StatusException` version.
### Example:

``` xml
<Events>
  <Timestamp>2014-01-08T06:33:00-08:00</Timestamp>
  <EventType>OD</EventType>
  <EventDescription>On FedEx vehicle for delivery</EventDescription>
  ... (etc)
```

vs 

``` xml
<Events>
  <Timestamp>2014-01-08T12:53:10-08:00</Timestamp>
  <EventType>DL</EventType>
  <EventDescription>Delivered</EventDescription>
  <StatusExceptionCode>014</StatusExceptionCode>
  <StatusExceptionDescription>Left at front door. Signature Service not requested.</StatusExceptionDescription>
  ... (etc)
</Events>
```

If `StatusExceptionCode` and `StatusExceptionDescription` are present, we'll prefer using that data to the `EventType` and `EventDescription` data, since it's always more descriptive.
### Effects of change

This will affect consumers of the `FedEx` `active_shipping` endpoint, since the codes and messages being returned for a tracking response will be different (but better!). I'd recommend a major version bump.

---
### Review

@kmcphillips @MalazAlamir @Goldenson 
