### PR TITLE
Clean up tests and formatting for Location

### DIFF
--- a/lib/active_shipping/location.rb
+++ b/lib/active_shipping/location.rb
@@ -75,7 +75,7 @@ module ActiveShipping #:nodoc:
         aliases.detect do |sym|
           value = if hash_access
             object[sym]
-          elsif object.respond_to?(sym) && !Hash.public_instance_methods.include?(sym.to_s)
+          elsif object.respond_to?(sym)
             object.send(sym)
           end
 

--- a/lib/active_shipping/location.rb
+++ b/lib/active_shipping/location.rb
@@ -2,7 +2,7 @@ module ActiveShipping #:nodoc:
   class Location
     ADDRESS_TYPES = %w(residential commercial po_box)
 
-    ATTRIBUTE_MAPPINGS = {
+    ATTRIBUTE_ALIASES = {
       name: [:name],
       country: [:country_code, :country],
       postal_code: [:postal_code, :zip, :postal],
@@ -71,12 +71,15 @@ module ActiveShipping #:nodoc:
         false
       end
 
-      ATTRIBUTE_MAPPINGS.each do |pair|
-        pair[1].each do |sym|
-          if value = (object[sym] if hash_access) || (object.send(sym) if object.respond_to?(sym) && (!hash_access || !Hash.public_instance_methods.include?(sym.to_s)))
-            attributes[pair[0]] = value
-            break
+      ATTRIBUTE_ALIASES.each do |attribute, aliases|
+        aliases.detect do |sym|
+          value = if hash_access
+            object[sym]
+          elsif object.respond_to?(sym) && !Hash.public_instance_methods.include?(sym.to_s)
+            object.send(sym)
           end
+
+          attributes[attribute] = value if value
         end
       end
 

--- a/lib/active_shipping/location.rb
+++ b/lib/active_shipping/location.rb
@@ -2,6 +2,21 @@ module ActiveShipping #:nodoc:
   class Location
     ADDRESS_TYPES = %w(residential commercial po_box)
 
+    ATTRIBUTE_MAPPINGS = {
+      name: [:name],
+      country: [:country_code, :country],
+      postal_code: [:postal_code, :zip, :postal],
+      province: [:province_code, :state_code, :territory_code, :region_code, :province, :state, :territory, :region],
+      city: [:city, :town],
+      address1: [:address1, :address, :street],
+      address2: [:address2],
+      address3: [:address3],
+      phone: [:phone, :phone_number],
+      fax: [:fax, :fax_number],
+      address_type: [:address_type],
+      company_name: [:company, :company_name],
+    }.freeze
+
     attr_reader :options,
                 :country,
                 :postal_code,
@@ -24,9 +39,12 @@ module ActiveShipping #:nodoc:
     alias_method :company, :company_name
 
     def initialize(options = {})
-      @country = (options[:country].nil? or options[:country].is_a?(ActiveUtils::Country)) ?
-                    options[:country] :
-                    ActiveUtils::Country.find(options[:country])
+      @country = if options[:country].nil? || options[:country].is_a?(ActiveUtils::Country)
+        options[:country]
+      else
+        ActiveUtils::Country.find(options[:country])
+      end
+
       @postal_code = options[:postal_code] || options[:postal] || options[:zip]
       @province = options[:province] || options[:state] || options[:territory] || options[:region]
       @city = options[:city]
@@ -42,29 +60,18 @@ module ActiveShipping #:nodoc:
     end
 
     def self.from(object, options = {})
-      return object if object.is_a? ActiveShipping::Location
-      attr_mappings = {
-        :name => [:name],
-        :country => [:country_code, :country],
-        :postal_code => [:postal_code, :zip, :postal],
-        :province => [:province_code, :state_code, :territory_code, :region_code, :province, :state, :territory, :region],
-        :city => [:city, :town],
-        :address1 => [:address1, :address, :street],
-        :address2 => [:address2],
-        :address3 => [:address3],
-        :phone => [:phone, :phone_number],
-        :fax => [:fax, :fax_number],
-        :address_type => [:address_type],
-        :company_name => [:company, :company_name]
-      }
+      return object if object.is_a?(ActiveShipping::Location)
+
       attributes = {}
+
       hash_access = begin
         object[:some_symbol]
         true
       rescue
         false
       end
-      attr_mappings.each do |pair|
+
+      ATTRIBUTE_MAPPINGS.each do |pair|
         pair[1].each do |sym|
           if value = (object[sym] if hash_access) || (object.send(sym) if object.respond_to?(sym) && (!hash_access || !Hash.public_instance_methods.include?(sym.to_s)))
             attributes[pair[0]] = value
@@ -72,7 +79,9 @@ module ActiveShipping #:nodoc:
           end
         end
       end
+
       attributes.delete(:address_type) unless ADDRESS_TYPES.include?(attributes[:address_type].to_s)
+
       new(attributes.update(options))
     end
 
@@ -80,10 +89,21 @@ module ActiveShipping #:nodoc:
       @country.nil? ? nil : @country.code(format).value
     end
 
-    def residential?; @address_type == 'residential' end
-    def commercial?; @address_type == 'commercial' end
-    def po_box?; @address_type == 'po_box' end
-    def unknown?; country_code == 'ZZ' end
+    def residential?
+      @address_type == 'residential'
+    end
+
+    def commercial?
+      @address_type == 'commercial'
+    end
+
+    def po_box?
+      @address_type == 'po_box'
+    end
+
+    def unknown?
+      country_code == 'ZZ'
+    end
 
     def address_type=(value)
       return unless value.present?
@@ -93,18 +113,18 @@ module ActiveShipping #:nodoc:
 
     def to_hash
       {
-        :country => country_code,
-        :postal_code => postal_code,
-        :province => province,
-        :city => city,
-        :name => name,
-        :address1 => address1,
-        :address2 => address2,
-        :address3 => address3,
-        :phone => phone,
-        :fax => fax,
-        :address_type => address_type,
-        :company_name => company_name
+        country: country_code,
+        postal_code: postal_code,
+        province: province,
+        city: city,
+        name: name,
+        address1: address1,
+        address2: address2,
+        address3: address3,
+        phone: phone,
+        fax: fax,
+        address_type: address_type,
+        company_name: company_name
       }
     end
 
@@ -129,9 +149,9 @@ module ActiveShipping #:nodoc:
     # Returns the postal code as a properly formatted Zip+4 code, e.g. "77095-2233"
     def zip_plus_4
       if /(\d{5})(\d{4})/ =~ @postal_code
-        return "#{$1}-#{$2}"
+        "#{$1}-#{$2}"
       elsif /\d{5}-\d{4}/ =~ @postal_code
-        return @postal_code
+        @postal_code
       else
         nil
       end

--- a/lib/active_shipping/location.rb
+++ b/lib/active_shipping/location.rb
@@ -151,13 +151,7 @@ module ActiveShipping #:nodoc:
 
     # Returns the postal code as a properly formatted Zip+4 code, e.g. "77095-2233"
     def zip_plus_4
-      if /(\d{5})(\d{4})/ =~ @postal_code
-        "#{$1}-#{$2}"
-      elsif /\d{5}-\d{4}/ =~ @postal_code
-        @postal_code
-      else
-        nil
-      end
+      "#{$1}-#{$2}" if /(\d{5})-?(\d{4})/ =~ @postal_code
     end
 
     def address2_and_3

--- a/test/unit/location_test.rb
+++ b/test/unit/location_test.rb
@@ -7,15 +7,7 @@ class LocationTest < ActiveSupport::TestCase
     @location = location_fixtures[:ottawa]
     @address2 = 'Apt 613'
     @address3 = 'Victory Lane'
-  end
-
-  test "#initialize sets a country object" do
-    assert_instance_of ActiveUtils::Country, @location.country
-    assert_equal 'CA', @location.country_code(:alpha2)
-  end
-
-  test "#initialize sets up the location from a hash" do
-    hash = {
+    @attributes_hash = {
       country: 'CA',
       zip: '90210',
       territory_code: 'QC',
@@ -26,39 +18,71 @@ class LocationTest < ActiveSupport::TestCase
       address_type: :commercial,
       name: "Bob Bobsen",
     }
-    location = Location.from(hash)
-
-    assert_equal hash[:country], location.country_code(:alpha2)
-    assert_equal hash[:zip], location.zip
-    assert_equal hash[:territory_code], location.province
-    assert_equal hash[:town], location.city
-    assert_equal hash[:address], location.address1
-    assert_equal hash[:phone], location.phone
-    assert_equal hash[:fax_number], location.fax
-    assert_equal hash[:address_type].to_s, location.address_type
-    assert_equal hash[:name], location.name
   end
 
-  test "#initialize sets the name to nil if it is not provided" do
+  test "#initialize sets a country object" do
+    assert_instance_of ActiveUtils::Country, @location.country
+    assert_equal 'CA', @location.country_code(:alpha2)
+  end
+
+  test ".from sets up the location from a hash" do
+    location = Location.from(@attributes_hash)
+
+    assert_equal @attributes_hash[:country], location.country_code(:alpha2)
+    assert_equal @attributes_hash[:zip], location.zip
+    assert_equal @attributes_hash[:territory_code], location.province
+    assert_equal @attributes_hash[:town], location.city
+    assert_equal @attributes_hash[:address], location.address1
+    assert_equal @attributes_hash[:phone], location.phone
+    assert_equal @attributes_hash[:fax_number], location.fax
+    assert_equal @attributes_hash[:address_type].to_s, location.address_type
+    assert_equal @attributes_hash[:name], location.name
+  end
+
+  test ".from sets from an object with properties" do
+    object = Class.new do
+      def initialize(hash)
+        @hash = hash
+      end
+      def method_missing(method)
+        @hash[method]
+      end
+      def respond_to?(method) ; true ; end
+    end.new(@attributes_hash)
+
+    location = Location.from(object)
+
+    assert_equal @attributes_hash[:country], location.country_code(:alpha2)
+    assert_equal @attributes_hash[:zip], location.zip
+    assert_equal @attributes_hash[:territory_code], location.province
+    assert_equal @attributes_hash[:town], location.city
+    assert_equal @attributes_hash[:address], location.address1
+    assert_equal @attributes_hash[:phone], location.phone
+    assert_equal @attributes_hash[:fax_number], location.fax
+    assert_equal @attributes_hash[:address_type].to_s, location.address_type
+    assert_equal @attributes_hash[:name], location.name
+  end
+
+  test ".from sets the name to nil if it is not provided" do
     location = Location.from({})
     assert_nil location.name
   end
 
-  test "#initialize sets company and company_name from company" do
+  test ".from sets company and company_name from company" do
     location = Location.from(company: "Mine")
 
     assert_equal "Mine", location.company
     assert_equal "Mine", location.company_name
   end
 
-  test "#initialize sets company and company_name from company_name" do
+  test ".from sets company and company_name from company_name" do
     location = Location.from(company_name: "Mine")
 
     assert_equal "Mine", location.company
     assert_equal "Mine", location.company_name
   end
 
-  test "#initialize prioritizes company" do
+  test ".from prioritizes company" do
     location = Location.from(company_name: "from company_name", company: "from company")
 
     assert_equal "from company", location.company

--- a/test/unit/location_test.rb
+++ b/test/unit/location_test.rb
@@ -3,21 +3,29 @@ require 'test_helper'
 class LocationTest < ActiveSupport::TestCase
   include ActiveShipping::Test::Fixtures
 
-  def test_countries
-    assert_instance_of ActiveUtils::Country, location_fixtures[:ottawa].country
-    assert_equal 'CA', location_fixtures[:ottawa].country_code(:alpha2)
+  setup do
+    @location = location_fixtures[:ottawa]
+    @address2 = 'Apt 613'
+    @address3 = 'Victory Lane'
   end
 
-  def test_location_from_strange_hash
-    hash = {  :country => 'CA',
-              :zip => '90210',
-              :territory_code => 'QC',
-              :town => 'Perth',
-              :address => '66 Gregory Ave.',
-              :phone => '515-555-1212',
-              :fax_number => 'none to speak of',
-              :address_type => :commercial
-            }
+  test "#initialize sets a country object" do
+    assert_instance_of ActiveUtils::Country, @location.country
+    assert_equal 'CA', @location.country_code(:alpha2)
+  end
+
+  test "#initialize sets up the location from a hash" do
+    hash = {
+      country: 'CA',
+      zip: '90210',
+      territory_code: 'QC',
+      town: 'Perth',
+      address: '66 Gregory Ave.',
+      phone: '515-555-1212',
+      fax_number: 'none to speak of',
+      address_type: :commercial,
+      name: "Bob Bobsen",
+    }
     location = Location.from(hash)
 
     assert_equal hash[:country], location.country_code(:alpha2)
@@ -28,108 +36,156 @@ class LocationTest < ActiveSupport::TestCase
     assert_equal hash[:phone], location.phone
     assert_equal hash[:fax_number], location.fax
     assert_equal hash[:address_type].to_s, location.address_type
+    assert_equal hash[:name], location.name
   end
 
-  def test_pretty_print
-    expected = "110 Laurier Avenue West\nOttawa, ON, K1P 1J1\nCanada"
-    assert_equal expected, location_fixtures[:ottawa].prettyprint
-  end
-
-  def test_to_s
-    expected = "110 Laurier Avenue West Ottawa, ON, K1P 1J1 Canada"
-    assert_equal expected, location_fixtures[:ottawa].to_s
-  end
-
-  def test_inspect
-    expected = "110 Laurier Avenue West\nOttawa, ON, K1P 1J1\nCanada\nPhone: 1-613-580-2400\nFax: 1-613-580-2495"
-    assert_equal expected, location_fixtures[:ottawa].inspect
-  end
-
-  def test_includes_name
-    location = Location.from(:name => "Bob Bobsen")
-    assert_equal "Bob Bobsen", location.name
-  end
-
-  def test_name_is_nil_if_not_provided
+  test "#initialize sets the name to nil if it is not provided" do
     location = Location.from({})
     assert_nil location.name
   end
 
-  def test_location_with_company_name
-    location = Location.from(:company => "Mine")
-    assert_equal "Mine", location.company_name
+  test "#initialize sets company and company_name from company" do
+    location = Location.from(company: "Mine")
 
-    location = Location.from(:company_name => "Mine")
+    assert_equal "Mine", location.company
     assert_equal "Mine", location.company_name
   end
 
-  def test_set_address_type
-    location = location_fixtures[:ottawa]
-    assert !location.commercial?
+  test "#initialize sets company and company_name from company_name" do
+    location = Location.from(company_name: "Mine")
 
-    location.address_type = :commercial
-    assert location.commercial?
+    assert_equal "Mine", location.company
+    assert_equal "Mine", location.company_name
   end
 
-  def test_set_address_type_invalid
-    location = location_fixtures[:ottawa]
+  test "#initialize prioritizes company" do
+    location = Location.from(company_name: "from company_name", company: "from company")
 
+    assert_equal "from company", location.company
+    assert_equal "from company", location.company_name
+  end
+
+  test "#prettyprint outputs a readable string" do
+    expected = "110 Laurier Avenue West\nOttawa, ON, K1P 1J1\nCanada"
+    assert_equal expected, @location.prettyprint
+  end
+
+  test "#to_s outputs a readable string without newlines" do
+    expected = "110 Laurier Avenue West Ottawa, ON, K1P 1J1 Canada"
+    assert_equal expected, @location.to_s
+  end
+
+  test "#inspect returns a readable string" do
+    expected = "110 Laurier Avenue West\nOttawa, ON, K1P 1J1\nCanada\nPhone: 1-613-580-2400\nFax: 1-613-580-2495"
+    assert_equal expected, @location.inspect
+  end
+
+  test "#address_type= assigns a type of address as commercial" do
+    refute @location.commercial?
+
+    @location.address_type = :commercial
+    assert @location.commercial?
+    refute @location.residential?
+    assert_equal "commercial", @location.address_type
+  end
+
+  test "#address_type= assigns a type of address as residential" do
+    refute @location.residential?
+
+    @location.address_type = :residential
+    assert @location.residential?
+    refute @location.commercial?
+    assert_equal "residential", @location.address_type
+  end
+
+  test "#address_type= raises on an invalid assignment" do
     assert_raises(ArgumentError) do
-      location.address_type = :new_address_type
+      @location.address_type = :new_address_type
     end
 
-    refute_equal "new_address_type", location.address_type
+    assert_nil @location.address_type
   end
 
-  def test_to_hash_attributes
-    assert_equal %w(address1 address2 address3 address_type city company_name country fax name phone postal_code province), location_fixtures[:ottawa].to_hash.stringify_keys.keys.sort
+  test "#address_type= cannot blank out the value as nil" do
+    @location.address_type = :residential
+    assert @location.residential?
+
+    @location.address_type = nil
+    assert @location.residential?
+    assert_equal "residential", @location.address_type
   end
 
-  def test_to_json
-    location_json = location_fixtures[:ottawa].to_json
-    assert_equal location_fixtures[:ottawa].to_hash, JSON.parse(location_json).symbolize_keys
+  test "#address_type= cannot blank out the value as empty string" do
+    @location.address_type = :residential
+    assert @location.residential?
+
+    @location.address_type = ""
+    assert @location.residential?
+    assert_equal "residential", @location.address_type
   end
 
-  def test_zip_plus_4_with_no_dash
-    zip = "33333"
-    plus_4 = "1234"
-    zip_plus_4 = "#{zip}-#{plus_4}"
-    location = Location.from(:zip => "#{zip}#{plus_4}")
-    assert_equal zip_plus_4, location.zip_plus_4
+  test "#to_hash has the expected attributes" do
+    expected = %w(address1 address2 address3 address_type city company_name country fax name phone postal_code province)
+
+    assert_equal expected, @location.to_hash.stringify_keys.keys.sort
   end
 
-  def test_zip_plus_4_with_dash
-    zip = "33333"
-    plus_4 = "1234"
-    zip_plus_4 = "#{zip}-#{plus_4}"
-    location = Location.from(:zip => zip_plus_4)
-    assert_equal zip_plus_4, location.zip_plus_4
+  test "#to_json returns the JSON values" do
+    expected = JSON.parse(@location.to_json).symbolize_keys
+
+    assert_equal @location.to_hash, expected
   end
 
-  def test_address2_and_3_is_nil
-    location = location_fixtures[:ottawa]
-    assert_nil location.address2
-    assert_nil location.address3
-    assert location.address2_and_3.blank?
+  test "#zip_plus_4 nil without the extra four" do
+    zip = "12345"
+    location = Location.from(zip: zip)
+
+    assert_nil location.zip_plus_4
+    assert_equal zip, location.zip
   end
 
-  def test_address2_and_3
-    address2 = 'Apt 613'
-    address3 = 'Victory Lane'
-    location = Location.from(:address2 => address2)
+  test "#zip_plus_4 parses without the dash" do
+    zip = "12345-9999"
+    zip_without_dash = "123459999"
+    location = Location.from(zip: zip_without_dash)
+
+    assert_equal zip, location.zip_plus_4
+    assert_equal zip_without_dash, location.zip
+  end
+
+  test "#zip_plus_4 parses with the dash" do
+    zip = "12345-9999"
+    location = Location.from(zip: zip)
+
+    assert_equal zip, location.zip_plus_4
+    assert_equal zip, location.zip
+  end
+
+  test "#address2_and_3 shows just address2" do
+    location = Location.from(address2: @address2)
     assert_equal 'Apt 613', location.address2_and_3
-
-    location = Location.from(:address2 => address2, :address3 => address3)
-    assert_equal 'Apt 613, Victory Lane', location.address2_and_3
-
-    location = Location.from(:address3 => address3)
-    assert_equal 'Victory Lane', location.address2_and_3
   end
 
-  def test_equality
-    location_1 = location_fixtures[:ottawa]
-    location_2 = Location.from(location_1.to_hash)
+  test "#address2_and_3 shows just address3" do
+    location = Location.from(address3: @address3)
+    assert_equal @address3, location.address2_and_3
+  end
 
-    assert_equal location_1, location_2
+  test "#address2_and_3 shows both address2 and address3" do
+    location = Location.from(address2: @address2, address3: @address3)
+    assert_equal "#{@address2}, #{@address3}", location.address2_and_3
+  end
+
+  test "#address2_and_3 shows an empty string when address2 and address3 are both blank" do
+    assert_nil @location.address2
+    assert_nil @location.address3
+    assert_equal "", @location.address2_and_3
+  end
+
+  test "#== compares locations by attributes" do
+    another_location = Location.from(@location.to_hash)
+
+    assert_equal @location, another_location
+    refute_equal @location, Location.new({})
   end
 end


### PR DESCRIPTION
All cleanup in `Location`.

No functional change. Cleans up formatting, extracts a constant, removes old hash syntax, expands methods to be more consistent.

Reformats the tests to be `test "" do` and adds a bunch of missed coverage.