### PR TITLE
[ci skip] Fix documentation typos

### DIFF
--- a/lib/active_shipping/rate_estimate.rb
+++ b/lib/active_shipping/rate_estimate.rb
@@ -6,21 +6,21 @@ module ActiveShipping
   #   The origin of the shipment
   #   @return [ActiveShipping::Location]
   #
-  # @!attribute desination
-  #   The desination of the shipment
+  # @!attribute destination
+  #   The destination of the shipment
   #   @return [ActiveShipping::Location]
   #
   # @!attribute package_rates
-  #   A list of rates for all the packages in the shipment.
+  #   A list of rates for all the packages in the shipment
   #   @return [Array<{:rate => Integer, :package => ActiveShipping::Package}>]
   #
   # @!attribute carrier
-  #   The name of the carrier (i.e. , e.g. 'USPS', 'FedEx')
+  #   The name of the carrier (e.g. 'USPS', 'FedEx')
   #   @return [String]
   #   @see ActiveShipping::Carrier.name
   #
   # @!attribute service_name
-  #   The name of the shipping service (e.g. `"First Class Ground"`)
+  #   The name of the shipping service (e.g. 'First Class Ground')
   #   @return [String]
   #
   # @!attribute service_code
@@ -28,26 +28,26 @@ module ActiveShipping
   #   @return [String]
   #
   # @!attribute description
-  #   Public description of the shipping service (e.g. "2 days delivery")
+  #   Public description of the shipping service (e.g. '2 days delivery')
   #   @return [String]
   #
   # @!attribute shipping_date
   #   The date on which the shipment will be expected. Normally, this means that the
-  #   delivery date range can only pe prmoised if the shipment is handed over on or
+  #   delivery date range can only be promised if the shipment is handed over on or
   #   before this date.
   #   @return [Date]
   #
   # @!attribute delivery_date
-  #   The date on which the shipment will be delivered. This is usually only availablee
-  #   for express shipments; in order cases a {#delivery_range} is given instead.
+  #   The date on which the shipment will be delivered. This is usually only available
+  #   for express shipments; in other cases a {#delivery_range} is given instead.
   #   @return [Date]
   #
   # @!attribute delivery_range
-  #   The minimum and maximum date of when the shipment is expected to be delivered.
+  #   The minimum and maximum date of when the shipment is expected to be delivered
   #   @return [Array<Date>]
   #
   # @!attribute currency
-  #   ISO4217 currency code of the quoted rate estimates, e.g. `CAD`, `EUR`, or `USD`.
+  #   ISO4217 currency code of the quoted rate estimates (e.g. `CAD`, `EUR`, or `USD`)
   #   @return [String]
   #   @see http://en.wikipedia.org/wiki/ISO_4217
   #
@@ -60,11 +60,11 @@ module ActiveShipping
   #   @return [Integer]
   #
   # @!attribute phone_required
-  #   Specifies if a phone number is required for the shipping rate.
+  #   Specifies if a phone number is required for the shipping rate
   #   @return [Boolean]
   #
   # @!attribute insurance_price
-  #   The price of insurance in cents.
+  #   The price of insurance in cents
   #   @return [Integer]
   #
   # @!attribute delivery_category
@@ -184,7 +184,7 @@ module ActiveShipping
     private
 
     # Returns a Date object for a given input
-    # @param [String, Date, Time, DateTime, ...] The object to infer a date from.
+    # @param date [String, Date, Time, DateTime, ...] The object to infer a date from.
     # @return [Date, nil] The Date object absed on the input, or `nil` if no date
     #   could be determined.
     def date_for(date)

--- a/lib/active_shipping/rate_response.rb
+++ b/lib/active_shipping/rate_response.rb
@@ -2,9 +2,9 @@ module ActiveShipping
 
   # The `RateResponse` object is returned by the {ActiveShipping::Carrier#find_rates}
   # call. The most important method is {#rates}, which will return a list of possible
-  # shipping options with ane stiated price.
+  # shipping options with an estimated price.
   #
-  # @note Some carriers provide more information that others, so not all attributes
+  # @note Some carriers provide more information than others, so not all attributes
   #   will be set, depending on what carrier you are using.
   #
   # @!attribute rates


### PR DESCRIPTION
Fix some typos in documentation for RateResponse & RateEstimate. Also
make minor cosmetic doc changes for consistency.