### PR TITLE
Change Package interface for ActiveShipping 2.0

### DIFF
--- a/lib/active_shipping/package.rb
+++ b/lib/active_shipping/package.rb
@@ -1,118 +1,62 @@
 module ActiveShipping #:nodoc:
   class Package
-    cattr_accessor :default_options
-    attr_reader :options, :value, :currency
+    cattr_accessor :default_options do {} end
+    attr_reader :weight, :length, :width, :height, :options, :value, :currency
 
-    # Package.new(100, [10, 20, 30], :units => :metric)
-    # Package.new(Mass.new(100, :grams), [10, 20, 30].map {|m| Length.new(m, :centimetres)})
-    # Package.new(100.grams, [10, 20, 30].map(&:centimetres))
-    def initialize(grams_or_ounces, dimensions, options = {})
-      options = @@default_options.update(options) if @@default_options
-      options.symbolize_keys!
-      @options = options
+    alias_attribute :mass, :weight
 
-      @dimensions = [dimensions].flatten.reject(&:nil?)
+    def initialize(weight:, length:, width:, height: nil, options: {})
+      @options = @@default_options.merge(options.symbolize_keys)
 
-      imperial = (options[:units] == :imperial) ||
-                 ([grams_or_ounces, *dimensions].all? { |m| m.respond_to?(:unit) && m.unit.to_sym == :imperial })
+      raise ArgumentError, "Weight needs to be a Measured::Measurable object" unless weight.is_a?(Measured::Measurable)
+      raise ArgumentError, "Length needs to be a Measured::Measurable object" unless length.is_a?(Measured::Measurable)
+      raise ArgumentError, "Width needs to be a Measured::Measurable object" unless width.is_a?(Measured::Measurable)
+      raise ArgumentError, "Height needs to be a Measured::Measurable object" unless height.nil? || length.is_a?(Measured::Measurable)
 
-      weight_imperial = dimensions_imperial = imperial if options.include?(:units)
+      @weight = weight
 
-      if options.include?(:weight_units)
-        weight_imperial = (options[:weight_units] == :imperial) ||
-                          (grams_or_ounces.respond_to?(:unit) && m.unit.to_sym == :imperial)
-      end
+      @length = length
+      @width  = width
+      @height = height || ( cylinder? ? width : Measured::Length.new(0, length.unit) )
 
-      if options.include?(:dim_units)
-        dimensions_imperial = (options[:dim_units] == :imperial) ||
-                              (dimensions && dimensions.all? { |m| m.respond_to?(:unit) && m.unit.to_sym == :imperial })
-      end
+      @value = self.class.cents_from(options[:value])
+      @currency = options[:currency] || options[:value].try(:currency)
+    end
 
-      @weight_unit_system = weight_imperial ? :imperial : :metric
-      @dimensions_unit_system = dimensions_imperial ? :imperial : :metric
+    def dimensions
+      [@length, @width, @height]
+    end
 
-      @weight = attribute_from_metric_or_imperial(grams_or_ounces, Measured::Weight, @weight_unit_system, :grams, :ounces)
+    def girth
+      @girth ||= cylinder ? width.scale(Math::PI) : (width + height).scale(2)
+    end
+    alias_method :circumference, :girth
+    alias_method :around, :girth
 
-      if @dimensions.blank?
-        zero_length = Measured::Length.new(0, (dimensions_imperial ? :inches : :centimetres))
-        @dimensions = [zero_length] * 3
+    def volume
+      @volume ||= if cylinder?
+        Math::PI * width.scale(0.5).value * height.scale(0.5).value * length.value
       else
-        process_dimensions
+        length.value * width.value * height.value
       end
-
-      @value = Package.cents_from(options[:value])
-      @currency = options[:currency] || (options[:value].currency if options[:value].respond_to?(:currency))
-      @cylinder = (options[:cylinder] || options[:tube]) ? true : false
-      @gift = options[:gift] ? true : false
-      @oversized = options[:oversized] ? true : false
-      @unpackaged = options[:unpackaged] ? true : false
-    end
-
-    def unpackaged?
-      @unpackaged
-    end
-
-    def oversized?
-      @oversized
     end
 
     def cylinder?
-      @cylinder
+      @cylinder ||= @options[:cylinder].present?
     end
     alias_method :tube?, :cylinder?
 
     def gift?
-      @gift
+      @gift ||= @options[:gift].present?
     end
 
-    def ounces(options = {})
-      weight(options).convert_to(:oz).value
+    def oversized?
+      @oversized ||= @options[:oversized].present?
     end
-    alias_method :oz, :ounces
 
-    def grams(options = {})
-      weight(options).convert_to(:g).value
+    def unpackaged?
+      @unpackaged ||= @options[:unpackaged].present?
     end
-    alias_method :g, :grams
-
-    def pounds(options = {})
-      weight(options).convert_to(:lb).value
-    end
-    alias_method :lb, :pounds
-    alias_method :lbs, :pounds
-
-    def kilograms(options = {})
-      weight(options).convert_to(:kg).value
-    end
-    alias_method :kg, :kilograms
-    alias_method :kgs, :kilograms
-
-    def inches(measurement = nil)
-      @inches ||= @dimensions.map { |m| m.convert_to(:in).value }
-      measurement.nil? ? @inches : measure(measurement, @inches)
-    end
-    alias_method :in, :inches
-
-    def centimetres(measurement = nil)
-      @centimetres ||= @dimensions.map { |m| m.convert_to(:cm).value }
-      measurement.nil? ? @centimetres : measure(measurement, @centimetres)
-    end
-    alias_method :cm, :centimetres
-
-    def weight(options = {})
-      case options[:type]
-      when nil, :actual
-        @weight
-      when :volumetric, :dimensional
-        @volumetric_weight ||= begin
-          m = Measured::Weight.new((centimetres(:box_volume) / 6.0), :grams)
-          @weight_unit_system == :imperial ? m.convert_to(:oz) : m
-        end
-      when :billable
-        [weight, weight(:type => :volumetric)].max
-      end
-    end
-    alias_method :mass, :weight
 
     def self.cents_from(money)
       return nil if money.nil?
@@ -127,41 +71,6 @@ module ActiveShipping #:nodoc:
         else
           money.to_i
         end
-      end
-    end
-
-    private
-
-    def attribute_from_metric_or_imperial(obj, klass, unit_system, metric_unit, imperial_unit)
-      if obj.is_a?(klass)
-        return obj
-      else
-        return klass.new(obj, (unit_system == :imperial ? imperial_unit : metric_unit))
-      end
-    end
-
-    def measure(measurement, ary)
-      case measurement
-      when Integer then ary[measurement]
-      when :x, :max, :length, :long then ary[2]
-      when :y, :mid, :width, :wide then ary[1]
-      when :z, :min, :height, :depth, :high, :deep then ary[0]
-      when :girth, :around, :circumference
-        self.cylinder? ? (Math::PI * (ary[0] + ary[1]) / 2) : (2 * ary[0]) + (2 * ary[1])
-      when :volume then self.cylinder? ? (Math::PI * (ary[0] + ary[1]) / 4)**2 * ary[2] : measure(:box_volume, ary)
-      when :box_volume then ary[0] * ary[1] * ary[2]
-      end
-    end
-
-    def process_dimensions
-      @dimensions = @dimensions.map do |l|
-        attribute_from_metric_or_imperial(l, Measured::Length, @dimensions_unit_system, :centimetres, :inches)
-      end.sort
-      # [1,2] => [1,1,2]
-      # [5] => [5,5,5]
-      # etc..
-      2.downto(@dimensions.length) do |_n|
-        @dimensions.unshift(@dimensions[0])
       end
     end
   end


### PR DESCRIPTION
# Preface
This PR makes major opinionated changes to the interface of `ActiveShipping::Package`. Feel free to chime in with your own opinions, because these opinions are often my own and I've been known to be wrong in the past. 😛 

# Changes
There are many changes here. Here's a list, with some more explicit details below each.

1. The constructor method for `Package` is much more explicit, at the cost of an increase in verbosity. 
    - No more memorization of argument order - `length:, width:, height:, weight:, options:` in any order. Keyword arguments!
2. The only dimension that can be omitted is `Height`.
    - Omitting any dimension raises an `ArgumentError` except for `Height`, which is commonly omitted in the shipping industry (e.g. envelopes!). In this case, it'll default to `Measured::Length(0, :cm)`, where the unit is the same as the defined dimensions' units.
3. `units`/`weight_unit_system`/`dimensions_unit_system`/all the unit things are gone. We're using `Measured` objects so we shouldn't need them.
    - It also means you can mix and match your units willy-nilly. If you want to have a length in centimetres and a width in inches, go wild. 
4. The named unit methods like `ounces`, `pounds`, `centimetres`, `inches`, etc are all gone.
    - I've introduced a `dimensions` method that operates like the old `inches/centimetres` methods, returning an array of the dimensions; only in `Measured` objects, not Floats.
    - `ounces` and `pounds` were mostly just arbitrary shortcuts to converting `Measured` objects and getting their raw values. I don't believe it's necessary but I can be persuaded otherwise. 
5. Volumetric and dimensional weight calculations are removed, because they're calculated on a per-carrier basis, not generically. 
    - See: https://github.com/Shopify/active_shipping/issues/466#issuecomment-272217277

# This is incomplete!
There's a few things that need to be done before this can be merged.

1. Fix everything that breaks because of the interface change. Like 40% of our tests are now red. 
2. Figure out a fix for `cents_from`. Related: #458 
3. Reintroduce volumetric/dimensional weight. Probably the same way we do 2. 
4. Add `Measured 2.0` so we can actually use the new Measured features. 