### PR TITLE
Add available_services method to carrier class

### DIFF
--- a/lib/active_shipping/carrier.rb
+++ b/lib/active_shipping/carrier.rb
@@ -94,11 +94,11 @@ module ActiveShipping
 
     # Get a list of services available for the a specific route
     #
-    # @param origin_country [String] The country of origin
-    # @param destination_country [String] The destination country
+    # @param origin_country_code [String] The country of origin
+    # @param destination_country_code [String] The destination country
     # @return [Array<String>] A list of names of the available services
     #
-    def available_services(origin_country, destination_country)
+    def available_services(origin_country_code, destination_country_code, options = {})
       raise NotImplementedError, "#available_services is not supported by #{self.class.name}."
     end
 

--- a/lib/active_shipping/carrier.rb
+++ b/lib/active_shipping/carrier.rb
@@ -92,6 +92,16 @@ module ActiveShipping
       raise NotImplementedError, "#find_tracking_info is not supported by #{self.class.name}."
     end
 
+    # Get a list of services available for the a specific route
+    #
+    # @param origin_country [String] The country of origin
+    # @param destination_country [String] The destination country
+    # @return [Array<String>] A list of names of the available services
+    #
+    def available_services(origin_country, destination_country)
+      raise NotImplementedError, "#available_services is not supported by #{self.class.name}."
+    end
+
     # Validate credentials with a call to the API.
     #
     # By default this just does a `find_rates` call with the origin and destination both as

--- a/test/unit/carrier_test.rb
+++ b/test/unit/carrier_test.rb
@@ -34,6 +34,12 @@ class CarrierTest < ActiveSupport::TestCase
     end
   end
 
+  test "#available_services is not implemented" do
+    assert_raises NotImplementedError do
+      @carrier.available_services(nil, nil)
+    end
+  end
+
   test "#maximum_weight returns a Measured::Weight" do
     assert_equal Measured::Weight.new(150, :pounds), @carrier.maximum_weight
   end


### PR DESCRIPTION
# Why

Carriers implement different ways to define what services are available for a route. We should have a common interface to fetch this information.

# What

By adding `available_services` method to the `Carrier` class, we could easily fetch a list of available services between two countries.

Other things to consider: There's a few other things that could impact the service availability like package price and weight (and many more). I figured the most common would be by route (countries from and to) and if you have a package, you can always just fetch the rates to see the available services.

I'm also not sure about the input parameters, using countries seems simple enough and to integrate well with carriers but we could also use a full `Location` to represent the origin and destination.

cc @qq99 @mdking