### PR TITLE
Adds notion of whether parsed timestamp for ShipmentEvent has a timezone

### DIFF
--- a/lib/active_shipping/carriers/fedex.rb
+++ b/lib/active_shipping/carriers/fedex.rb
@@ -662,10 +662,12 @@ module ActiveShipping
           description = event.at('EventDescription').text
           type_code = event.at('EventType').text
 
-          time          = Time.parse(event.at('Timestamp').text)
+          timestamp     = event.at('Timestamp').text
+          time          = Time.parse(timestamp)
+          zoneless      = (timestamp =~ /[-+]\d{2}:\d{2}$/).blank?
           zoneless_time = time.utc
 
-          shipment_events << ShipmentEvent.new(description, zoneless_time, location, description, type_code)
+          shipment_events << ShipmentEvent.new(description, zoneless_time, location, description, type_code, zoneless)
         end
         shipment_events = shipment_events.sort_by(&:time)
 

--- a/lib/active_shipping/carriers/fedex.rb
+++ b/lib/active_shipping/carriers/fedex.rb
@@ -664,12 +664,12 @@ module ActiveShipping
           description = event.at('EventDescription').text
           type_code = event.at('EventType').text
 
-          timestamp     = event.at('Timestamp').text
-          time          = Time.parse(timestamp)
-          zoneless      = (timestamp =~ TIMEZONE_OFFSET_FROM_DATE_REGEX).blank?
-          zoneless_time = time.utc
+          timestamp          = event.at('Timestamp').text
+          time               = Time.parse(timestamp)
+          timezone_ambiguous = (timestamp =~ TIMEZONE_OFFSET_FROM_DATE_REGEX).blank?
+          zoneless_time      = time.utc
 
-          shipment_events << ShipmentEvent.new(description, zoneless_time, location, description, type_code, zoneless)
+          shipment_events << ShipmentEvent.new(description, zoneless_time, location, description, type_code, timezone_ambiguous)
         end
         shipment_events = shipment_events.sort_by(&:time)
 

--- a/lib/active_shipping/carriers/fedex.rb
+++ b/lib/active_shipping/carriers/fedex.rb
@@ -13,6 +13,8 @@ module ActiveShipping
     TEST_URL = 'https://gatewaybeta.fedex.com:443/xml'
     LIVE_URL = 'https://gateway.fedex.com:443/xml'
 
+    TIMEZONE_OFFSET_FROM_DATE_REGEX = /[-+](\d{2}:\d{2})$/
+
     CARRIER_CODES = {
       "fedex_ground" => "FDXG",
       "fedex_express" => "FDXE"
@@ -664,7 +666,7 @@ module ActiveShipping
 
           timestamp     = event.at('Timestamp').text
           time          = Time.parse(timestamp)
-          zoneless      = (timestamp =~ /[-+]\d{2}:\d{2}$/).blank?
+          zoneless      = (timestamp =~ TIMEZONE_OFFSET_FROM_DATE_REGEX).blank?
           zoneless_time = time.utc
 
           shipment_events << ShipmentEvent.new(description, zoneless_time, location, description, type_code, zoneless)

--- a/lib/active_shipping/shipment_event.rb
+++ b/lib/active_shipping/shipment_event.rb
@@ -2,12 +2,16 @@ module ActiveShipping
   class ShipmentEvent
     attr_reader :name, :time, :location, :message, :type_code
 
-    def initialize(name, time, location, message = nil, type_code = nil)
-      @name, @time, @location, @message, @type_code = name, time, location, message, type_code
+    def initialize(name, time, location, message = nil, type_code = nil, zoneless = true)
+      @name, @time, @location, @message, @type_code, @zoneless = name, time, location, message, type_code, zoneless
     end
 
     def delivered?
       status == :delivered
+    end
+
+    def zoneless?
+      @zoneless
     end
 
     def status

--- a/lib/active_shipping/shipment_event.rb
+++ b/lib/active_shipping/shipment_event.rb
@@ -2,16 +2,16 @@ module ActiveShipping
   class ShipmentEvent
     attr_reader :name, :time, :location, :message, :type_code
 
-    def initialize(name, time, location, message = nil, type_code = nil, zoneless = true)
-      @name, @time, @location, @message, @type_code, @zoneless = name, time, location, message, type_code, zoneless
+    def initialize(name, time, location, message = nil, type_code = nil, timezone_ambiguous = true)
+      @name, @time, @location, @message, @type_code, @timezone_ambiguous = name, time, location, message, type_code, timezone_ambiguous
     end
 
     def delivered?
       status == :delivered
     end
 
-    def zoneless?
-      @zoneless
+    def timezone_ambiguous?
+      @timezone_ambiguous
     end
 
     def status

--- a/test/unit/carriers/fedex_test.rb
+++ b/test/unit/carriers/fedex_test.rb
@@ -469,13 +469,13 @@ class FedExTest < ActiveSupport::TestCase
     assert_equal 'IT', response.latest_event.type_code
   end
 
-  test "tracking: shipment_events have zoneless=false for the timestamp received from remote" do
+  test "tracking: shipment_events have timezone_ambiguous? false for the timestamp received from remote" do
     mock_response = xml_fixture('fedex/tracking_response_in_transit')
     @carrier.expects(:commit).returns(mock_response)
     response = @carrier.find_tracking_info('123456789012')
 
     shipment_event = response.shipment_events.first
-    refute_predicate shipment_event, :zoneless?
+    refute_predicate shipment_event, :timezone_ambiguous?
   end
 
   def test_tracking_info_for_shipment_exception

--- a/test/unit/carriers/fedex_test.rb
+++ b/test/unit/carriers/fedex_test.rb
@@ -469,6 +469,15 @@ class FedExTest < ActiveSupport::TestCase
     assert_equal 'IT', response.latest_event.type_code
   end
 
+  test "tracking: shipment_events have zoneless=false for the timestamp received from remote" do
+    mock_response = xml_fixture('fedex/tracking_response_in_transit')
+    @carrier.expects(:commit).returns(mock_response)
+    response = @carrier.find_tracking_info('123456789012')
+
+    shipment_event = response.shipment_events.first
+    refute_predicate shipment_event, :zoneless?
+  end
+
   def test_tracking_info_for_shipment_exception
     mock_response = xml_fixture('fedex/tracking_response_shipment_exception')
     @carrier.expects(:commit).returns(mock_response)

--- a/test/unit/carriers/usps_test.rb
+++ b/test/unit/carriers/usps_test.rb
@@ -71,6 +71,16 @@ class USPSTest < ActiveSupport::TestCase
     assert_equal '9102901000462189604217', response.tracking_number
   end
 
+  test "tracking: shipment_events have zoneless=true for the timestamp received from remote" do
+    @carrier.expects(:commit).returns(@tracking_response)
+    response = @carrier.find_tracking_info('9102901000462189604217', :test => true)
+
+    response.shipment_events.each do |shipment_event|
+      assert shipment_event.time.present?, message: "Event did not have a timestamp"
+      assert_predicate shipment_event, :zoneless?
+    end
+  end
+
   def test_find_tracking_info_should_return_shipment_events_in_ascending_chronological_order
     @carrier.expects(:commit).returns(@tracking_response)
     response = @carrier.find_tracking_info('9102901000462189604217', :test => true)

--- a/test/unit/carriers/usps_test.rb
+++ b/test/unit/carriers/usps_test.rb
@@ -71,13 +71,13 @@ class USPSTest < ActiveSupport::TestCase
     assert_equal '9102901000462189604217', response.tracking_number
   end
 
-  test "tracking: shipment_events have zoneless=true for the timestamp received from remote" do
+  test "tracking: shipment_events have timezone_ambiguous? true for the timestamp received from remote" do
     @carrier.expects(:commit).returns(@tracking_response)
     response = @carrier.find_tracking_info('9102901000462189604217', :test => true)
 
     response.shipment_events.each do |shipment_event|
       assert shipment_event.time.present?, message: "Event did not have a timestamp"
-      assert_predicate shipment_event, :zoneless?
+      assert_predicate shipment_event, :timezone_ambiguous?
     end
   end
 


### PR DESCRIPTION
Information around timezones can be lost when creating tracking events.  We've attempted to normalize the shipment event time in tracking events to a "zoneless" fashion, but from an API consumer perspective, it can be handy to know if the UTC time value on the event is really UTC, or UTC only by virtue of the carrier not having supplied a timezone with their timestamp.

Examples:
USPS timestamps look a bit like:
```xml
      <EventTime>9:01 am</EventTime>
      <EventDate>April 28, 2015</EventDate>
```
with no other info as to convey the timezone.  It's probably based on the city/province/country in question, but perhaps it could be USPS server time.  In any case, it's ambiguous and `timezone_ambiguous?` would&should be true.

FedEx timestamps (most? all?) look like this:
```xml
<Timestamp>2014-11-18T18:13:00+11:00</Timestamp>
```
since the TZ is included in the timestamp, `timezone_ambiguous?` would&should be `false`.

This PR adds a method to be more sure whether an instance of `ShipmentEvent` is really zoneless or not