### PR TITLE
Update Timecop dates to bypass weird test bug

### DIFF
--- a/test/unit/carrier_test.rb
+++ b/test/unit/carrier_test.rb
@@ -58,8 +58,8 @@ class CarrierTest < Minitest::Test
   end
 
   def test_timestamp_from_business_day_returns_two_days_in_the_future
-    current = DateTime.new(2016, 7, 19) # Tuesday
-    expected = DateTime.new(2016, 7, 21)
+    current = DateTime.parse("Tue 19 Jul 2016")
+    expected = DateTime.parse("Thu 21 Jul 2016")
 
     Timecop.freeze(current) do
       assert_equal expected, @carrier.send(:timestamp_from_business_day, 2)
@@ -67,8 +67,8 @@ class CarrierTest < Minitest::Test
   end
 
   def test_timestamp_from_business_day_returns_two_days_in_the_future_over_a_weekend
-    current = DateTime.new(2016, 7, 22) # Friday
-    expected = DateTime.new(2016, 7, 26)
+    current = DateTime.parse("Fri 22 Jul 2016")
+    expected = DateTime.parse("Tue 26 Jul 2016")
 
     Timecop.freeze(current) do
       assert_equal expected, @carrier.send(:timestamp_from_business_day, 2)
@@ -76,8 +76,8 @@ class CarrierTest < Minitest::Test
   end
 
   def test_timestamp_from_business_day_returns_fifteen_days_in_the_future
-    current = DateTime.new(2016, 7, 6) # Wednesday
-    expected = DateTime.new(2016, 7, 27) # includes 3 weekends
+    current = DateTime.parse("Wed 06 Jul 2016")
+    expected = DateTime.parse("Wed 27 Jul 2016") # includes 3 weekends
 
     Timecop.freeze(current) do
       assert_equal expected, @carrier.send(:timestamp_from_business_day, 15)
@@ -85,8 +85,8 @@ class CarrierTest < Minitest::Test
   end
 
   def test_timestamp_from_business_day_handles_saturday
-    current = DateTime.new(2016, 7, 9) # Saturday
-    expected = DateTime.new(2016, 7, 11)
+    current = DateTime.parse("Sat 09 Jul 2016")
+    expected = DateTime.parse("Mon 11 Jul 2016")
 
     Timecop.freeze(current) do
       assert_equal expected, @carrier.send(:timestamp_from_business_day, 1)
@@ -94,8 +94,8 @@ class CarrierTest < Minitest::Test
   end
 
   def test_timestamp_from_business_day_handles_sunday
-    current = DateTime.new(2016, 7, 10) # Sunday
-    expected = DateTime.new(2016, 7, 11)
+    current = DateTime.parse("Sun 10 Jul 2016")
+    expected = DateTime.parse("Mon 11 Jul 2016")
 
     Timecop.freeze(current) do
       assert_equal expected, @carrier.send(:timestamp_from_business_day, 1)
@@ -103,7 +103,7 @@ class CarrierTest < Minitest::Test
   end
 
   def test_timestamp_from_business_day_returns_datetime
-    Timecop.freeze(DateTime.civil(2016, 7, 19)) do
+    Timecop.freeze(DateTime.parse("Tue 19 Jul 2016")) do
       assert_equal DateTime, @carrier.send(:timestamp_from_business_day, 1).class
     end
   end

--- a/test/unit/carriers/fedex_test.rb
+++ b/test/unit/carriers/fedex_test.rb
@@ -39,7 +39,7 @@ class FedExTest < Minitest::Test
   def test_turn_around_time_default
     mock_response = xml_fixture('fedex/ottawa_to_beverly_hills_rate_response').gsub('<v6:DeliveryTimestamp>2011-07-29</v6:DeliveryTimestamp>', '')
 
-    today = DateTime.civil(2013, 3, 11, 0, 0, 0, "-4") #Monday
+    today = Date.parse("Mon 11 Mar 2013")
 
     Timecop.freeze(today) do
       delivery_date = Date.today + 7.days # FIVE_DAYS in fixture response, plus weekend
@@ -278,7 +278,7 @@ class FedExTest < Minitest::Test
 
     @carrier.expects(:commit).returns(mock_response)
 
-    today = DateTime.civil(2015, 06, 04, 0, 0, 0, "-4") #Thursday
+    today = Date.parse("Thursday 04 Jun 2015")
 
     Timecop.freeze(today) do
       rate_estimates = @carrier.find_rates( location_fixtures[:ottawa],

--- a/test/unit/carriers/fedex_test.rb
+++ b/test/unit/carriers/fedex_test.rb
@@ -15,24 +15,24 @@ class FedExTest < Minitest::Test
   end
 
   def test_business_days
-    today = DateTime.civil(2013, 3, 12, 0, 0, 0, "-4") #Tuesday
+    today = DateTime.parse("Tue 12 Mar 2013 00:00:00-0400")
 
     Timecop.freeze(today) do
-      assert_equal DateTime.civil(2013, 3, 13, 0, 0, 0, "-4"), @carrier.send(:business_days_from, today, 1)
-      assert_equal DateTime.civil(2013, 3, 15, 0, 0, 0, "-4"), @carrier.send(:business_days_from, today, 3)
-      assert_equal DateTime.civil(2013, 3, 18, 0, 0, 0, "-4"), @carrier.send(:business_days_from, today, 4)
-      assert_equal DateTime.civil(2013, 3, 19, 0, 0, 0, "-4"), @carrier.send(:business_days_from, today, 5)
+      assert_equal DateTime.parse("Wed 13 Mar 2013 00:00:00-0400"), @carrier.send(:business_days_from, today, 1)
+      assert_equal DateTime.parse("Fri 15 Mar 2013 00:00:00-0400"), @carrier.send(:business_days_from, today, 3)
+      assert_equal DateTime.parse("Mon 18 Mar 2013 00:00:00-0400"), @carrier.send(:business_days_from, today, 4)
+      assert_equal DateTime.parse("Tue 19 Mar 2013 00:00:00-0400"), @carrier.send(:business_days_from, today, 5)
     end
   end
 
   def test_home_delivery_business_days
-    today = DateTime.civil(2013, 3, 12, 0, 0, 0, "-4") #Tuesday
+    today = DateTime.parse("Tue 12 Mar 2013 00:00:00-0400")
 
     Timecop.freeze(today) do
-      assert_equal DateTime.civil(2013, 3, 13, 0, 0, 0, "-4"), @carrier.send(:business_days_from, today, 1, true)
-      assert_equal DateTime.civil(2013, 3, 15, 0, 0, 0, "-4"), @carrier.send(:business_days_from, today, 3, true)
-      assert_equal DateTime.civil(2013, 3, 16, 0, 0, 0, "-4"), @carrier.send(:business_days_from, today, 4, true)
-      assert_equal DateTime.civil(2013, 3, 19, 0, 0, 0, "-4"), @carrier.send(:business_days_from, today, 5, true)
+      assert_equal DateTime.parse("Wed 13 Mar 2013 00:00:00-0400"), @carrier.send(:business_days_from, today, 1, true)
+      assert_equal DateTime.parse("Fri 15 Mar 2013 00:00:00-0400"), @carrier.send(:business_days_from, today, 3, true)
+      assert_equal DateTime.parse("Sat 16 Mar 2013 00:00:00-0400"), @carrier.send(:business_days_from, today, 4, true)
+      assert_equal DateTime.parse("Tue 19 Mar 2013 00:00:00-0400"), @carrier.send(:business_days_from, today, 5, true)
     end
   end
 
@@ -260,7 +260,7 @@ class FedExTest < Minitest::Test
 
     @carrier.expects(:commit).returns(mock_response)
 
-    today = DateTime.civil(2013, 3, 15, 0, 0, 0, "-4")
+    today = Date.parse("Fri 15 Mar 2013")
 
     Timecop.freeze(today) do
       rate_estimates = @carrier.find_rates( location_fixtures[:ottawa],
@@ -268,7 +268,7 @@ class FedExTest < Minitest::Test
                                             package_fixtures.values_at(:book, :wii), :test => true)
 
       # the above fixture will specify a transit time of 5 days, with 2 weekend days accounted for
-      delivery_date = Date.today + 7
+      delivery_date = Date.today + 5 + 2
       assert_equal delivery_date, rate_estimates.rates[0].delivery_date
     end
   end
@@ -298,7 +298,7 @@ class FedExTest < Minitest::Test
 
     @carrier.expects(:commit).returns(mock_response)
 
-    today = DateTime.civil(2015, 06, 03, 0, 0, 0, "-4") #Wednesday
+    today = Date.parse("Wed 03 Jun 2015") #Wednesday
 
     Timecop.freeze(today) do
       rate_estimates = @carrier.find_rates( location_fixtures[:ottawa],

--- a/test/unit/carriers/shipwire_test.rb
+++ b/test/unit/carriers/shipwire_test.rb
@@ -23,7 +23,7 @@ class ShipwireTest < Minitest::Test
   end
 
   def test_successfully_get_international_rates
-    date = DateTime.new(2011, 8, 1)
+    date = DateTime.parse("Mon 01 Aug 2011")
     @carrier.expects(:ssl_post).returns(xml_fixture('shipwire/international_rates_response'))
 
     Timecop.freeze(date) do
@@ -49,7 +49,7 @@ class ShipwireTest < Minitest::Test
   end
 
   def test_successfully_get_domestic_rates
-    date = DateTime.new(2011, 8, 1)
+    date = DateTime.parse("Mon 01 Aug 2011")
     @carrier.expects(:ssl_post).returns(xml_fixture('shipwire/rates_response'))
 
     Timecop.freeze(date) do

--- a/test/unit/rate_estimate_test.rb
+++ b/test/unit/rate_estimate_test.rb
@@ -6,7 +6,7 @@ class RateEstimateTest < Minitest::Test
     @destination = {city: "Beverly Hills", state: "CA", country: "United States", postal_code: "90210"}
     @line_items  = [Package.new(500, [2, 3, 4], description: "a box full of stuff", value: 2500)]
     @carrier     = CanadaPost.new(login: 'test')
-    @options     = {currency: 'USD', delivery_range: [DateTime.new(2016, 7, 1), DateTime.new(2016, 7, 3)]}
+    @options     = {currency: 'USD', delivery_range: [DateTime.parse("Fri 01 Jul 2016"), DateTime.parse("Sun 03 Jul 2016")]}
 
     @rate_estimate = RateEstimate.new(@origin, @destination, @carrier, @service_name, @options)
   end
@@ -64,7 +64,7 @@ class RateEstimateTest < Minitest::Test
   end
 
   def test_delivery_date_pulls_from_delivery_range
-    assert_equal [DateTime.new(2016, 7, 1), DateTime.new(2016, 7, 3)], @rate_estimate.delivery_range
-    assert_equal DateTime.new(2016, 7, 3), @rate_estimate.delivery_date
+    assert_equal [DateTime.parse("Fri 01 Jul 2016"), DateTime.parse("Sun 03 Jul 2016")], @rate_estimate.delivery_range
+    assert_equal DateTime.parse("Sun 03 Jul 2016"), @rate_estimate.delivery_date
   end
 end

--- a/test/unit/shipment_event_test.rb
+++ b/test/unit/shipment_event_test.rb
@@ -4,7 +4,7 @@ class ShipmentEventTest < Minitest::Test
   def test_equality
     options1 = [
       'ARRIVED AT UNIT',
-      DateTime.new(2016, 5, 12, 5, 45),
+      DateTime.parse('Thu 12 May 2016 05:45:00'),
       Location.new(city: 'SAN JOSE', state: 'CA', postal_code: '90001', country: 'US'),
       'ARRIVED AT UNIT',
       '07'

--- a/test/unit/tracking_response_test.rb
+++ b/test/unit/tracking_response_test.rb
@@ -7,19 +7,19 @@ class TrackingResponseTest < Minitest::Test
       status: 'DELIVERED',
       status_code: 'I0',
       status_description: 'DELIVERED',
-      actual_delivery_date: DateTime.new(2016, 5, 14, 13, 20),
+      actual_delivery_date: DateTime.parse("Sat 14 May 2016 13:20:00"),
       tracking_number: 'TRACKINGNUMBER1234ABC',
       shipment_events: [
         ShipmentEvent.new(
           'DELIVERED',
-          DateTime.new(2016, 5, 14, 13, 20),
+          DateTime.parse("Sat 14 May 2016 13:20:00"),
           Location.new(city: 'LOS ANGELES', state: 'CA', postal_code: '90210', country: 'US'),
           'DELIVERED',
           'I0'
         ),
         ShipmentEvent.new(
           'ARRIVED AT UNIT',
-          DateTime.new(2016, 5, 12, 5, 45),
+          DateTime.parse("Thu 12 May 2016 05:45:00"),
           Location.new(city: 'SAN JOSE', state: 'CA', postal_code: '90001', country: 'US'),
           'ARRIVED AT UNIT',
           '07'


### PR DESCRIPTION
**_This pull request is opened for conversation and direction on the best way to resolve the issue._**

When running the tests locally, I had two tests fail due to an issue
with Timecop. A [similar issue](https://github.com/travisjeffery/timecop/issues/100) has been opened on Timecop's repo, but it has not been addressed. Here are the errors:

```
Finished in 12.098837s, 45.0457 runs/s, 126.1278 assertions/s.

  1) Failure:
FedExTest#test_delivery_date_from_ground_home_transit_time [/home/alex/fn/active_shipping/test/unit/carriers/fedex_test.rb:292]:
--- expected
+++ actual
@@ -1 +1 @@
-Mon, 08 Jun 2015
+Sat, 06 Jun 2015 00:00:00 +0000



  2) Failure:
FedExTest#test_turn_around_time_default [/home/alex/fn/active_shipping/test/unit/carriers/fedex_test.rb:54]:
--- expected
+++ actual
@@ -1 +1 @@
-[Sun, 17 Mar 2013, Sun, 17 Mar 2013]
+[Fri, 15 Mar 2013 00:00:00 +0000, Fri, 15 Mar 2013 00:00:00 +0000]
```

It seems that using a string in Timecop.freeze fixes this issue.