### PR TITLE
Deprecate Fixnum usage for Integer (Ruby 2.4 Compatibility)

### DIFF
--- a/lib/active_shipping/package.rb
+++ b/lib/active_shipping/package.rb
@@ -142,7 +142,7 @@ module ActiveShipping #:nodoc:
 
     def measure(measurement, ary)
       case measurement
-      when Fixnum then ary[measurement]
+      when Integer then ary[measurement]
       when :x, :max, :length, :long then ary[2]
       when :y, :mid, :width, :wide then ary[1]
       when :z, :min, :height, :depth, :high, :deep then ary[0]

--- a/test/remote/fedex_test.rb
+++ b/test/remote/fedex_test.rb
@@ -33,7 +33,7 @@ class RemoteFedExTest < ActiveSupport::TestCase
     assert response.rates.length > 0
     response.rates.each do |rate|
       assert_instance_of String, rate.service_name
-      assert_instance_of Fixnum, rate.price
+      assert_kind_of Integer, rate.price
     end
   end
 
@@ -75,7 +75,7 @@ class RemoteFedExTest < ActiveSupport::TestCase
     assert response.rates.length > 0
     response.rates.each do |rate|
       assert_instance_of String, rate.service_name
-      assert_instance_of Fixnum, rate.price
+      assert_kind_of Integer, rate.price
     end
   end
 
@@ -134,7 +134,7 @@ class RemoteFedExTest < ActiveSupport::TestCase
     assert response.rates.length > 0
     response.rates.each do |rate|
       assert_instance_of String, rate.service_name
-      assert_instance_of Fixnum, rate.price
+      assert_kind_of Integer, rate.price
     end
   end
 
@@ -149,7 +149,7 @@ class RemoteFedExTest < ActiveSupport::TestCase
     assert response.rates.length > 0
     response.rates.each do |rate|
       assert_instance_of String, rate.service_name
-      assert_instance_of Fixnum, rate.price
+      assert_kind_of Integer, rate.price
     end
   end
 
@@ -164,7 +164,7 @@ class RemoteFedExTest < ActiveSupport::TestCase
     assert response.rates.length > 0
     response.rates.each do |rate|
       assert_instance_of String, rate.service_name
-      assert_instance_of Fixnum, rate.price
+      assert_kind_of Integer, rate.price
     end
   end
 
@@ -179,7 +179,7 @@ class RemoteFedExTest < ActiveSupport::TestCase
     assert response.rates.length > 0
     response.rates.each do |rate|
       assert_instance_of String, rate.service_name
-      assert_instance_of Fixnum, rate.price
+      assert_kind_of Integer, rate.price
     end
   end
 
@@ -194,7 +194,7 @@ class RemoteFedExTest < ActiveSupport::TestCase
     assert response.rates.length > 0
     response.rates.each do |rate|
       assert_instance_of String, rate.service_name
-      assert_instance_of Fixnum, rate.price
+      assert_kind_of Integer, rate.price
     end
   end
 

--- a/test/remote/stamps_test.rb
+++ b/test/remote/stamps_test.rb
@@ -138,7 +138,7 @@ class RemoteStampsTest < ActiveSupport::TestCase
     assert_equal '10017', response.rate.destination.zip
     assert_equal 'US', response.rate.destination.country_code
 
-    assert_instance_of Fixnum, response.rate.total_price
+    assert_kind_of Integer, response.rate.total_price
     assert_instance_of String, response.stamps_tx_id
 
     assert_nil response.label_url
@@ -169,7 +169,7 @@ class RemoteStampsTest < ActiveSupport::TestCase
     assert_equal 'K1P 1J1', response.rate.destination.zip
     assert_equal 'CA', response.rate.destination.country_code
 
-    assert_instance_of Fixnum, response.rate.total_price
+    assert_kind_of Integer, response.rate.total_price
     assert_instance_of String, response.stamps_tx_id
     assert_instance_of String, response.label_url
 
@@ -299,8 +299,8 @@ class RemoteStampsTest < ActiveSupport::TestCase
     rate = response.rates.first
     assert_equal 'Stamps', rate.carrier
     assert_equal 'USD', rate.currency
-    assert_instance_of Fixnum, rate.total_price
-    assert_instance_of Fixnum, rate.price
+    assert_kind_of Integer, rate.total_price
+    assert_kind_of Integer, rate.price
     assert_instance_of String, rate.service_name
     assert_instance_of String, rate.service_code
     assert_instance_of Array, rate.package_rates
@@ -328,8 +328,8 @@ class RemoteStampsTest < ActiveSupport::TestCase
     rate = response.rates.first
     assert_equal 'Stamps', rate.carrier
     assert_equal 'USD', rate.currency
-    assert_instance_of Fixnum, rate.total_price
-    assert_instance_of Fixnum, rate.price
+    assert_kind_of Integer, rate.total_price
+    assert_kind_of Integer, rate.price
     assert_instance_of String, rate.service_name
     assert_instance_of String, rate.service_code
     assert_instance_of Array, rate.package_rates

--- a/test/remote/ups_test.rb
+++ b/test/remote/ups_test.rb
@@ -80,12 +80,12 @@ class RemoteUPSTest < ActiveSupport::TestCase
     assert_equal 'UPS', rate.carrier
     assert_equal 'CAD', rate.currency
     if @options[:origin_account]
-      assert_instance_of Fixnum, rate.negotiated_rate
+      assert_kind_of Integer, rate.negotiated_rate
     else
       assert_equal rate.negotiated_rate, 0
     end
-    assert_instance_of Fixnum, rate.total_price
-    assert_instance_of Fixnum, rate.price
+    assert_kind_of Integer, rate.total_price
+    assert_kind_of Integer, rate.price
     assert_instance_of String, rate.service_name
     assert_instance_of String, rate.service_code
     assert_instance_of Array, rate.package_rates

--- a/test/remote/usps_test.rb
+++ b/test/remote/usps_test.rb
@@ -76,8 +76,8 @@ class RemoteUSPSTest < ActiveSupport::TestCase
     rate = response.rates.first
     assert_equal 'USPS', rate.carrier
     assert_equal 'USD', rate.currency
-    assert_instance_of Fixnum, rate.total_price
-    assert_instance_of Fixnum, rate.price
+    assert_kind_of Integer, rate.total_price
+    assert_kind_of Integer, rate.price
     assert_instance_of String, rate.service_name
     assert_instance_of String, rate.service_code
     assert_instance_of Array, rate.package_rates
@@ -109,8 +109,8 @@ class RemoteUSPSTest < ActiveSupport::TestCase
     rate = response.rates.first
     assert_equal 'USPS', rate.carrier
     assert_equal 'USD', rate.currency
-    assert_instance_of Fixnum, rate.total_price
-    assert_instance_of Fixnum, rate.price
+    assert_kind_of Integer, rate.total_price
+    assert_kind_of Integer, rate.price
     assert_instance_of String, rate.service_name
     assert_instance_of String, rate.service_code
     assert_instance_of Array, rate.package_rates

--- a/test/unit/carriers/canada_post_test.rb
+++ b/test/unit/carriers/canada_post_test.rb
@@ -28,7 +28,7 @@ class CanadaPostTest < ActiveSupport::TestCase
       assert_instance_of Date, rate.delivery_date
       assert_instance_of Date, rate.shipping_date
       assert_instance_of String, rate.service_name
-      assert_instance_of Fixnum, rate.total_price
+      assert_kind_of Integer, rate.total_price
     end
 
     rate_estimates.boxes.each do |box|
@@ -41,7 +41,7 @@ class CanadaPostTest < ActiveSupport::TestCase
       assert_instance_of Float, box.width
 
       box.packedItems.each do |p|
-        assert_instance_of Fixnum, p.quantity
+        assert_kind_of Integer, p.quantity
         assert_instance_of String, p.description
       end
     end
@@ -61,7 +61,7 @@ class CanadaPostTest < ActiveSupport::TestCase
       assert_instance_of Date, rate.delivery_date
       assert_instance_of Date, rate.shipping_date
       assert_instance_of String, rate.service_name
-      assert_instance_of Fixnum, rate.total_price
+      assert_kind_of Integer, rate.total_price
     end
 
     rate_estimates.boxes.each do |box|
@@ -74,7 +74,7 @@ class CanadaPostTest < ActiveSupport::TestCase
       assert_instance_of Float, box.width
 
       box.packedItems.each do |p|
-        assert_instance_of Fixnum, p.quantity
+        assert_kind_of Integer, p.quantity
         assert_instance_of String, p.description
       end
     end

--- a/test/unit/carriers/fedex_test.rb
+++ b/test/unit/carriers/fedex_test.rb
@@ -144,8 +144,8 @@ class FedExTest < ActiveSupport::TestCase
     rate = response.rates.first
     assert_equal 'FedEx', rate.carrier
     assert_equal 'USD', rate.currency
-    assert_instance_of Fixnum, rate.total_price
-    assert_instance_of Fixnum, rate.price
+    assert_kind_of Integer, rate.total_price
+    assert_kind_of Integer, rate.price
     assert_instance_of String, rate.service_name
     assert_instance_of String, rate.service_code
     assert_instance_of Array, rate.package_rates
@@ -177,8 +177,8 @@ class FedExTest < ActiveSupport::TestCase
     rate = response.rates.first
     assert_equal 'FedEx', rate.carrier
     assert_equal 'CAD', rate.currency
-    assert_instance_of Fixnum, rate.total_price
-    assert_instance_of Fixnum, rate.price
+    assert_kind_of Integer, rate.total_price
+    assert_kind_of Integer, rate.price
     assert_instance_of String, rate.service_name
     assert_instance_of String, rate.service_code
     assert_instance_of Array, rate.package_rates


### PR DESCRIPTION
In ruby 2.4, Fixnum and Bignums were unified together into the Integer class.

We should deprecate them so that we can upgrade to ruby 2.4 without deprecations.

Links related to this change in ruby...

https://bugs.ruby-lang.org/issues/12005
http://blog.bigbinary.com/2016/11/18/ruby-2-4-unifies-fixnum-and-bignum-into-integer.html