### PR TITLE
Drop support for Rails below 4.2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,29 +3,13 @@ script: bundle exec rake test
 sudo: false
 
 rvm:
-- "2.0"
-- "2.1"
 - "2.2.2"
 - "2.3.1"
 
 gemfile:
-- gemfiles/activesupport32.gemfile
-- gemfiles/activesupport40.gemfile
-- gemfiles/activesupport41.gemfile
 - gemfiles/activesupport42.gemfile
 - gemfiles/activesupport50.gemfile
 - gemfiles/activesupport_master.gemfile
-
-matrix:
-  exclude:
-    - rvm: "2.0"
-      gemfile: gemfiles/activesupport50.gemfile
-    - rvm: "2.0"
-      gemfile: gemfiles/activesupport_master.gemfile
-    - rvm: "2.1"
-      gemfile: gemfiles/activesupport50.gemfile
-    - rvm: "2.1"
-      gemfile: gemfiles/activesupport_master.gemfile
 
 env:
   global:

--- a/active_shipping.gemspec
+++ b/active_shipping.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |s|
   s.require_path  = "lib"
 
   s.add_dependency("quantified", "~> 1.0.1")
-  s.add_dependency("activesupport", ">= 3.2", "< 5.1.0")
+  s.add_dependency("activesupport", ">= 4.2", "< 5.1.0")
   s.add_dependency("active_utils", "~> 3.2.0")
   s.add_dependency("nokogiri", ">= 1.6")
 

--- a/gemfiles/activesupport32.gemfile
+++ b/gemfiles/activesupport32.gemfile
@@ -1,6 +1,0 @@
-source "https://rubygems.org"
-
-gemspec path: '..'
-
-gem 'activesupport', '~> 3.2.0'
-gem 'tzinfo'

--- a/gemfiles/activesupport40.gemfile
+++ b/gemfiles/activesupport40.gemfile
@@ -1,5 +1,0 @@
-source "https://rubygems.org"
-
-gemspec path: '..'
-
-gem 'activesupport', '~> 4.0.0'

--- a/gemfiles/activesupport41.gemfile
+++ b/gemfiles/activesupport41.gemfile
@@ -1,5 +1,0 @@
-source "https://rubygems.org"
-
-gemspec path: '..'
-
-gem 'activesupport', '~> 4.1.0'


### PR DESCRIPTION
For version 2.0, we are dropping support for any rails version that is no longer maintained.

Closes #426

@thegedge @mdking @jonathankwok 