### PR TITLE
Fix CustomerReference element nesting for FedEx labels with multiple refs

### DIFF
--- a/lib/active_shipping/carriers/fedex.rb
+++ b/lib/active_shipping/carriers/fedex.rb
@@ -242,8 +242,8 @@ module ActiveShipping
                 # Reference Numbers
                 reference_numbers = Array(package.options[:reference_numbers])
                 if reference_numbers.size > 0
-                  xml.CustomerReferences do
-                    reference_numbers.each do |reference_number_info|
+                  reference_numbers.each do |reference_number_info|
+                    xml.CustomerReferences do
                       xml.CustomerReferenceType(reference_number_info[:type] || "CUSTOMER_REFERENCE")
                       xml.Value(reference_number_info[:value])
                     end


### PR DESCRIPTION
Attempting to pass multiple reference elements to a fedex label currently generates an invalid format error.

The generated XML looks like this

```
<CustomerReferences>
  <CustomerReferenceType>TYPE_1</CustomerReferenceType>
  <Value>Val1</Value>
  <CustomerReferenceType>TYPE_2</CustomerReferenceType>
  <Value>Val2</Value>
</CustomerReferences>
```

This fix simply corrects the format to

```
<CustomerReferences>
  <CustomerReferenceType>TYPE_1</CustomerReferenceType>
  <Value>Val1</Value>
</CustomerReferences>
<CustomerReferences>
  <CustomerReferenceType>TYPE_2</CustomerReferenceType>
  <Value>Val2</Value>
</CustomerReferences>
```

I've modified the create_shipment test to include two refs and test them.