### PR TITLE
Fix ExcessPackageQuantity validation

### DIFF
--- a/lib/active_shipping/shipment_packer.rb
+++ b/lib/active_shipping/shipment_packer.rb
@@ -30,6 +30,8 @@ module ActiveShipping
             package_weight, package_value = 0, 0
             state = :filling_package
           when :filling_package
+            validate_package_quantity(packages.count)
+
             items_to_pack.each do |item|
               quantity = determine_fillable_quantity_for_package(item, maximum_weight, package_weight)
               package_weight += item_weight(quantity, item[:grams])
@@ -61,6 +63,10 @@ module ActiveShipping
 
           raise_excess_quantity_error if maybe_excess_package_quantity?(total_weight, maximum_weight)
         end
+      end
+
+      def validate_package_quantity(number_of_packages)
+        raise_excess_quantity_error if number_of_packages >= EXCESS_PACKAGE_QUANTITY_THRESHOLD
       end
 
       def raise_excess_quantity_error

--- a/test/unit/shipment_packer_test.rb
+++ b/test/unit/shipment_packer_test.rb
@@ -146,10 +146,35 @@ class ShipmentPackerTest < ActiveSupport::TestCase
     assert_equal 100, package.value
   end
 
-  test "excess packages" do
+  test "excess packages raised over threshold before packing begins" do
+    ActiveShipping::Package.expects(:new).never
+    items = [{ grams: 1, quantity: ShipmentPacker::EXCESS_PACKAGE_QUANTITY_THRESHOLD + 1, price: 1.0 }]
+
     assert_raises(ShipmentPacker::ExcessPackageQuantity) do
-      items = [{ grams: 1, quantity: ShipmentPacker::EXCESS_PACKAGE_QUANTITY_THRESHOLD + 1, price: 1.0 }]
       ShipmentPacker.pack(items, @dimensions, 1, 'USD')
+    end
+  end
+
+  test "excess packages not raised at threshold" do
+    items = [{ grams: 1, quantity: ShipmentPacker::EXCESS_PACKAGE_QUANTITY_THRESHOLD, price: 1.0 }]
+    packages = ShipmentPacker.pack(items, @dimensions, 1, 'USD')
+
+    assert_predicate packages, :present?
+  end
+
+  test "excess packages not raised below threshold" do
+    items = [{ grams: 1, quantity: ShipmentPacker::EXCESS_PACKAGE_QUANTITY_THRESHOLD - 1, price: 1.0 }]
+    packages = ShipmentPacker.pack(items, @dimensions, 1, 'USD')
+
+    assert_predicate packages, :present?
+  end
+
+  test "excess packages with slightly larger max weight than item weight" do
+    max_weight = 750
+    items = [{ grams: 500, quantity: ShipmentPacker::EXCESS_PACKAGE_QUANTITY_THRESHOLD + 1, price: 1.0 }]
+
+    assert_raises(ShipmentPacker::ExcessPackageQuantity) do
+      ShipmentPacker.pack(items, @dimensions, max_weight, 'USD')
     end
   end
 


### PR DESCRIPTION
The current ExcessPackageQuantity error is checked using:
`total_weight > (maximum_weight * EXCESS_PACKAGE_QUANTITY_THRESHOLD)`

This works for the most part, but this starts to fail when packages are not packed to their max capacity. For example, max weight is 750g, you have one item that weighs 500g with 10001 quantity, the check will do (500 * 10001) > (750 * 10000), which returns false. But at the end of the packing process, you would still end up with 10001 packages, which is over the threshold.

I think this validation is still good, but its not 100% accurate, its a best guess, looser validation. If it returns true, then you will definitely end up with packages over the allowed threshold. But it can miss the case I mentioned above. 

I decided to keep this validation there, to short circuit the the method if `likely_excess_quantity?` returns true (we wont even start the packing process if it returns true), but I also added another validation that simply checks `packages.count` when a package is in full state.