### PR TITLE
Use minitest-reporters gem for nicer output

### DIFF
--- a/active_shipping.gemspec
+++ b/active_shipping.gemspec
@@ -24,6 +24,7 @@ Gem::Specification.new do |s|
   s.add_dependency("nokogiri", ">= 1.6")
 
   s.add_development_dependency("minitest")
+  s.add_development_dependency("minitest-reporters")
   s.add_development_dependency("rake")
   s.add_development_dependency("mocha", "~> 1")
   s.add_development_dependency("timecop")

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -1,6 +1,7 @@
 require 'bundler/setup'
 
 require 'minitest/autorun'
+require "minitest/reporters"
 require 'mocha/mini_test'
 require 'timecop'
 require 'business_time'
@@ -9,6 +10,8 @@ require 'active_shipping'
 require 'logger'
 require 'erb'
 require 'pry'
+
+Minitest::Reporters.use!
 
 # This makes sure that Minitest::Test exists when an older version of Minitest
 # (i.e. 4.x) is required by ActiveSupport.


### PR DESCRIPTION
Let's use `minitest-reporters` gem to give a cleaner output from tests, inline with most of our other apps too.

@jonathankwok @mdking @thegedge 

## Before

<img width="870" alt="kevin_kevify____source_active_shipping__zsh_" src="https://cloud.githubusercontent.com/assets/84159/20984115/fd0d0ee2-bc8c-11e6-80d4-7d69b5dc9985.png">

## After

<img width="874" alt="kevin_kevify____source_active_shipping__zsh__and___source_active_shipping_active_shipping_gemspec_ _active_shipping" src="https://cloud.githubusercontent.com/assets/84159/20984106/f2ef8dd6-bc8c-11e6-946d-09dde18548e9.png">
