### PR TITLE
Add VCR gem for remote tests

### DIFF
--- a/active_shipping.gemspec
+++ b/active_shipping.gemspec
@@ -31,4 +31,6 @@ Gem::Specification.new do |s|
   s.add_development_dependency("business_time")
   s.add_development_dependency("pry")
   s.add_development_dependency("pry-byebug")
+  s.add_development_dependency("vcr")
+  s.add_development_dependency("webmock")
 end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -10,10 +10,18 @@ require 'active_shipping'
 require 'logger'
 require 'erb'
 require 'pry'
+require 'vcr'
+require 'webmock/minitest'
 
 require_relative 'helpers/holiday_helpers.rb'
 
 Minitest::Reporters.use! Minitest::Reporters::ProgressReporter.new(detailed_skip: !!ENV["CI"])
+
+VCR.configure do |config|
+  config.cassette_library_dir = 'test/remote/vcr_cassettes'
+  config.allow_http_connections_when_no_cassette = true
+  config.hook_into :webmock
+end
 
 class ActiveSupport::TestCase
   include ActiveShipping


### PR DESCRIPTION
Mostly a setup PR.  Adds the `vcr` and `webmock` dependencies so we can run remote tests locally, and push the results to CI.

Before I merge I'll try running some carrier tests to verify the saved cassette data doesn't contain credentials 😅 