### PR TITLE
Do not show detals of skips locally

### DIFF
--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -11,7 +11,7 @@ require 'logger'
 require 'erb'
 require 'pry'
 
-Minitest::Reporters.use!
+Minitest::Reporters.use! Minitest::Reporters::ProgressReporter.new(detailed_skip: !!ENV["CI"])
 
 class ActiveSupport::TestCase
   include ActiveShipping


### PR DESCRIPTION
Reduce some of the noise locally, making it easier to red/green/refactor and unit test.

This suppresses the detailed output of skips locally, but still shows them in CI output.

## Local
![kevin_kevify____source_active_shipping__zsh_](https://cloud.githubusercontent.com/assets/84159/21018128/be38c578-bd39-11e6-9341-c35bbfec7cb8.png)

## CI

![job__1387_1_-_shopify_active_shipping_-_travis_ci](https://cloud.githubusercontent.com/assets/84159/21018110/a2f9f246-bd39-11e6-8b42-561040d55140.png)
