### PR TITLE
Added holiday configuration for 2017 on ups provider

### DIFF
--- a/test/helpers/holiday_helpers.rb
+++ b/test/helpers/holiday_helpers.rb
@@ -11,6 +11,14 @@ module HolidayHelpers
         { month: 11, day: 24 },
         { month: 12, day: 26 },
       ],
+      "2017" => [
+        { month: 1,  day: 2  },
+        { month: 5,  day: 29 },
+        { month: 6,  day: 4  },
+        { month: 9,  day: 4  },
+        { month: 11, day: 23 },
+        { month: 12, day: 25 },
+      ]
     }
   }
 


### PR DESCRIPTION
This PR adds a basic holiday configuration for the 2017 year on the ups provider for tests.

Required for #453 and further PR that will be done in 2017.