### PR TITLE
Clean up test output and fix warnings

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -6,6 +6,7 @@ Rake::TestTask.new(:test) do |t|
   t.libs << "test"
   t.pattern = 'test/**/*_test.rb'
   t.verbose = true
+  t.warning = false
 end
 
 namespace :test do
@@ -14,6 +15,7 @@ namespace :test do
     t.libs << "test"
     t.pattern = 'test/unit/**/*_test.rb'
     t.verbose = true
+    t.warning = false
   end
 
   desc "Run functional remote tests"
@@ -21,6 +23,7 @@ namespace :test do
     t.libs << "test"
     t.pattern = 'test/remote/*_test.rb'
     t.verbose = true
+    t.warning = false
   end
 end
 

--- a/lib/active_shipping/carriers/canada_post_pws.rb
+++ b/lib/active_shipping/carriers/canada_post_pws.rb
@@ -1,6 +1,6 @@
 module ActiveShipping
   class CanadaPostPWS < Carrier
-    
+
     cattr_reader :name
     @@name = "Canada Post PWS"
 
@@ -569,13 +569,13 @@ module ActiveShipping
 
     def tracking_url(pin)
       case pin.length
-        when 12, 13, 16
-          endpoint + "vis/track/pin/%s/detail" % pin
-        when 15
-          endpoint + "vis/track/dnc/%s/detail" % pin
-        else
-          raise InvalidPinFormatError
-        end
+      when 12, 13, 16
+        "#{endpoint}vis/track/pin/#{pin}/detail"
+      when 15
+        "#{endpoint}vis/track/dnc/#{pin}/detail"
+      else
+        raise InvalidPinFormatError
+      end
     end
 
     def create_shipment_url(options)

--- a/test/remote/fedex_test.rb
+++ b/test/remote/fedex_test.rb
@@ -225,7 +225,7 @@ class RemoteFedExTest < Minitest::Test
     assert_equal "Delivered", response.status_description
 
     assert_equal Time.parse('Fri, 03 Jan 2014'), response.ship_time
-    assert_equal nil, response.scheduled_delivery_date
+    assert_nil response.scheduled_delivery_date
     assert_equal Time.parse('2014-01-09 18:31:00 +0000'), response.actual_delivery_date
 
     origin_address = ActiveShipping::Location.new(
@@ -261,7 +261,7 @@ class RemoteFedExTest < Minitest::Test
     assert_equal 'OC', response.shipment_events.second.type_code
     assert_equal 'AR', response.shipment_events.third.type_code
     assert_nil response.actual_delivery_date
-    assert_equal nil, response.scheduled_delivery_date
+    assert_nil response.scheduled_delivery_date
   end
 
   def test_find_tracking_info_for_in_transit_shipment_2
@@ -275,8 +275,8 @@ class RemoteFedExTest < Minitest::Test
     assert_equal "Arrived at FedEx location", response.status_description
 
     assert_equal Time.parse('Fri, 03 Jan 2014'), response.ship_time
-    assert_equal nil, response.scheduled_delivery_date
-    assert_equal nil, response.actual_delivery_date
+    assert_nil response.scheduled_delivery_date
+    assert_nil response.actual_delivery_date
 
     origin_address = ActiveShipping::Location.new(
       city: 'CAMBRIDGE',
@@ -391,7 +391,7 @@ class RemoteFedExTest < Minitest::Test
 
     assert response.success?
     refute_empty response.labels
-    data = response.labels.first.img_data 
+    data = response.labels.first.img_data
     refute_empty data
     assert data[0...4] == '%PDF'
   end

--- a/test/unit/carriers/canada_post_pws_tracking_test.rb
+++ b/test/unit/carriers/canada_post_pws_tracking_test.rb
@@ -112,7 +112,7 @@ class CanadaPostPwsTrackingTest < Minitest::Test
 
     assert_equal CPPWSTrackingResponse, response.class
     assert_equal "Expedited Parcels", response.service_name
-    assert_equal nil, response.expected_date
+    assert_nil response.expected_date
     assert_equal "8213295707205355", response.tracking_number
     assert_equal 1, response.shipment_events.size
     assert_equal response.origin.city, "MAPLE"
@@ -130,7 +130,7 @@ class CanadaPostPwsTrackingTest < Minitest::Test
     response = @cp.find_tracking_info('1371134583769923', {})
 
     assert_equal false, response.delivered?
-    assert_equal nil, response.actual_delivery_time
+    assert_nil response.actual_delivery_time
   end
 
   def test_parse_tracking_response_shipment_events

--- a/test/unit/carriers/fedex_test.rb
+++ b/test/unit/carriers/fedex_test.rb
@@ -379,7 +379,7 @@ class FedExTest < Minitest::Test
     refute response.exception?
 
     assert_equal Date.parse('2013-12-30'), response.ship_time
-    assert_equal nil, response.scheduled_delivery_date
+    assert_nil response.scheduled_delivery_date
     assert_equal Time.parse('2014-01-02T18:23:29Z'), response.actual_delivery_date
 
     origin_address = ActiveShipping::Location.new(
@@ -417,7 +417,7 @@ class FedExTest < Minitest::Test
     assert_equal 'AR', response.shipment_events.third.type_code
     assert_equal 'Delivered', response.latest_event.name
     assert_equal 'DL', response.latest_event.type_code
-    assert_equal nil, response.delivery_signature
+    assert_nil response.delivery_signature
   end
 
   def test_state_degrades_to_unknown
@@ -449,13 +449,13 @@ class FedExTest < Minitest::Test
     assert_equal :in_transit, response.status
     assert_equal 'IT', response.status_code
     assert_equal "Package available for clearance", response.status_description
-    assert_equal nil, response.delivery_signature
+    assert_nil response.delivery_signature
 
     assert_equal Time.parse('2014-11-17T22:39:00+11:00'), response.ship_time
-    assert_equal nil, response.scheduled_delivery_date
-    assert_equal nil, response.actual_delivery_date
+    assert_nil response.scheduled_delivery_date
+    assert_nil response.actual_delivery_date
 
-    assert_equal nil, response.origin
+    assert_nil response.origin
 
     destination_address = ActiveShipping::Location.new(
       city: 'GRAFTON',
@@ -481,8 +481,8 @@ class FedExTest < Minitest::Test
     assert_equal "Unable to deliver", response.status_description
 
     assert_equal Date.parse('2014-01-27'), response.ship_time
-    assert_equal nil, response.scheduled_delivery_date
-    assert_equal nil, response.actual_delivery_date
+    assert_nil response.scheduled_delivery_date
+    assert_nil response.actual_delivery_date
 
     origin_address = ActiveShipping::Location.new(
       city: 'AUSTIN',

--- a/test/unit/carriers/kunaki_test.rb
+++ b/test/unit/carriers/kunaki_test.rb
@@ -43,7 +43,7 @@ class KunakiTest < Minitest::Test
 
     assert rate = response.rates.first
     assert_equal "USPS Priority Mail", rate.service_name
-    assert_equal nil, rate.service_code
+    assert_nil rate.service_code
     assert_equal "USPS", rate.carrier
     assert_equal 800, rate.total_price
     assert_equal ["UPS 2nd Day Air", "UPS Ground", "UPS Next Day Air Saver", "USPS Priority Mail"], response.rates.collect(&:service_name).sort

--- a/test/unit/carriers/stamps_test.rb
+++ b/test/unit/carriers/stamps_test.rb
@@ -68,7 +68,7 @@ class StampsTest < Minitest::Test
     assert_equal 'ActiveShipping::StampsPurchasePostageResponse', purchase_status.class.name
 
     assert_equal 'Success', purchase_status.purchase_status
-    assert_equal nil, purchase_status.transaction_id
+    assert_nil purchase_status.transaction_id
   end
 
   def test_validate_address

--- a/test/unit/carriers/usps_test.rb
+++ b/test/unit/carriers/usps_test.rb
@@ -160,13 +160,13 @@ class USPSTest < Minitest::Test
     # USPS API doesn't tell where it's going
     @carrier.expects(:commit).returns(@tracking_response)
     response = @carrier.find_tracking_info('9102901000462189604217', :test => true)
-    assert_equal response.destination, nil
+    assert_nil response.destination
   end
 
   def test_find_tracking_info_tracking_number
     @carrier.expects(:commit).returns(@tracking_response)
     response = @carrier.find_tracking_info('9102901000462189604217', :test => true)
-    assert_equal response.tracking_number, '9102901000462189604217'
+    assert_equal '9102901000462189604217', response.tracking_number
   end
 
   def test_find_tracking_info_should_have_correct_status

--- a/test/unit/external_return_label_request_test.rb
+++ b/test/unit/external_return_label_request_test.rb
@@ -118,24 +118,24 @@ class ExternalReturnLabelRequestTest < Minitest::Test
   end
 
   def test_sanitize
-    assert_equal @external_request_label_req.send(:sanitize,'   ').length, 0
-    assert_equal @external_request_label_req.send(:sanitize, 'some string   '), 'some string'
-    assert_equal @external_request_label_req.send(:sanitize, {}), nil
-    assert_equal @external_request_label_req.send(:sanitize, nil), nil
-    assert_equal @external_request_label_req.send(:sanitize, nil), nil
-    assert_equal @external_request_label_req.send(:sanitize, []), nil
-    assert_equal @external_request_label_req.send(:sanitize, (1..100).to_a.join("_")).size, ExternalReturnLabelRequest::CAP_STRING_LEN
+    assert_equal "", @external_request_label_req.send(:sanitize,'   ')
+    assert_equal 'some string', @external_request_label_req.send(:sanitize, 'some string   ')
+    assert_nil @external_request_label_req.send(:sanitize, {})
+    assert_nil @external_request_label_req.send(:sanitize, nil)
+    assert_nil @external_request_label_req.send(:sanitize, nil)
+    assert_nil @external_request_label_req.send(:sanitize, [])
+    assert_equal ExternalReturnLabelRequest::CAP_STRING_LEN, @external_request_label_req.send(:sanitize, (1..100).to_a.join("_")).size
   end
 
   def test_to_bool
-    assert_equal @external_request_label_req.send(:to_bool, 'yes'), true
-    assert_equal @external_request_label_req.send(:to_bool, 'true'), true
-    assert_equal @external_request_label_req.send(:to_bool, true), true
-    assert_equal @external_request_label_req.send(:to_bool, '1'), true
-    assert_equal @external_request_label_req.send(:to_bool, '0'), false
-    assert_equal @external_request_label_req.send(:to_bool, 'false'), false
-    assert_equal @external_request_label_req.send(:to_bool, false), false
-    assert_equal @external_request_label_req.send(:to_bool, nil, false), false
+    assert_equal true, @external_request_label_req.send(:to_bool, 'yes')
+    assert_equal true, @external_request_label_req.send(:to_bool, 'true')
+    assert_equal true, @external_request_label_req.send(:to_bool, true)
+    assert_equal true, @external_request_label_req.send(:to_bool, '1')
+    assert_equal false, @external_request_label_req.send(:to_bool, '0')
+    assert_equal false, @external_request_label_req.send(:to_bool, 'false')
+    assert_equal false, @external_request_label_req.send(:to_bool, false)
+    assert_equal false, @external_request_label_req.send(:to_bool, nil, false)
   end
 
   def test_validate_range
@@ -176,8 +176,8 @@ class ExternalReturnLabelRequestTest < Minitest::Test
     assert_raises(USPSValidationError) do
       @external_request_label_req.send(:validate_email, '    ', __method__)
     end
-    assert_equal @external_request_label_req.send(:validate_email, 'no-reply@example.com', __method__), 'no-reply@example.com'
-    assert_equal @external_request_label_req.send(:validate_email, '  no-reply@example.com  ', __method__), 'no-reply@example.com'
+    assert_equal 'no-reply@example.com', @external_request_label_req.send(:validate_email, 'no-reply@example.com', __method__)
+    assert_equal 'no-reply@example.com', @external_request_label_req.send(:validate_email, '  no-reply@example.com  ', __method__)
   end
 
   def test_tag_required


### PR DESCRIPTION
Test output is polluted with so many warnings.

<img width="1141" alt="kevin_kevify____source_active_shipping__zsh_" src="https://cloud.githubusercontent.com/assets/84159/20862807/5ba8086a-b983-11e6-98c6-8159000a9c8c.png">

This reduces the extra verbose mode, and fixes a bunch of the ones that were still logged.

<img width="782" alt="kevin_kevify____source_active_shipping__zsh_" src="https://cloud.githubusercontent.com/assets/84159/20862816/769bf690-b983-11e6-8115-9fd6538aa63d.png">
