### PR TITLE
#date_for should return a Date, not a DateTime

### DIFF
--- a/lib/active_shipping/rate_estimate.rb
+++ b/lib/active_shipping/rate_estimate.rb
@@ -189,7 +189,7 @@ module ActiveShipping
     # @return [Date, nil] The Date object absed on the input, or `nil` if no date
     #   could be determined.
     def date_for(date)
-      date && DateTime.strptime(date.to_s, "%Y-%m-%d")
+      date && Date.strptime(date.to_s, "%Y-%m-%d")
     rescue ArgumentError
       nil
     end

--- a/test/unit/carriers/canada_post_test.rb
+++ b/test/unit/carriers/canada_post_test.rb
@@ -25,8 +25,8 @@ class CanadaPostTest < ActiveSupport::TestCase
 
     rate_estimates.rates.each do |rate|
       assert_instance_of RateEstimate, rate
-      assert_instance_of DateTime, rate.delivery_date
-      assert_instance_of DateTime, rate.shipping_date
+      assert_instance_of Date, rate.delivery_date
+      assert_instance_of Date, rate.shipping_date
       assert_instance_of String, rate.service_name
       assert_instance_of Fixnum, rate.total_price
     end
@@ -58,8 +58,8 @@ class CanadaPostTest < ActiveSupport::TestCase
 
     rate_estimates.rates.each do |rate|
       assert_instance_of RateEstimate, rate
-      assert_instance_of DateTime, rate.delivery_date
-      assert_instance_of DateTime, rate.shipping_date
+      assert_instance_of Date, rate.delivery_date
+      assert_instance_of Date, rate.shipping_date
       assert_instance_of String, rate.service_name
       assert_instance_of Fixnum, rate.total_price
     end


### PR DESCRIPTION
I believe this method is the source of a tricky bug in my application, and I suspect it is in others as well.

I discovered it while inspecting API responses from Stamps.com. As indicated by the method signature, API responses are expected to provide _calendar_ date information – any timezone information is discarded here, which is correct. However, the `#date_for` method returns an instance of DateTime, which includes time zone information. In this case that time zone is set to the default value of UTC (+0000) which is likely not correct.

If the resulting value is passed, for instance, to a Rails app that saves it in a timestamp field, it will be erroneously converted to a local time thus possibly changing the date (as it does in my application).

Changing this method to return a Date instance (as documented in the comment above `#date_for`) prevents the extra timezone information from being added by the DateTime constructor, which we don't want because the `#strptime` arguments cause them to be lost.