### PR TITLE
Add price_details attribute to RateEstimate

### DIFF
--- a/lib/active_shipping/rate_estimate.rb
+++ b/lib/active_shipping/rate_estimate.rb
@@ -75,6 +75,10 @@ module ActiveShipping
   #   Additional priced options bundled with the given rate estimate with price in cents
   #   @return [Array<{ code: String, price: Integer }>]
   #
+  # @!attribute charge_items
+  #   Breakdown of a shipping rate's price with amounts in cents.
+  #   @return [Array<{ group: String, code: String, name: String, description: String, amount: Integer }>]
+  #
   class RateEstimate
     attr_accessor :origin, :destination, :package_rates,
                 :carrier, :service_name, :service_code, :description,
@@ -82,7 +86,7 @@ module ActiveShipping
                 :currency, :negotiated_rate, :insurance_price,
                 :estimate_reference, :expires_at, :pickup_time,
                 :compare_price, :phone_required, :delivery_category,
-                :shipment_options
+                :shipment_options, :charge_items
 
     def initialize(origin, destination, carrier, service_name, options = {})
       self.origin, self.destination, self.carrier, self.service_name = origin, destination, carrier, service_name
@@ -107,6 +111,7 @@ module ActiveShipping
       self.insurance_price = options[:insurance_price]
       self.delivery_category = options[:delivery_category]
       self.shipment_options = options[:shipment_options] || []
+      self.charge_items = options[:charge_items] || []
     end
 
     # The total price of the shipments in cents.

--- a/test/unit/rate_estimate_test.rb
+++ b/test/unit/rate_estimate_test.rb
@@ -63,6 +63,28 @@ class RateEstimateTest < Minitest::Test
     assert_equal "local_delivery", est.delivery_category
   end
 
+  def test_charge_items_is_set
+    charge_items = [
+      {
+        group: "base_charge",
+        code: 'label',
+        name: "USPS Priority Mail label",
+        description: "USPS Priority Mail label to New York, NY, US",
+        amount: 14.64
+      },
+      {
+        group: "included_option",
+        code: 'tracking',
+        name: "Tracking",
+        description: "Free tracking",
+        amount: 0
+      }
+    ]
+    est = RateEstimate.new(@origin, @destination, @carrier, @service_name, @options.merge(charge_items: charge_items))
+
+    assert_equal charge_items, est.charge_items
+  end
+
   def test_delivery_date_pulls_from_delivery_range
     assert_equal [DateTime.parse("Fri 01 Jul 2016"), DateTime.parse("Sun 03 Jul 2016")], @rate_estimate.delivery_range
     assert_equal DateTime.parse("Sun 03 Jul 2016"), @rate_estimate.delivery_date


### PR DESCRIPTION
### Problem
Currently there is no way to detect which services provide included features, like insurance and tracking. There is `shipment_options` but these are used for options that the merchant might select on top of the included ones.

### Solution
Add a new attribute `price_details` that can be initialized with detailed informations on each item of a rate estimate.

@kmcphillips @jonathankwok @mdking 