### PR TITLE
Force re-encoding of ISO-8859-1 to UTF-8

### DIFF
--- a/lib/active_shipping/carriers/ups.rb
+++ b/lib/active_shipping/carriers/ups.rb
@@ -1001,7 +1001,8 @@ module ActiveShipping
     end
 
     def commit(action, request, test = false)
-      ssl_post("#{test ? TEST_URL : LIVE_URL}/#{RESOURCES[action]}", request)
+      response = ssl_post("#{test ? TEST_URL : LIVE_URL}/#{RESOURCES[action]}", request)
+      response.encode('utf-8', 'iso-8859-1')
     end
 
     def within_same_area?(origin, location)

--- a/test/unit/carriers/ups_test.rb
+++ b/test/unit/carriers/ups_test.rb
@@ -179,6 +179,13 @@ class UPSTest < Minitest::Test
     assert_equal "Failure: Package exceeds the maximum length constraint of 108 inches. Length is the longest side of a package.", e.message
   end
 
+  def test_response_parsing_an_undecoded_character
+    unencoded_response = @tracking_response.gsub('NAPERVILLE', "N\xc4PERVILLE")
+    @carrier.stubs(:ssl_post).returns(unencoded_response)
+    response = @carrier.find_tracking_info('1Z5FX0076803466397')
+    assert_equal 'NÄPERVILLE', response.shipment_events.first.location.city
+  end
+
   def test_response_parsing_an_unknown_error
     mock_response = '<RatingServiceSelectionResponse><Response><ResponseStatusCode>0</ResponseStatusCode></Response></RatingServiceSelectionResponse>'
     @carrier.expects(:commit).returns(mock_response)


### PR DESCRIPTION
## About
We were encountering `REXML::ParseException` on [this line, where we call `Hash.from_xml(response)`](https://github.com/Shopify/active_shipping/blob/master/lib/active_shipping/carriers/ups.rb#L889) when the `response` contains a "UTF-8, but not actually" character (in our case, `\xCF`). This means the response we're getting is assumed to be UTF-8 but isn't necessarily encoded in UTF-8, for example in the case of UPS, it's ISO-8859-1.

[The typical fix for an encoding issue like this is to re-encode the string in what we want it to actually be, in this case UTF-8.](http://www.justinweiss.com/articles/3-steps-to-fix-encoding-problems-in-ruby/), so this PR will re-encode everything into UTF-8; a no-op if it's properly encoded in UTF-8 and a fix for the exceptional cases.

@kmcphillips @lucasuyezu @MalazAlamir 