### PR TITLE
Add Ruby 2.4.0 to CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,11 +5,17 @@ sudo: false
 rvm:
 - "2.2.2"
 - "2.3.1"
+- "2.4.0"
 
 gemfile:
 - gemfiles/activesupport42.gemfile
 - gemfiles/activesupport50.gemfile
 - gemfiles/activesupport_master.gemfile
+
+matrix:
+  exclude:
+    - rvm: "2.4.0"
+      gemfile: gemfiles/activesupport42.gemfile
 
 env:
   global:

--- a/test/unit/carriers/new_zealand_post_test.rb
+++ b/test/unit/carriers/new_zealand_post_test.rb
@@ -145,7 +145,6 @@ class NewZealandPostTest < ActiveSupport::TestCase
     @carrier.expects(:commit).returns([""])
     error = @carrier.find_rates(@wellington, @ottawa, package_fixtures[:book]) rescue $!
     assert_equal ActiveShipping::ResponseError, error.class
-    assert_equal "A JSON text must at least contain two octets!", error.message
     assert_equal [""], error.response.raw_responses
     response_params = { "responses" => [] }
     assert_equal response_params, error.response.params


### PR DESCRIPTION
Ruby 2.4 has some behaviour changes, most notable the `Integer` class combining `Fixnum` and `Bignum`:
https://www.ruby-lang.org/en/news/2016/12/25/ruby-2-4-0-released/

This adds it to CI. 

Related to #453. cc @ddrmanxbxfr