### PR TITLE
Handle a potential missing 'required' UPS element in TrackResponse

### DIFF
--- a/lib/active_shipping/carriers/ups.rb
+++ b/lib/active_shipping/carriers/ups.rb
@@ -848,8 +848,8 @@ module ActiveShipping
         activities = first_package.css('> Activity')
         unless activities.empty?
           shipment_events = activities.map do |activity|
-            description = activity.at('Status/StatusType/Description').text
-            type_code = activity.at('Status/StatusType/Code').text
+            description = activity.at('Status/StatusType/Description').try(:text)
+            type_code = activity.at('Status/StatusType/Code').try(:text)
             zoneless_time = parse_ups_datetime(:time => activity.at('Time'), :date => activity.at('Date'))
             location = location_from_address_node(activity.at('ActivityLocation/Address'))
             ShipmentEvent.new(description, zoneless_time, location, description, type_code)


### PR DESCRIPTION
## About
![image](https://cloud.githubusercontent.com/assets/4521864/20444324/9bb5f4da-ad9e-11e6-9069-10092470514f.png)
From their documentation

![image](https://cloud.githubusercontent.com/assets/4521864/20444331/a34bd728-ad9e-11e6-9c31-5fcde9d1a43f.png)
From their documentation

```xml
<Status>
  <StatusType>
    <Code>I</Code>
  </StatusType>
  <StatusCode>
    <Code>DS</Code>
  </StatusCode>
</Status>
```
Something they actually returned.


@mdking @RichardBlair 