### PR TITLE
Added support for Holiday customization in tests

### DIFF
--- a/test/helpers/holiday_helpers.rb
+++ b/test/helpers/holiday_helpers.rb
@@ -1,0 +1,46 @@
+module HolidayHelpers
+  class MissingConfigurationError < RuntimeError; end
+
+  HOLIDAYS = {
+    ups: { # https://compass.ups.com/ups-holiday-schedule-2016/
+      "2016" => [
+        { month: 1,  day: 1  },
+        { month: 5,  day: 30 },
+        { month: 6,  day: 4  },
+        { month: 9,  day: 5  },
+        { month: 11, day: 24 },
+        { month: 12, day: 26 },
+      ],
+    }
+  }
+
+  def with_holidays(carrier, year=Date.current.year)
+    holiday_config = fetch_holidays(carrier, year)
+
+    BusinessTime::Config.with(holidays: holiday_config) do
+      yield
+    end
+
+  rescue MissingConfigurationError
+    self.logger.warn(
+      "[HolidayHelpers] Missing holiday configuration. You need to update test/helpers/holiday_helpers.rb. "\
+      "test: #{self}, carrier: #{carrier}, year: #{year}")
+    yield
+  end
+
+  private
+
+  def fetch_holidays(carrier, year)
+    carrier_holiday_config = case carrier
+    when :ups
+      HOLIDAYS[carrier]
+    else
+      raise MissingConfigurationError
+    end
+    raise MissingConfigurationError unless carrier_holiday_config.include?(year.to_s)
+
+    carrier_holiday_config[year.to_s].map do |holiday|
+      Date.new(year, holiday[:month], holiday[:day])
+    end
+  end
+end

--- a/test/remote/ups_test.rb
+++ b/test/remote/ups_test.rb
@@ -3,6 +3,7 @@ require 'test_helper'
 class RemoteUPSTest < ActiveSupport::TestCase
   include ActiveShipping::Test::Credentials
   include ActiveShipping::Test::Fixtures
+  include HolidayHelpers
 
   def setup
     @options = credentials(:ups).merge(:test => true)
@@ -312,7 +313,7 @@ class RemoteUPSTest < ActiveSupport::TestCase
     assert response.success?
     refute_empty response.delivery_estimates
     ground_delivery_estimate = response.delivery_estimates.select {|de| de.service_name == "UPS Ground"}.first
-    assert_equal 1.business_days.after(today), ground_delivery_estimate.date
+    with_holidays(:ups) { assert_equal 1.business_days.after(today), ground_delivery_estimate.date }
   end
 
   def test_delivery_date_estimates_within_zip_with_no_value
@@ -331,7 +332,7 @@ class RemoteUPSTest < ActiveSupport::TestCase
     assert response.success?
     refute_empty response.delivery_estimates
     ground_delivery_estimate = response.delivery_estimates.select {|de| de.service_name == "UPS Ground"}.first
-    assert_equal 1.business_days.after(today), ground_delivery_estimate.date
+    with_holidays(:ups) { assert_equal 1.business_days.after(today), ground_delivery_estimate.date }
   end
 
   def test_delivery_date_estimates_across_zips
@@ -350,9 +351,11 @@ class RemoteUPSTest < ActiveSupport::TestCase
     assert response.success?
     refute_empty response.delivery_estimates
     ground_delivery_estimate = response.delivery_estimates.select {|de| de.service_name == "UPS Ground"}.first
-    assert_equal 3.business_days.after(today), ground_delivery_estimate.date
-    next_day_delivery_estimate = response.delivery_estimates.select {|de| de.service_name == "UPS Next Day Air"}.first
-    assert_equal 1.business_days.after(today), next_day_delivery_estimate.date
+    with_holidays(:ups) do
+      assert_equal 3.business_days.after(today), ground_delivery_estimate.date
+      next_day_delivery_estimate = response.delivery_estimates.select {|de| de.service_name == "UPS Next Day Air"}.first
+      assert_equal 1.business_days.after(today), next_day_delivery_estimate.date
+    end
   end
 
   def test_rate_with_single_service
@@ -387,7 +390,7 @@ class RemoteUPSTest < ActiveSupport::TestCase
     assert response.success?
     refute_empty response.delivery_estimates
     ww_express_estimate = response.delivery_estimates.select {|de| de.service_name == "UPS Worldwide Express"}.first
-    assert_equal 1.business_days.after(today), ww_express_estimate.date
+    with_holidays(:ups) { assert_equal 1.business_days.after(today), ww_express_estimate.date }
   end
 
   def test_void_shipment

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -11,10 +11,16 @@ require 'logger'
 require 'erb'
 require 'pry'
 
+require_relative 'helpers/holiday_helpers.rb'
+
 Minitest::Reporters.use! Minitest::Reporters::ProgressReporter.new(detailed_skip: !!ENV["CI"])
 
 class ActiveSupport::TestCase
   include ActiveShipping
+
+  def logger
+    @logger ||= Logger.new(STDERR)
+  end
 end
 
 module ActiveShipping::Test


### PR DESCRIPTION
This allows us to wrap assertions around `with_holidays(:carrier)` - And lets us support other carriers such as usps, fedex in the future.

FedEX will be more complicated to support: http://www.fedex.com/us/service-guide/holiday-schedule.html
USPS pretty simple: https://about.usps.com/news/events-calendar/2016-postal-holidays.htm