### PR TITLE
Change assert to assert_equal

### DIFF
--- a/test/unit/carriers/canada_post_pws_register_test.rb
+++ b/test/unit/carriers/canada_post_pws_register_test.rb
@@ -37,9 +37,11 @@ class CanadaPostPwsRegisterTest < Minitest::Test
     endpoint = @cp.endpoint + "ot/token"
     response = xml_fixture('canadapost_pws/register_token_response')
     @cp.expects(:ssl_post).with(endpoint, anything, anything).returns(response)
+    url = 'http://localhost:3000/cp-register/'
+    customer_id = "12345"
 
     response = @cp.register_merchant
-    assert "http://www.canadapost.ca/cpotools/apps/drc/merchant?return-url=#{CGI.escape('http://localhost:3000/cp-register/')}&token-id=#{response.token_id}&platform-id=111111111", response.redirect_url('http://localhost:3000/cp-register/', '111111111')
+    assert_equal "http://www.canadapost.ca/cpotools/apps/drc/merchant?return-url=#{customer_id}&token-id=#{response.token_id}&platform-id=#{url}", response.redirect_url(url, customer_id)
   end
 
   def test_retrieve_merchant_details

--- a/test/unit/carriers/ups_test.rb
+++ b/test/unit/carriers/ups_test.rb
@@ -527,7 +527,7 @@ class UPSTest < Minitest::Test
     )
 
     response.delivery_estimates.each do |delivery_estimate|
-      assert delivery_estimate.service_name, UPS::DEFAULT_SERVICES[delivery_estimate.service_code]
+      assert_equal delivery_estimate.service_code, UPS::DEFAULT_SERVICE_NAME_TO_CODE[delivery_estimate.service_name]
     end
   end
 


### PR DESCRIPTION
We have two cases of old tests where we say `assert` where we mean `assert_equal`. The API of MiniTest's assertion is confusing, as the second argument is a description message. So these both false passed.