### PR TITLE
Use gemfiles/*.gemfile structure

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,23 +9,23 @@ rvm:
 - "2.3.1"
 
 gemfile:
-- Gemfile.activesupport32
-- Gemfile.activesupport40
-- Gemfile.activesupport41
-- Gemfile.activesupport42
-- Gemfile.activesupport50
-- Gemfile.activesupport_master
+- gemfiles/activesupport32.gemfile
+- gemfiles/activesupport40.gemfile
+- gemfiles/activesupport41.gemfile
+- gemfiles/activesupport42.gemfile
+- gemfiles/activesupport50.gemfile
+- gemfiles/activesupport_master.gemfile
 
 matrix:
   exclude:
     - rvm: "2.0"
-      gemfile: Gemfile.activesupport50
+      gemfile: gemfiles/activesupport50.gemfile
     - rvm: "2.0"
-      gemfile: Gemfile.activesupport_master
+      gemfile: gemfiles/activesupport_master.gemfile
     - rvm: "2.1"
-      gemfile: Gemfile.activesupport50
+      gemfile: gemfiles/activesupport50.gemfile
     - rvm: "2.1"
-      gemfile: Gemfile.activesupport_master
+      gemfile: gemfiles/activesupport_master.gemfile
 
 env:
   global:

--- a/gemfiles/activesupport32.gemfile
+++ b/gemfiles/activesupport32.gemfile
@@ -1,5 +1,6 @@
 source "https://rubygems.org"
-gemspec
+
+gemspec path: '..'
 
 gem 'activesupport', '~> 3.2.0'
 gem 'tzinfo'

--- a/gemfiles/activesupport40.gemfile
+++ b/gemfiles/activesupport40.gemfile
@@ -1,4 +1,5 @@
 source "https://rubygems.org"
-gemspec
+
+gemspec path: '..'
 
 gem 'activesupport', '~> 4.0.0'

--- a/gemfiles/activesupport41.gemfile
+++ b/gemfiles/activesupport41.gemfile
@@ -1,4 +1,5 @@
 source "https://rubygems.org"
-gemspec
+
+gemspec path: '..'
 
 gem 'activesupport', '~> 4.1.0'

--- a/gemfiles/activesupport42.gemfile
+++ b/gemfiles/activesupport42.gemfile
@@ -1,4 +1,5 @@
 source "https://rubygems.org"
-gemspec
+
+gemspec path: '..'
 
 gem 'activesupport', '~> 4.2.0'

--- a/gemfiles/activesupport50.gemfile
+++ b/gemfiles/activesupport50.gemfile
@@ -1,5 +1,6 @@
 source "https://rubygems.org"
-gemspec
+
+gemspec path: '..'
 
 gem 'activesupport', '~> 5.0.0'
 gem 'active_utils', '~> 3.2.2'

--- a/gemfiles/activesupport_master.gemfile
+++ b/gemfiles/activesupport_master.gemfile
@@ -1,4 +1,5 @@
 source "https://rubygems.org"
-gemspec
+
+gemspec path: '..'
 
 gem 'activesupport', github: 'rails/rails'


### PR DESCRIPTION
@thegedge @jonathankwok 

Functional noop.

Moves the gemfiles into a folder structure, and with the `.gemfile` extension which most editors and things understand better. Just code quality and readability cleanup.