### PR TITLE
Update active_utils to 3.2.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # ActiveShipping CHANGELOG
 
+### v1.9.2
+- Update active_utils dependency to v3.2.4
+
 ### v1.8.6
 - Fix UPS TrackResponse with no status code
 - Stop FedEx from raising for successful responses with no statuses

--- a/active_shipping.gemspec
+++ b/active_shipping.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |s|
 
   s.add_dependency("quantified", "~> 1.0.1")
   s.add_dependency("activesupport", ">= 4.2", "< 5.1.0")
-  s.add_dependency("active_utils", "~> 3.2.0")
+  s.add_dependency("active_utils", "~> 3.2.4")
   s.add_dependency("nokogiri", ">= 1.6")
 
   s.add_development_dependency("minitest")

--- a/lib/active_shipping/version.rb
+++ b/lib/active_shipping/version.rb
@@ -1,3 +1,3 @@
 module ActiveShipping
-  VERSION = "1.9.1"
+  VERSION = "1.9.2"
 end


### PR DESCRIPTION
Differences between 3.2.0 and 3.2.4: https://github.com/Shopify/active_utils/compare/v3.2.0...v3.2.4
