### PR TITLE
Sort FedEx tracking response error codes between retryable and not

### DIFF
--- a/test/fixtures/xml/fedex/tracking_response_failure_code_9080.xml
+++ b/test/fixtures/xml/fedex/tracking_response_failure_code_9080.xml
@@ -1,0 +1,51 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<TrackReply xmlns="http://fedex.com/ws/track/v7" xmlns:SOAP-ENV="http://schemas.xmlsoap.org/soap/envelope/">
+  <HighestSeverity>SUCCESS</HighestSeverity>
+  <Notifications>
+    <Severity>SUCCESS</Severity>
+    <Source>trck</Source>
+    <Code>0</Code>
+    <Message>Request was successfully processed.</Message>
+    <LocalizedMessage>Request was successfully processed.</LocalizedMessage>
+  </Notifications>
+  <TransactionDetail>
+    <CustomerTransactionId>ActiveShipping</CustomerTransactionId>
+  </TransactionDetail>
+  <Version>
+    <ServiceId>trck</ServiceId>
+    <Major>7</Major>
+    <Intermediate>0</Intermediate>
+    <Minor>0</Minor>
+  </Version>
+  <CompletedTrackDetails>
+    <HighestSeverity>SUCCESS</HighestSeverity>
+    <Notifications>
+      <Severity>SUCCESS</Severity>
+      <Source>trck</Source>
+      <Code>0</Code>
+      <Message>Request was successfully processed.</Message>
+      <LocalizedMessage>Request was successfully processed.</LocalizedMessage>
+    </Notifications>
+    <DuplicateWaybill>false</DuplicateWaybill>
+    <MoreData>false</MoreData>
+    <TrackDetails>
+      <Notification>
+        <Severity>FAILURE</Severity>
+        <Source>trck</Source>
+        <Code>9080</Code>
+        <Message>Sorry, we are unable to process your tracking request.  Please contact Customer Service at 1.800.Go.FedEx(R) 800.463.3339.</Message>
+        <LocalizedMessage>Sorry, we are unable to process your tracking request.  Please contact Customer Service at 1.800.Go.FedEx(R) 800.463.3339.</LocalizedMessage>
+      </Notification>
+      <StatusDetail>
+        <Location>
+          <Residential>false</Residential>
+        </Location>
+      </StatusDetail>
+      <PackageSequenceNumber>0</PackageSequenceNumber>
+      <PackageCount>0</PackageCount>
+      <DeliveryAttempts>0</DeliveryAttempts>
+      <TotalUniqueAddressCountInConsolidation>0</TotalUniqueAddressCountInConsolidation>
+      <RedirectToHoldEligibility>INELIGIBLE</RedirectToHoldEligibility>
+    </TrackDetails>
+  </CompletedTrackDetails>
+</TrackReply>

--- a/test/unit/carriers/fedex_test.rb
+++ b/test/unit/carriers/fedex_test.rb
@@ -327,15 +327,27 @@ class FedExTest < Minitest::Test
     end
   end
 
-  def test_response_failure_code_9045
+  def test_response_transient_failure
     mock_response = xml_fixture('fedex/tracking_response_failure_code_9045')
+    @carrier.expects(:commit).returns(mock_response)
+
+    error = assert_raises(ActiveShipping::ShipmentNotFound) do
+      @carrier.find_tracking_info('123456789013')
+    end
+
+    msg = 'Sorry, we are unable to process your tracking request.  Please retry later, or contact Customer Service at 1.800.Go.FedEx(R) 800.463.3339.'
+    assert_equal msg, error.message
+  end
+
+  def test_response_terminal_failure
+    mock_response = xml_fixture('fedex/tracking_response_failure_code_9080')
     @carrier.expects(:commit).returns(mock_response)
 
     error = assert_raises(ActiveShipping::ResponseContentError) do
       @carrier.find_tracking_info('123456789013')
     end
 
-    msg = 'Sorry, we are unable to process your tracking request.  Please retry later, or contact Customer Service at 1.800.Go.FedEx(R) 800.463.3339.'
+    msg = 'Sorry, we are unable to process your tracking request.  Please contact Customer Service at 1.800.Go.FedEx(R) 800.463.3339.'
     assert_equal msg, error.message
   end
 


### PR DESCRIPTION
Resource: https://www.fedex.com/us/developer/WebHelp/ws/2014/dvg/WS_DVG_WebHelp/index.htm#Appendix_O_Error_Code_Messages.htm

## Summary
Error codes are more extensive than known in FedEx, and for some errors, they were continuing past the error code check because they weren't known in the `case`. From the resource, I sorted the tracking errors (9xxx) between transient and non-transient, on the basis of whether the message contains "`Please retry later`" or not. 

This strategy aligns with what I've seen with existing numbers (e.g. 9080 is the error returned when I tried to track something with code `BadTrackingCode`, and the error response doesn't prompt a retry.)

As for the error classes being returned, I'm maintaining the current return pattern; `ShipmentNotFound` for transient errors, and `ResponseContentError` otherwise. Not great, but that's part of a larger scale rework coming later.

@iWuzHere @kmcphillips 