### PR TITLE
Raise a ResponseError for FedEx#find_tracking_info

### DIFF
--- a/lib/active_shipping/carriers/fedex.rb
+++ b/lib/active_shipping/carriers/fedex.rb
@@ -590,6 +590,12 @@ module ActiveShipping
       message = response_message(xml)
 
       if success
+        tracking_details_root = xml.at('CompletedTrackDetails')
+        success = response_success?(tracking_details_root)
+        message = response_message(tracking_details_root)
+      end
+
+      if success
         delivery_signature = nil
         shipment_events = []
 
@@ -718,13 +724,13 @@ module ActiveShipping
     end
 
     def response_success?(document)
-      highest_severity = document.root.at('HighestSeverity')
+      highest_severity = document.at('HighestSeverity')
       return false if highest_severity.nil?
       %w(SUCCESS WARNING NOTE).include?(highest_severity.text)
     end
 
     def response_message(document)
-      notifications = document.root.at('Notifications')
+      notifications = document.at('Notifications')
       return "" if notifications.nil?
 
       "#{notifications.at('Severity').text} - #{notifications.at('Code').text}: #{notifications.at('Message').text}"

--- a/test/fixtures/xml/fedex/tracking_response_no_results.xml
+++ b/test/fixtures/xml/fedex/tracking_response_no_results.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<TrackReply xmlns="http://fedex.com/ws/track/v7" xmlns:SOAP-ENV="http://schemas.xmlsoap.org/soap/envelope/">
+  <HighestSeverity>SUCCESS</HighestSeverity>
+  <Notifications>
+    <Severity>SUCCESS</Severity>
+    <Source>trck</Source>
+    <Code>0</Code>
+    <Message>Request was successfully processed.</Message>
+    <LocalizedMessage>Request was successfully processed.</LocalizedMessage>
+  </Notifications>
+  <TransactionDetail>
+    <CustomerTransactionId>ActiveShipping</CustomerTransactionId>
+  </TransactionDetail>
+  <Version>
+    <ServiceId>trck</ServiceId>
+    <Major>7</Major>
+    <Intermediate>0</Intermediate>
+    <Minor>0</Minor>
+  </Version>
+  <CompletedTrackDetails>
+    <HighestSeverity>SUCCESS</HighestSeverity>
+    <DuplicateWaybill>true</DuplicateWaybill>
+    <MoreData>false</MoreData>
+  </CompletedTrackDetails>
+</TrackReply>

--- a/test/fixtures/xml/fedex/tracking_response_unable_to_process.xml
+++ b/test/fixtures/xml/fedex/tracking_response_unable_to_process.xml
@@ -18,8 +18,15 @@
     <Minor>0</Minor>
   </Version>
   <CompletedTrackDetails>
-    <HighestSeverity>SUCCESS</HighestSeverity>
-    <DuplicateWaybill>true</DuplicateWaybill>
+    <HighestSeverity>FAILURE</HighestSeverity>
+    <Notifications>
+      <Severity>FAILURE</Severity>
+      <Source>trck</Source>
+      <Code>6330</Code>
+      <Message>Sorry, we are unable to process your tracking request.  Please retry later, or contact Customer Service at 1.800.Go.FedEx(R) 800.463.3339.</Message>
+      <LocalizedMessage>Sorry, we are unable to process your tracking request.  Please retry later, or contact Customer Service at 1.800.Go.FedEx(R) 800.463.3339.</LocalizedMessage>
+    </Notifications>
+    <DuplicateWaybill>false</DuplicateWaybill>
     <MoreData>false</MoreData>
   </CompletedTrackDetails>
 </TrackReply>

--- a/test/remote/fedex_test.rb
+++ b/test/remote/fedex_test.rb
@@ -316,6 +316,8 @@ class RemoteFedExTest < ActiveSupport::TestCase
     end
   end
 
+  ### create_shipment
+
   def test_cant_obtain_multiple_shipping_labels
     assert_raises(ActiveShipping::Error,"Multiple packages are not supported yet.") do
       @carrier.create_shipment(


### PR DESCRIPTION
In a couple of places we were raising an `ActiveShipping::Error` when we could raise/return a more informed `ActiveShipping::TrackingResponse(false, ...)` that has additional information (e..g, response, request) for clients of this gem.

The one point of discussion here is w.r.t. the semantics of `ResponseError`. Generally it means there was an issue in the response, but for these two cases I've changed aren't considered error responses by FedEx, and aren't given special status codes (i.e., `/TrackReply/Notifications/Code` is 0), so perhaps this doesn't make sense?

Also made a few small formatting changes on nearby code (separate commit).