### PR TITLE
Use ActiveSupport::TestCase globally

### DIFF
--- a/test/remote/australia_post_test.rb
+++ b/test/remote/australia_post_test.rb
@@ -1,6 +1,6 @@
 require 'test_helper'
 
-class RemoteAustraliaPostTest < Minitest::Test
+class RemoteAustraliaPostTest < ActiveSupport::TestCase
   include ActiveShipping::Test::Credentials
   include ActiveShipping::Test::Fixtures
 

--- a/test/remote/canada_post_pws_platform_test.rb
+++ b/test/remote/canada_post_pws_platform_test.rb
@@ -1,7 +1,7 @@
 require 'test_helper'
 
 # All remote tests require Canada Post development environment credentials
-class RemoteCanadaPostPWSPlatformTest < Minitest::Test
+class RemoteCanadaPostPWSPlatformTest < ActiveSupport::TestCase
   include ActiveShipping::Test::Credentials
   include ActiveShipping::Test::Fixtures
 

--- a/test/remote/canada_post_pws_test.rb
+++ b/test/remote/canada_post_pws_test.rb
@@ -1,6 +1,6 @@
 require 'test_helper'
 
-class RemoteCanadaPostPWSTest < Minitest::Test
+class RemoteCanadaPostPWSTest < ActiveSupport::TestCase
   # All remote tests require Canada Post development environment credentials
   include ActiveShipping::Test::Credentials
   include ActiveShipping::Test::Fixtures

--- a/test/remote/canada_post_test.rb
+++ b/test/remote/canada_post_test.rb
@@ -1,6 +1,6 @@
 require 'test_helper'
 
-class RemoteCanadaPostTest < Minitest::Test
+class RemoteCanadaPostTest < ActiveSupport::TestCase
   include ActiveShipping::Test::Credentials
 
   def setup

--- a/test/remote/correios_test.rb
+++ b/test/remote/correios_test.rb
@@ -1,7 +1,6 @@
 require 'test_helper'
 
-class RemoteCorreiosTest < Minitest::Test
-
+class RemoteCorreiosTest < ActiveSupport::TestCase
   def setup
     @carrier = Correios.new
 

--- a/test/remote/fedex_test.rb
+++ b/test/remote/fedex_test.rb
@@ -1,6 +1,6 @@
 require 'test_helper'
 
-class RemoteFedExTest < Minitest::Test
+class RemoteFedExTest < ActiveSupport::TestCase
   include ActiveShipping::Test::Credentials
   include ActiveShipping::Test::Fixtures
 

--- a/test/remote/kunaki_test.rb
+++ b/test/remote/kunaki_test.rb
@@ -1,6 +1,6 @@
 require 'test_helper'
 
-class RemoteKunakiTest < Minitest::Test
+class RemoteKunakiTest < ActiveSupport::TestCase
   include ActiveShipping::Test::Fixtures
 
   def setup

--- a/test/remote/new_zealand_post_test.rb
+++ b/test/remote/new_zealand_post_test.rb
@@ -1,6 +1,6 @@
 require 'test_helper'
 
-class RemoteNewZealandPostTest < Minitest::Test
+class RemoteNewZealandPostTest < ActiveSupport::TestCase
   include ActiveShipping::Test::Credentials
   include ActiveShipping::Test::Fixtures
 

--- a/test/remote/shipwire_test.rb
+++ b/test/remote/shipwire_test.rb
@@ -1,6 +1,6 @@
 require 'test_helper'
 
-class RemoteShipwireTest < Minitest::Test
+class RemoteShipwireTest < ActiveSupport::TestCase
   include ActiveShipping::Test::Credentials
   include ActiveShipping::Test::Fixtures
 

--- a/test/remote/stamps_test.rb
+++ b/test/remote/stamps_test.rb
@@ -1,6 +1,6 @@
 require 'test_helper'
 
-class RemoteStampsTest < Minitest::Test
+class RemoteStampsTest < ActiveSupport::TestCase
   include ActiveShipping::Test::Credentials
   include ActiveShipping::Test::Fixtures
 

--- a/test/remote/ups_surepost_test.rb
+++ b/test/remote/ups_surepost_test.rb
@@ -1,6 +1,6 @@
 require 'test_helper'
 
-class RemoteUPSSurepostTest < Minitest::Test
+class RemoteUPSSurepostTest < ActiveSupport::TestCase
   include ActiveShipping::Test::Credentials
   include ActiveShipping::Test::Fixtures
 

--- a/test/remote/ups_test.rb
+++ b/test/remote/ups_test.rb
@@ -1,6 +1,6 @@
 require 'test_helper'
 
-class RemoteUPSTest < Minitest::Test
+class RemoteUPSTest < ActiveSupport::TestCase
   include ActiveShipping::Test::Credentials
   include ActiveShipping::Test::Fixtures
 

--- a/test/remote/usps_returns_test.rb
+++ b/test/remote/usps_returns_test.rb
@@ -1,6 +1,6 @@
 require 'test_helper'
 
-class RemoteUSPSReturnsTest < Minitest::Test
+class RemoteUSPSReturnsTest < ActiveSupport::TestCase
   include ActiveShipping::Test::Credentials
   include ActiveShipping::Test::Fixtures
 

--- a/test/remote/usps_test.rb
+++ b/test/remote/usps_test.rb
@@ -1,6 +1,6 @@
 require 'test_helper'
 
-class RemoteUSPSTest < Minitest::Test
+class RemoteUSPSTest < ActiveSupport::TestCase
   include ActiveShipping::Test::Credentials
   include ActiveShipping::Test::Fixtures
 

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -13,14 +13,7 @@ require 'pry'
 
 Minitest::Reporters.use!
 
-# This makes sure that Minitest::Test exists when an older version of Minitest
-# (i.e. 4.x) is required by ActiveSupport.
-unless defined?(Minitest::Test)
-  Minitest::Test = MiniTest::Unit::TestCase
-end
-
-
-class Minitest::Test
+class ActiveSupport::TestCase
   include ActiveShipping
 end
 

--- a/test/unit/carrier_test.rb
+++ b/test/unit/carrier_test.rb
@@ -1,6 +1,6 @@
 require 'test_helper'
 
-class CarrierTest < Minitest::Test
+class CarrierTest < ActiveSupport::TestCase
   class ExampleCarrier < Carrier
     cattr_reader :name
     @@name = "Example Carrier"

--- a/test/unit/carriers/australia_post_test.rb
+++ b/test/unit/carriers/australia_post_test.rb
@@ -1,6 +1,6 @@
 require 'test_helper'
 
-class AustraliaPostTest < Minitest::Test
+class AustraliaPostTest < ActiveSupport::TestCase
   include ActiveShipping::Test::Fixtures
 
   def setup

--- a/test/unit/carriers/benchmark_test.rb
+++ b/test/unit/carriers/benchmark_test.rb
@@ -1,6 +1,6 @@
 require 'test_helper'
 
-class BenchmarkTest < Minitest::Test
+class BenchmarkTest < ActiveSupport::TestCase
   include ActiveShipping::Test::Fixtures
 
   def setup

--- a/test/unit/carriers/canada_post_pws_rating_test.rb
+++ b/test/unit/carriers/canada_post_pws_rating_test.rb
@@ -1,6 +1,6 @@
 require 'test_helper'
 
-class CanadaPostPwsRatingTest < Minitest::Test
+class CanadaPostPwsRatingTest < ActiveSupport::TestCase
   include ActiveShipping::Test::Fixtures
 
   def setup

--- a/test/unit/carriers/canada_post_pws_register_test.rb
+++ b/test/unit/carriers/canada_post_pws_register_test.rb
@@ -1,6 +1,6 @@
 require 'test_helper'
 
-class CanadaPostPwsRegisterTest < Minitest::Test
+class CanadaPostPwsRegisterTest < ActiveSupport::TestCase
   include ActiveShipping::Test::Fixtures
 
   def setup

--- a/test/unit/carriers/canada_post_pws_shipping_test.rb
+++ b/test/unit/carriers/canada_post_pws_shipping_test.rb
@@ -1,5 +1,5 @@
 require 'test_helper'
-class CanadaPostPwsShippingTest < Minitest::Test
+class CanadaPostPwsShippingTest < ActiveSupport::TestCase
   include ActiveShipping::Test::Fixtures
 
   def setup

--- a/test/unit/carriers/canada_post_pws_tracking_test.rb
+++ b/test/unit/carriers/canada_post_pws_tracking_test.rb
@@ -1,6 +1,6 @@
 require 'test_helper'
 
-class CanadaPostPwsTrackingTest < Minitest::Test
+class CanadaPostPwsTrackingTest < ActiveSupport::TestCase
   include ActiveShipping::Test::Fixtures
 
   def setup

--- a/test/unit/carriers/canada_post_test.rb
+++ b/test/unit/carriers/canada_post_test.rb
@@ -1,6 +1,6 @@
 require 'test_helper'
 
-class CanadaPostTest < Minitest::Test
+class CanadaPostTest < ActiveSupport::TestCase
   include ActiveShipping::Test::Fixtures
 
   def setup

--- a/test/unit/carriers/correios_test.rb
+++ b/test/unit/carriers/correios_test.rb
@@ -1,6 +1,6 @@
 require "test_helper"
 
-class CorreiosTest < Minitest::Test
+class CorreiosTest < ActiveSupport::TestCase
   include ActiveShipping::Test::Fixtures
 
   def setup

--- a/test/unit/carriers/fedex_test.rb
+++ b/test/unit/carriers/fedex_test.rb
@@ -1,6 +1,6 @@
 require 'test_helper'
 
-class FedExTest < Minitest::Test
+class FedExTest < ActiveSupport::TestCase
   include ActiveShipping::Test::Fixtures
 
   def setup

--- a/test/unit/carriers/kunaki_test.rb
+++ b/test/unit/carriers/kunaki_test.rb
@@ -1,6 +1,6 @@
 require 'test_helper'
 
-class KunakiTest < Minitest::Test
+class KunakiTest < ActiveSupport::TestCase
   include ActiveShipping::Test::Fixtures
 
   def setup

--- a/test/unit/carriers/new_zealand_post_test.rb
+++ b/test/unit/carriers/new_zealand_post_test.rb
@@ -1,6 +1,6 @@
 require "test_helper"
 
-class NewZealandPostTest < Minitest::Test
+class NewZealandPostTest < ActiveSupport::TestCase
   include ActiveShipping::Test::Fixtures
 
   def setup

--- a/test/unit/carriers/shipwire_test.rb
+++ b/test/unit/carriers/shipwire_test.rb
@@ -1,6 +1,6 @@
 require 'test_helper'
 
-class ShipwireTest < Minitest::Test
+class ShipwireTest < ActiveSupport::TestCase
   include ActiveShipping::Test::Fixtures
 
   def setup

--- a/test/unit/carriers/stamps_test.rb
+++ b/test/unit/carriers/stamps_test.rb
@@ -1,6 +1,6 @@
 require 'test_helper'
 
-class StampsTest < Minitest::Test
+class StampsTest < ActiveSupport::TestCase
   include ActiveShipping::Test::Fixtures
 
   def setup

--- a/test/unit/carriers/ups_test.rb
+++ b/test/unit/carriers/ups_test.rb
@@ -1,6 +1,6 @@
 require 'test_helper'
 
-class UPSTest < Minitest::Test
+class UPSTest < ActiveSupport::TestCase
   include ActiveShipping::Test::Fixtures
 
   def setup

--- a/test/unit/carriers/usps_returns_test.rb
+++ b/test/unit/carriers/usps_returns_test.rb
@@ -1,6 +1,6 @@
 require 'test_helper'
 
-class USPSReturnsTest < Minitest::Test
+class USPSReturnsTest < ActiveSupport::TestCase
   include ActiveShipping::Test::Fixtures
 
   attr_reader :carrier

--- a/test/unit/carriers/usps_test.rb
+++ b/test/unit/carriers/usps_test.rb
@@ -1,6 +1,6 @@
 require 'test_helper'
 
-class USPSTest < Minitest::Test
+class USPSTest < ActiveSupport::TestCase
   include ActiveShipping::Test::Fixtures
 
   def setup

--- a/test/unit/carriers_test.rb
+++ b/test/unit/carriers_test.rb
@@ -1,6 +1,6 @@
 require 'test_helper'
 
-class CarriersTest < Minitest::Test
+class CarriersTest < ActiveSupport::TestCase
 
   def test_get_usps_by_string
     assert_equal ActiveShipping::USPS, ActiveShipping::Carriers.find('usps')

--- a/test/unit/external_return_label_request_test.rb
+++ b/test/unit/external_return_label_request_test.rb
@@ -1,6 +1,6 @@
 require 'test_helper'
 
-class ExternalReturnLabelRequestTest < Minitest::Test
+class ExternalReturnLabelRequestTest < ActiveSupport::TestCase
   include ActiveShipping::Test::Fixtures
 
   def setup

--- a/test/unit/location_test.rb
+++ b/test/unit/location_test.rb
@@ -1,6 +1,6 @@
 require 'test_helper'
 
-class LocationTest < Minitest::Test
+class LocationTest < ActiveSupport::TestCase
   include ActiveShipping::Test::Fixtures
 
   def test_countries

--- a/test/unit/package_item_test.rb
+++ b/test/unit/package_item_test.rb
@@ -1,6 +1,6 @@
 require 'test_helper'
 
-class PackageItemTest < Minitest::Test
+class PackageItemTest < ActiveSupport::TestCase
   def setup
     @name = "Fancy Pants"
     @weight = 100

--- a/test/unit/package_test.rb
+++ b/test/unit/package_test.rb
@@ -1,6 +1,6 @@
 require 'test_helper'
 
-class PackageTest < Minitest::Test
+class PackageTest < ActiveSupport::TestCase
   def setup
     @weight = 100
     @dimensions = [5, 6, 7]

--- a/test/unit/rate_estimate_test.rb
+++ b/test/unit/rate_estimate_test.rb
@@ -1,6 +1,6 @@
 require 'test_helper'
 
-class RateEstimateTest < Minitest::Test
+class RateEstimateTest < ActiveSupport::TestCase
   def setup
     @origin      = {address1: "61A York St", city: "Ottawa", province: "ON", country: "Canada", postal_code: "K1N 5T2"}
     @destination = {city: "Beverly Hills", state: "CA", country: "United States", postal_code: "90210"}

--- a/test/unit/response_test.rb
+++ b/test/unit/response_test.rb
@@ -1,6 +1,6 @@
 require 'test_helper'
 
-class ResponseTest < Minitest::Test
+class ResponseTest < ActiveSupport::TestCase
   def test_initialize_success
     response = RateResponse.new(true, "success!", {:rate => 'Free!'}, :rates => [stub(:service_name => 'Free!', :total_price => 0)], :xml => "<rate>Free!</rate>")
     assert response.success?

--- a/test/unit/shipment_event_test.rb
+++ b/test/unit/shipment_event_test.rb
@@ -1,6 +1,6 @@
 require 'test_helper'
 
-class ShipmentEventTest < Minitest::Test
+class ShipmentEventTest < ActiveSupport::TestCase
   def test_equality
     options1 = [
       'ARRIVED AT UNIT',

--- a/test/unit/shipment_packer_test.rb
+++ b/test/unit/shipment_packer_test.rb
@@ -1,6 +1,6 @@
 require 'test_helper'
 
-class ShipmentPackerTest < Minitest::Test
+class ShipmentPackerTest < ActiveSupport::TestCase
   def setup
     @dimensions = [5.1, 15.2, 30.5]
   end

--- a/test/unit/tracking_response_test.rb
+++ b/test/unit/tracking_response_test.rb
@@ -1,6 +1,6 @@
 require 'test_helper'
 
-class TrackingResponseTest < Minitest::Test
+class TrackingResponseTest < ActiveSupport::TestCase
   def test_equality
     options1 = {
       carrier: 'usps',


### PR DESCRIPTION
No need to use the `Minitest` parent class, or the version swapping check. We've dropped lower versions. And can use `ActiveSupport::TestCase` and all the things it provides everywhere.