### PR TITLE
UTF-8 by default so comments no longer needed

### DIFF
--- a/lib/active_shipping/carriers/correios.rb
+++ b/lib/active_shipping/carriers/correios.rb
@@ -1,5 +1,3 @@
-# -*- encoding utf-8 -*-
-
 module ActiveShipping
   class Correios < Carrier
 

--- a/lib/active_shipping/carriers/ups.rb
+++ b/lib/active_shipping/carriers/ups.rb
@@ -1,5 +1,3 @@
-# -*- encoding: utf-8 -*-
-
 module ActiveShipping
   class UPS < Carrier
     self.retry_safe = true

--- a/lib/active_shipping/carriers/usps.rb
+++ b/lib/active_shipping/carriers/usps.rb
@@ -1,5 +1,3 @@
-# -*- encoding: utf-8 -*-
-
 module ActiveShipping
   # After getting an API login from USPS (looks like '123YOURNAME456'),
   # run the following test:

--- a/lib/active_shipping/external_return_label_request.rb
+++ b/lib/active_shipping/external_return_label_request.rb
@@ -1,8 +1,5 @@
-# -*- coding: utf-8 -*-
 module ActiveShipping
-
   class ExternalReturnLabelRequest
-
     CAP_STRING_LEN = 100
 
     USPS_EMAIL_REGEX = /^([a-zA-Z0-9_\-\.]+)@((\[[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.)|(([a-zA-Z0-9\-]+\.)+))([a-zA-Z]{2,4}|[0-9]{1,3})(\]?)$/
@@ -416,6 +413,5 @@ module ActiveShipping
         raise USPSValidationError, "'#{v}' is not a valid e-mail in #{meth}"
       end
     end
-
   end
 end

--- a/test/remote/canada_post_pws_platform_test.rb
+++ b/test/remote/canada_post_pws_platform_test.rb
@@ -1,5 +1,3 @@
-# encoding: utf-8
-
 require 'test_helper'
 
 # All remote tests require Canada Post development environment credentials

--- a/test/unit/carriers/correios_test.rb
+++ b/test/unit/carriers/correios_test.rb
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 require "test_helper"
 
 class CorreiosTest < Minitest::Test


### PR DESCRIPTION
@thegedge @mdking @jonathankwok 

These UTF-8 encoding strings are no longer necessary as this is the default in ruby now.