### PR TITLE
Fix ShipmentPacker#pack to pack whole items when max weight is float

### DIFF
--- a/lib/active_shipping/shipment_packer.rb
+++ b/lib/active_shipping/shipment_packer.rb
@@ -84,7 +84,8 @@ module ActiveShipping
           # Grab the max amount of this item we can fit into this package
           # Or, if there are fewer than the max for this item, put
           # what is left into this package
-          [(maximum_weight - package_weight) / item_grams, item_quantity].min
+          available_grams = (maximum_weight - package_weight).to_i
+          [available_grams / item_grams, item_quantity].min
         end
       end
 

--- a/test/unit/shipment_packer_test.rb
+++ b/test/unit/shipment_packer_test.rb
@@ -36,6 +36,19 @@ class ShipmentPackerTest < ActiveSupport::TestCase
     end
   end
 
+  def test_divide_order_with_single_line_into_two_packages_max_weight_as_float
+    max_weight = 68038.8555
+
+    items = [{ grams: 45359, quantity: 2, price: 1.0 }]
+
+    packages = ShipmentPacker.pack(items, @dimensions, max_weight, 'USD')
+    assert_equal 2, packages.size
+
+    packages.each do |package|
+      assert_equal Measured::Weight(45359, :g), package.weight
+    end
+  end
+
   def test_divide_order_with_multiple_lines_into_two_packages
     items = [
       {:grams => 1, :quantity => 1, :price => 1.0},


### PR DESCRIPTION
There's currently an issue with `ShipmentPacker#pack` when max weight is passed in as a float. 

https://github.com/Shopify/active_shipping/blob/master/lib/active_shipping/shipment_packer.rb#L49

Particularly `(maximum_weight - package_weight) / item[:grams].to_i`

if max weights is a float (or something like it) they'd be off by one package.. this is because it tries to pack as much as it can in one box, so if they pass a float for `maximum_weight ` we can end up packing half an item

````
irb(main):001:0> 1.0 / 2
=> 0.5
irb(main):002:0> 1 / 2
=> 0
irb(main):003:0> 

````

Which then `items.reject! { |i| i[:quantity].to_i==0 }` discards the remaining half of the item.

Solution is to `.to_i` the numerator, denominator is already an integer.