### PR TITLE
Handle UPS tracking responses with no status code

### DIFF
--- a/lib/active_shipping/carriers/ups.rb
+++ b/lib/active_shipping/carriers/ups.rb
@@ -816,16 +816,18 @@ module ActiveShipping
         # Build status hash
         status_nodes = first_package.css('Activity > Status > StatusType')
 
-        # Prefer a delivery node
-        status_node = status_nodes.detect { |x| x.at('Code').text == 'D' }
-        status_node ||= status_nodes.first
+        if status_nodes.present?
+          # Prefer a delivery node
+          status_node = status_nodes.detect { |x| x.at('Code').text == 'D' }
+          status_node ||= status_nodes.first
 
-        status_code = status_node.at('Code').text
-        status_description = status_node.at('Description').text
-        status = TRACKING_STATUS_CODES[status_code]
+          status_code = status_node.at('Code').try(:text)
+          status_description = status_node.at('Description').try(:text)
+          status = TRACKING_STATUS_CODES[status_code]
 
-        if status_description =~ /out.*delivery/i
-          status = :out_for_delivery
+          if status_description =~ /out.*delivery/i
+            status = :out_for_delivery
+          end
         end
 
         origin, destination = %w(Shipper ShipTo).map do |location|

--- a/test/fixtures/xml/ups/no_status_node_success.xml
+++ b/test/fixtures/xml/ups/no_status_node_success.xml
@@ -1,0 +1,34 @@
+<?xml version="1.0"?>
+<TrackResponse>
+  <Response>
+    <ResponseStatusCode>1</ResponseStatusCode>
+    <ResponseStatusDescription>Success</ResponseStatusDescription>
+  </Response>
+  <Shipment>
+    <Shipper/>
+    <ShipmentWeight>
+      <UnitOfMeasurement>
+        <Code>LBS</Code>
+      </UnitOfMeasurement>
+      <Weight>0.00</Weight>
+    </ShipmentWeight>
+    <Service>
+      <Code>YW</Code>
+      <Description>UPS SUREPOST</Description>
+    </Service>
+    <ShipmentIdentificationNumber>1Z5FX0076803466397</ShipmentIdentificationNumber>
+    <DeliveryDateUnavailable>
+      <Type>Scheduled Delivery</Type>
+      <Description>Scheduled Delivery Date is not currently available, please try back later</Description>
+    </DeliveryDateUnavailable>
+    <Package>
+      <TrackingNumber>1Z5FX0076803466397</TrackingNumber>
+      <PackageWeight>
+        <UnitOfMeasurement>
+          <Code>LBS</Code>
+        </UnitOfMeasurement>
+        <Weight>0.00</Weight>
+      </PackageWeight>
+    </Package>
+  </Shipment>
+</TrackResponse>

--- a/test/unit/carriers/ups_test.rb
+++ b/test/unit/carriers/ups_test.rb
@@ -166,6 +166,13 @@ class UPSTest < Minitest::Test
     assert_equal Time.parse('2015-01-29 00:00:00 UTC'), response.scheduled_delivery_date
   end
 
+  def test_find_tracking_info_should_handle_no_status_node
+    @carrier.expects(:commit).returns(xml_fixture('ups/no_status_node_success'))
+    response = @carrier.find_tracking_info('1Z5FX0076803466397')
+    assert_equal 'Success', response.params.fetch("Response").fetch("ResponseStatusDescription")
+    assert_empty response.shipment_events
+  end
+
   def test_response_parsing_an_oversize_package
     mock_response = xml_fixture('ups/package_exceeds_maximum_length')
     @carrier.expects(:commit).returns(mock_response)


### PR DESCRIPTION
## About
Some `TrackResponse`s from UPS don't have a status node, but are considered "Successful" responses. The current implementation expects all successful responses to have a status node but that's not true in all cases - the XML fixture I added is a real-world example of a response that has no status node but is considered a successful response.

This PR prevents the `status_code.at('Code').text` from failing on the `.text` call by not reading through the non-existent status nodes. 

What this means is that at the end when building `TrackingResponse`, the `@status` field will be empty; this is preferable to raising without returning anything so this is an acceptable side-effect.

@benwah @thegedge @iWuzHere 