### PR TITLE
Modernize tests - Part 1

### DIFF
--- a/test/unit/carrier_test.rb
+++ b/test/unit/carrier_test.rb
@@ -6,58 +6,58 @@ class CarrierTest < ActiveSupport::TestCase
     @@name = "Example Carrier"
   end
 
-  def setup
+  setup do
     @carrier = ExampleCarrier.new
   end
 
-  def test_find_rates_not_implemented
+  test "#find_rates is not implemented" do
     assert_raises NotImplementedError do
       @carrier.find_rates(nil, nil, nil)
     end
   end
 
-  def test_create_shipment_not_implemented
+  test "#create_shipment is not implemented" do
     assert_raises NotImplementedError do
       @carrier.create_shipment(nil, nil, nil)
     end
   end
 
-  def test_cancel_shipment_not_implemented
+  test "#cancel_shipment is not implemented" do
     assert_raises NotImplementedError do
       @carrier.cancel_shipment(nil)
     end
   end
 
-  def test_find_tracking_info_not_implemented
+  test "#find_tracking_info is not implemented" do
     assert_raises NotImplementedError do
       @carrier.find_tracking_info(nil)
     end
   end
 
-  def test_maximum_weight
+  test "#maximum_weight returns a Quantified::Mass" do
     assert_equal Quantified::Mass.new(150, :pounds), @carrier.maximum_weight
   end
 
-  def test_maximum_address_field_length
+  test "#maximum_address_field_length default value" do
     assert_equal 255, @carrier.maximum_address_field_length
   end
 
-  def test_requirements_empty_array
+  test "#requirements is an empty array" do
     assert_equal [], @carrier.send(:requirements)
   end
 
-  def test_timestamp_from_business_day_returns_nil_without_a_day
+  test "#timestamp_from_business_day returns nil without a day" do
     assert_nil @carrier.send(:timestamp_from_business_day, nil)
   end
 
-  def test_save_request
+  test "#save_request caches the last request on the object" do
     request = Object.new
     assert_nil @carrier.last_request
     @carrier.send(:save_request, request)
     assert_equal request, @carrier.last_request
   end
 
-  def test_timestamp_from_business_day_returns_two_days_in_the_future
+  test "#timestamp_from_business_day returns two days in the future" do
     current = DateTime.parse("Tue 19 Jul 2016")
     expected = DateTime.parse("Thu 21 Jul 2016")
 
@@ -66,7 +66,7 @@ class CarrierTest < ActiveSupport::TestCase
     end
   end
 
-  def test_timestamp_from_business_day_returns_two_days_in_the_future_over_a_weekend
+  test "#timestamp_from_business_day returns two days in the future over a weekend" do
     current = DateTime.parse("Fri 22 Jul 2016")
     expected = DateTime.parse("Tue 26 Jul 2016")
 
@@ -75,7 +75,7 @@ class CarrierTest < ActiveSupport::TestCase
     end
   end
 
-  def test_timestamp_from_business_day_returns_fifteen_days_in_the_future
+  test "#timestamp_from_business_day returns fifteen days in the future" do
     current = DateTime.parse("Wed 06 Jul 2016")
     expected = DateTime.parse("Wed 27 Jul 2016") # includes 3 weekends
 
@@ -84,7 +84,7 @@ class CarrierTest < ActiveSupport::TestCase
     end
   end
 
-  def test_timestamp_from_business_day_handles_saturday
+  test "#timestamp_from_business_day handles saturday" do
     current = DateTime.parse("Sat 09 Jul 2016")
     expected = DateTime.parse("Mon 11 Jul 2016")
 
@@ -93,7 +93,7 @@ class CarrierTest < ActiveSupport::TestCase
     end
   end
 
-  def test_timestamp_from_business_day_handles_sunday
+  test "#timestamp_from_business_day handles sunday" do
     current = DateTime.parse("Sun 10 Jul 2016")
     expected = DateTime.parse("Mon 11 Jul 2016")
 
@@ -102,13 +102,13 @@ class CarrierTest < ActiveSupport::TestCase
     end
   end
 
-  def test_timestamp_from_business_day_returns_datetime
+  test "#timestamp_from_business_day returns a DateTime" do
     Timecop.freeze(DateTime.parse("Tue 19 Jul 2016")) do
       assert_equal DateTime, @carrier.send(:timestamp_from_business_day, 1).class
     end
   end
 
-  def test_default_location
+  test ".default_location is a valid address with defaults" do
     result = Carrier.default_location
 
     assert_equal Location, result.class

--- a/test/unit/carriers_test.rb
+++ b/test/unit/carriers_test.rb
@@ -1,17 +1,16 @@
 require 'test_helper'
 
 class CarriersTest < ActiveSupport::TestCase
-
-  def test_get_usps_by_string
+  test ".find searches by string for a carrier and finds USPS" do
     assert_equal ActiveShipping::USPS, ActiveShipping::Carriers.find('usps')
     assert_equal ActiveShipping::USPS, ActiveShipping::Carriers.find('USPS')
   end
 
-  def test_get_usps_by_name
+  test ".find searches by symbol for a carrier and finds USPS" do
     assert_equal ActiveShipping::USPS, ActiveShipping::Carriers.find(:usps)
   end
 
-  def test_get_unknown_carrier
+  test ".find raises with an unknown carrier" do
     assert_raises(NameError) { ActiveShipping::Carriers.find(:polar_north) }
   end
 end

--- a/test/unit/external_return_label_request_test.rb
+++ b/test/unit/external_return_label_request_test.rb
@@ -3,121 +3,164 @@ require 'test_helper'
 class ExternalReturnLabelRequestTest < ActiveSupport::TestCase
   include ActiveShipping::Test::Fixtures
 
-  def setup
+  setup do
     @external_request_label_req =
-      ExternalReturnLabelRequest.from_hash ({
-        :customer_name => "Test Customer",
-        :customer_address1 => "122 Hudson St.",
-        :customer_city => "New York",
-        :customer_state => "NY",
-        :customer_zipcode => "10013",
-        :label_format => "No Instructions",
-        :label_definition => "4X6",
-        :service_type_code => "044",
-        :merchant_account_id => "12345",
-        :mid => "12345678",
-        :call_center_or_self_service => "Customer",
-        :address_override_notification => "true"
-      })
-
+      ExternalReturnLabelRequest.from_hash(
+        customer_name: "Test Customer",
+        customer_address1: "122 Hudson St.",
+        customer_city: "New York",
+        customer_state: "NY",
+        customer_zipcode: "10013",
+        label_format: "No Instructions",
+        label_definition: "4X6",
+        service_type_code: "044",
+        merchant_account_id: "12345",
+        mid: "12345678",
+        call_center_or_self_service: "Customer",
+        address_override_notification: "true",
+      )
+    @email = "no-reply@example.com"
+    @invalid_email = "not_a_valid_email"
   end
 
-  def test_recipient_bcc
+  test "#recipient_bcc raises on an invalid email" do
     assert_raises(USPSValidationError) do
-      @external_request_label_req.recipient_bcc = "not_a_valid_email"
-    end
-    assert_silent do
-      @external_request_label_req.recipient_bcc = "no-reply@example.com"
+      @external_request_label_req.recipient_bcc = @invalid_email
     end
   end
 
-  def test_recipient_email
+  test "#recipient_bcc assigns the email" do
+    assert_nothing_raised do
+      @external_request_label_req.recipient_bcc = @email
+      assert_equal @email, @external_request_label_req.recipient_bcc
+    end
+  end
+
+  test "#recipient_email raises if invalid" do
     assert_raises(USPSValidationError) do
-      @external_request_label_req.recipient_email = "not_a_valid_email"
+      @external_request_label_req.recipient_email = @invalid_email
     end
-    assert_silent do
-      @external_request_label_req.recipient_email = "no-reply@example.com"
+    assert_nothing_raised do
+      @external_request_label_req.recipient_email = @email
     end
   end
 
-  def test_recipient_name
-    assert_silent do
+  test "#recipient_name accepts anything" do
+    assert_nothing_raised do
       @external_request_label_req.recipient_name = "any string"
     end
   end
 
-  def test_sender_email
+  test "#sender_email raises if invalid" do
     assert_raises(USPSValidationError) do
-      @external_request_label_req.sender_email = "not_a_valid_email"
-    end
-    assert_silent do
-      @external_request_label_req.sender_email = "no-reply@example.com"
+      @external_request_label_req.sender_email = @invalid_email
     end
   end
 
-  def test_sender_name
-    assert_silent do
+  test "#sender_email assigns the email" do
+    assert_nothing_raised do
+      @external_request_label_req.sender_email = @email
+    end
+  end
+
+  test "#sender_name assigns the value" do
+    assert_nothing_raised do
       @external_request_label_req.sender_name = "any string"
     end
+  end
+
+  test "#sender_name raises if blank" do
     assert_raises(USPSValidationError) do
       @external_request_label_req.sender_name = ""
     end
   end
 
-  def test_image_type
-    assert_silent do
+  test "#sender_name raises if nil" do
+    assert_raises(USPSValidationError) do
+      @external_request_label_req.sender_name = nil
+    end
+  end
+
+  test "#image_type accepts a valid image type" do
+    assert_nothing_raised do
       ExternalReturnLabelRequest::IMAGE_TYPE.each do |img_type|
         @external_request_label_req.image_type = img_type.downcase
       end
     end
+  end
+
+  test "#image_type raises on jpg" do
     assert_raises(USPSValidationError) do
       @external_request_label_req.image_type = "jpg"
     end
   end
 
-  def test_call_center_or_self_service
-    assert_silent do
+  test "#call_center_or_self_service accepts the valid values defined" do
+    assert_nothing_raised do
       ExternalReturnLabelRequest::CALL_CENTER_OR_SELF_SERVICE.each do |cc_or_cs|
         @external_request_label_req.call_center_or_self_service = cc_or_cs
       end
     end
+  end
+
+  test "#call_center_or_self_service raises on an invalid value" do
     assert_raises(USPSValidationError) do
       @external_request_label_req.call_center_or_self_service = "Invalid"
     end
   end
 
-  def test_packaging_information
-    assert_silent do
+  test "#packaging_information accepts a value" do
+    assert_nothing_raised do
       @external_request_label_req.packaging_information = "Any String"
-    end
-    assert_raises(USPSValidationError) do
-      @external_request_label_req.packaging_information = (1..50).to_a.join("_")
     end
   end
 
-  def test_packaging_information2
-    assert_silent do
+  test "#packaging_information accepts blank values" do
+    assert_nothing_raised do
+      @external_request_label_req.packaging_information = " "
+      @external_request_label_req.packaging_information = ""
+    end
+  end
+
+  test "#packaging_information raises on a value too long" do
+    assert_raises(USPSValidationError) do
+      @external_request_label_req.packaging_information = "a" * 16
+    end
+  end
+
+  test "#packaging_information2 accepts a value" do
+    assert_nothing_raised do
       @external_request_label_req.packaging_information2 = "Any String"
     end
-    assert_silent do
+  end
+
+  test "#packaging_information2 accepts blank values" do
+    assert_nothing_raised do
       @external_request_label_req.packaging_information2 = " "
       @external_request_label_req.packaging_information2 = ""
     end
+  end
+
+  test "#packaging_information2 raises when a value is too long" do
     assert_raises(USPSValidationError) do
-      @external_request_label_req.packaging_information2 = (1..50).to_a.join("_")
+      @external_request_label_req.packaging_information2 = "a" * 16
     end
   end
 
-  def test_customer_address2
-    assert_silent do
-      @external_request_label_req.customer_address2 = "     "
+  test "#customer_address2 accepts a value" do
+    assert_nothing_raised do
+      @external_request_label_req.customer_address2 = "anything"
     end
-    assert_silent do
+  end
+
+  test "#customer_address2 accepts blank values" do
+    assert_nothing_raised do
+      @external_request_label_req.customer_address2 = "     "
       @external_request_label_req.customer_address2 = nil
     end
   end
 
-  def test_sanitize
+  test "#sanitize scrubs strings" do
     assert_equal "", @external_request_label_req.send(:sanitize,'   ')
     assert_equal 'some string', @external_request_label_req.send(:sanitize, 'some string   ')
     assert_nil @external_request_label_req.send(:sanitize, {})
@@ -127,18 +170,21 @@ class ExternalReturnLabelRequestTest < ActiveSupport::TestCase
     assert_equal ExternalReturnLabelRequest::CAP_STRING_LEN, @external_request_label_req.send(:sanitize, (1..100).to_a.join("_")).size
   end
 
-  def test_to_bool
+  test "#to_bool coerces true values" do
     assert_equal true, @external_request_label_req.send(:to_bool, 'yes')
     assert_equal true, @external_request_label_req.send(:to_bool, 'true')
     assert_equal true, @external_request_label_req.send(:to_bool, true)
     assert_equal true, @external_request_label_req.send(:to_bool, '1')
+  end
+
+  test "#to_bool coerces false values" do
     assert_equal false, @external_request_label_req.send(:to_bool, '0')
     assert_equal false, @external_request_label_req.send(:to_bool, 'false')
     assert_equal false, @external_request_label_req.send(:to_bool, false)
     assert_equal false, @external_request_label_req.send(:to_bool, nil, false)
   end
 
-  def test_validate_range
+  test "#validate_range" do
     assert_raises(USPSValidationError) do
       @external_request_label_req.send(:validate_range, '1', 5, 10, __method__)
     end
@@ -149,7 +195,7 @@ class ExternalReturnLabelRequestTest < ActiveSupport::TestCase
     @external_request_label_req.send(:validate_range, '5 char', nil, 10, __method__)
   end
 
-  def test_validate_string_length
+  test "#validate_string_length" do
     assert_raises(USPSValidationError) do
       @external_request_label_req.send(:validate_string_length, '14 char string', 13, __method__)
     end
@@ -159,7 +205,7 @@ class ExternalReturnLabelRequestTest < ActiveSupport::TestCase
     @external_request_label_req.send(:validate_string_length, '14 char string', 14, __method__)
   end
 
-  def test_validate_set_inclusion
+  test "#validate_set_inclusion" do
     assert_raises(USPSValidationError) do
       @external_request_label_req.send(:validate_set_inclusion, 'not_in_set', ['v1','v2','v3'], __method__)
     end
@@ -169,20 +215,22 @@ class ExternalReturnLabelRequestTest < ActiveSupport::TestCase
     @external_request_label_req.send(:validate_set_inclusion, 'v1', ['v1','v2','v3'], __method__)
   end
 
-  def test_validate_email
+  test "#validate_email" do
     assert_raises(USPSValidationError) do
-      @external_request_label_req.send(:validate_email, 'not_a_valid_email', __method__)
+      @external_request_label_req.send(:validate_email, @invalid_email, __method__)
     end
     assert_raises(USPSValidationError) do
-      @external_request_label_req.send(:validate_email, '    ', __method__)
+      @external_request_label_req.send(:validate_email, "    ", __method__)
     end
-    assert_equal 'no-reply@example.com', @external_request_label_req.send(:validate_email, 'no-reply@example.com', __method__)
-    assert_equal 'no-reply@example.com', @external_request_label_req.send(:validate_email, '  no-reply@example.com  ', __method__)
+    assert_equal @email, @external_request_label_req.send(:validate_email, @email, __method__)
+    assert_equal @email, @external_request_label_req.send(:validate_email, "    #{@email}    ", __method__)
   end
 
-  def test_tag_required
+  test "#initialize raises with no tag" do
     assert_raises(USPSMissingRequiredTagError) { ExternalReturnLabelRequest.new }
+  end
 
+  test "#initialize passes with valid values and that every key is necessary" do
     sample_hash = {
       :customer_name => "Test Customer",
       :customer_address1 => "122 Hudson St.",
@@ -198,7 +246,7 @@ class ExternalReturnLabelRequestTest < ActiveSupport::TestCase
       :address_override_notification => "true"
     }
 
-    assert_silent do
+    assert_nothing_raised do
       ExternalReturnLabelRequest.from_hash(sample_hash)
     end
 
@@ -208,5 +256,4 @@ class ExternalReturnLabelRequestTest < ActiveSupport::TestCase
       end
     end
   end
-
 end

--- a/test/unit/external_return_label_request_test.rb
+++ b/test/unit/external_return_label_request_test.rb
@@ -21,6 +21,8 @@ class ExternalReturnLabelRequestTest < ActiveSupport::TestCase
       )
     @email = "no-reply@example.com"
     @invalid_email = "not_a_valid_email"
+    @anything = "Any string"
+    @blank_values = ["", "    "]
   end
 
   test "#recipient_bcc raises on an invalid email" do
@@ -30,25 +32,24 @@ class ExternalReturnLabelRequestTest < ActiveSupport::TestCase
   end
 
   test "#recipient_bcc assigns the email" do
-    assert_nothing_raised do
-      @external_request_label_req.recipient_bcc = @email
-      assert_equal @email, @external_request_label_req.recipient_bcc
-    end
+    @external_request_label_req.recipient_bcc = @email
+    assert_equal @email, @external_request_label_req.recipient_bcc
   end
 
   test "#recipient_email raises if invalid" do
     assert_raises(USPSValidationError) do
       @external_request_label_req.recipient_email = @invalid_email
     end
-    assert_nothing_raised do
-      @external_request_label_req.recipient_email = @email
-    end
+  end
+
+  test "#recipient_email assigns the email" do
+    @external_request_label_req.recipient_email = @email
+    assert_equal @email, @external_request_label_req.recipient_email
   end
 
   test "#recipient_name accepts anything" do
-    assert_nothing_raised do
-      @external_request_label_req.recipient_name = "any string"
-    end
+    @external_request_label_req.recipient_name = @anything
+    assert_equal @anything, @external_request_label_req.recipient_name
   end
 
   test "#sender_email raises if invalid" do
@@ -58,20 +59,20 @@ class ExternalReturnLabelRequestTest < ActiveSupport::TestCase
   end
 
   test "#sender_email assigns the email" do
-    assert_nothing_raised do
-      @external_request_label_req.sender_email = @email
-    end
+    @external_request_label_req.sender_email = @email
+    assert_equal @email, @external_request_label_req.sender_email
   end
 
   test "#sender_name assigns the value" do
-    assert_nothing_raised do
-      @external_request_label_req.sender_name = "any string"
-    end
+    @external_request_label_req.sender_name = @anything
+    assert_equal @anything, @external_request_label_req.sender_name
   end
 
-  test "#sender_name raises if blank" do
-    assert_raises(USPSValidationError) do
-      @external_request_label_req.sender_name = ""
+  test "#sender_name raises if blank or nil" do
+    @blank_values.each do |blank|
+      assert_raises(USPSValidationError) do
+        @external_request_label_req.sender_name = blank
+      end
     end
   end
 
@@ -82,10 +83,9 @@ class ExternalReturnLabelRequestTest < ActiveSupport::TestCase
   end
 
   test "#image_type accepts a valid image type" do
-    assert_nothing_raised do
-      ExternalReturnLabelRequest::IMAGE_TYPE.each do |img_type|
-        @external_request_label_req.image_type = img_type.downcase
-      end
+    ExternalReturnLabelRequest::IMAGE_TYPE.each do |type|
+      @external_request_label_req.image_type = type.downcase
+      assert_equal type, @external_request_label_req.image_type
     end
   end
 
@@ -96,10 +96,9 @@ class ExternalReturnLabelRequestTest < ActiveSupport::TestCase
   end
 
   test "#call_center_or_self_service accepts the valid values defined" do
-    assert_nothing_raised do
-      ExternalReturnLabelRequest::CALL_CENTER_OR_SELF_SERVICE.each do |cc_or_cs|
-        @external_request_label_req.call_center_or_self_service = cc_or_cs
-      end
+    ExternalReturnLabelRequest::CALL_CENTER_OR_SELF_SERVICE.each do |cc_or_cs|
+      @external_request_label_req.call_center_or_self_service = cc_or_cs
+      assert_equal cc_or_cs, @external_request_label_req.call_center_or_self_service
     end
   end
 
@@ -110,15 +109,14 @@ class ExternalReturnLabelRequestTest < ActiveSupport::TestCase
   end
 
   test "#packaging_information accepts a value" do
-    assert_nothing_raised do
-      @external_request_label_req.packaging_information = "Any String"
-    end
+    @external_request_label_req.packaging_information = @anything
+    assert_equal @anything, @external_request_label_req.packaging_information
   end
 
   test "#packaging_information accepts blank values" do
-    assert_nothing_raised do
-      @external_request_label_req.packaging_information = " "
-      @external_request_label_req.packaging_information = ""
+    @blank_values.each do |blank|
+      @external_request_label_req.packaging_information = blank
+      assert_equal "", @external_request_label_req.packaging_information
     end
   end
 
@@ -129,15 +127,14 @@ class ExternalReturnLabelRequestTest < ActiveSupport::TestCase
   end
 
   test "#packaging_information2 accepts a value" do
-    assert_nothing_raised do
-      @external_request_label_req.packaging_information2 = "Any String"
-    end
+    @external_request_label_req.packaging_information2 = @anything
+    assert_equal @anything, @external_request_label_req.packaging_information2
   end
 
   test "#packaging_information2 accepts blank values" do
-    assert_nothing_raised do
-      @external_request_label_req.packaging_information2 = " "
-      @external_request_label_req.packaging_information2 = ""
+    @blank_values.each do |blank|
+      @external_request_label_req.packaging_information2 = blank
+      assert_equal "", @external_request_label_req.packaging_information2
     end
   end
 
@@ -148,16 +145,20 @@ class ExternalReturnLabelRequestTest < ActiveSupport::TestCase
   end
 
   test "#customer_address2 accepts a value" do
-    assert_nothing_raised do
-      @external_request_label_req.customer_address2 = "anything"
-    end
+    @external_request_label_req.customer_address2 = @anything
+    assert_equal @anything, @external_request_label_req.customer_address2
   end
 
   test "#customer_address2 accepts blank values" do
-    assert_nothing_raised do
-      @external_request_label_req.customer_address2 = "     "
-      @external_request_label_req.customer_address2 = nil
+    @blank_values.each do |blank|
+      @external_request_label_req.customer_address2 = blank
+      assert_nil @external_request_label_req.customer_address2
     end
+  end
+
+  test "#customer_address2 accepts nil" do
+    @external_request_label_req.customer_address2 = nil
+    assert_nil @external_request_label_req.customer_address2
   end
 
   test "#sanitize scrubs strings" do
@@ -246,9 +247,7 @@ class ExternalReturnLabelRequestTest < ActiveSupport::TestCase
       :address_override_notification => "true"
     }
 
-    assert_nothing_raised do
-      ExternalReturnLabelRequest.from_hash(sample_hash)
-    end
+    assert ExternalReturnLabelRequest.from_hash(sample_hash)
 
     sample_hash.keys.each do |k|
       assert_raises(USPSMissingRequiredTagError) do


### PR DESCRIPTION
Now that #442 is in I'm going to slowly start converting the fragile, confusing, and unclear `def test_` DSL and replace it with the `ActiveSupport::TestCase` `test()` block based DSL.

Changes are just around naming and formatting mostly. Split up test cases that do more than one thing onto distinct tests with a clearer fail message. Extracted some shared variables. In one case I replaced `assert_silent` with `assert_nothing_raised` because the original author I don't think understood the assertions. The former is about printing to standard out, but I'm sure they intended to deal with exceptions.

This does `Carrier` `Carriers` and `ExternalReturnLabelRequest`.