### PR TITLE
Modernize ResponseTest

### DIFF
--- a/test/unit/response_test.rb
+++ b/test/unit/response_test.rb
@@ -1,19 +1,38 @@
 require 'test_helper'
 
 class ResponseTest < ActiveSupport::TestCase
-  def test_initialize_success
-    response = RateResponse.new(true, "success!", {:rate => 'Free!'}, :rates => [stub(:service_name => 'Free!', :total_price => 0)], :xml => "<rate>Free!</rate>")
-    assert response.success?
+  test "#initialize for a successful response" do
+    response = RateResponse.new(
+      true,
+      "success!",
+      { rate: 'Free!' },
+      rates: [ stub(service_name: 'Free!', total_price: 0) ],
+      xml: "<rate>Free!</rate>"
+    )
+    assert_predicate response, :success?
   end
 
-  def test_initialize_failure
+  test "#initialize for a failed response raises ResponseError" do
     assert_raises(ActiveShipping::ResponseError) do
-      RateResponse.new(false, "fail!", {:rate => 'Free!'}, :rates => [stub(:service_name => 'Free!', :total_price => 0)], :xml => "<rate>Free!</rate>")
+      RateResponse.new(
+        false,
+        "fail!",
+        { rate: 'Free!' },
+        rates: [ stub(service_name: 'Free!', total_price: 0) ],
+        xml: "<rate>Free!</rate>"
+      )
     end
   end
 
-  def test_initialize_failure_no_raise
-    response = RateResponse.new(false, "fail!", {:rate => 'Free!'}, :rates => [stub(:service_name => 'Free!', :total_price => 0)], :xml => "<rate>Free!</rate>", :allow_failure => true)
-    refute response.success?
+  test "#initialize doesn't raise when you pass in allow_failure" do
+    response = RateResponse.new(
+      false,
+      "fail!",
+      { rate: 'Free!' },
+      rates: [ stub(service_name: 'Free!', total_price: 0) ],
+      xml: "<rate>Free!</rate>",
+      allow_failure: true,
+    )
+    refute_predicate response, :success?
   end
 end


### PR DESCRIPTION
1. Uses `test "" do` syntax.
2. Multi-line `.new` because readability and line length considerations.
3. `assert_predicate` over `assert`.

