### PR TITLE
Required as part of activesupport/all

### DIFF
--- a/lib/active_shipping/carriers/australia_post.rb
+++ b/lib/active_shipping/carriers/australia_post.rb
@@ -1,5 +1,3 @@
-require 'active_support/core_ext/object/to_query'
-
 module ActiveShipping
   class AustraliaPost < Carrier
     cattr_reader :name

--- a/lib/active_shipping/carriers/new_zealand_post.rb
+++ b/lib/active_shipping/carriers/new_zealand_post.rb
@@ -1,5 +1,3 @@
-require 'active_support/core_ext/object/to_query'
-
 module ActiveShipping
   class NewZealandPost < Carrier
     cattr_reader :name


### PR DESCRIPTION
These come in as part of the `require 'actives_support/all'`  which is line 1 of `active_shipping.rb`

@jonathankwok @mdking @thegedge 