### PR TITLE
Further improve shipment packer and tests

### DIFF
--- a/test/unit/shipment_packer_test.rb
+++ b/test/unit/shipment_packer_test.rb
@@ -5,8 +5,8 @@ class ShipmentPackerTest < ActiveSupport::TestCase
     @dimensions = [5.1, 15.2, 30.5]
   end
 
-  def test_pack_divide_order_into_a_single_package
-    items = [{:grams => 1, :quantity => 1, :price => 1.0}]
+  test "pack divide order into a single package" do
+    items = [{ grams: 1, quantity: 1, price: 1.0 }]
 
     packages = ShipmentPacker.pack(items, @dimensions, 1, 'USD')
     assert_equal 1, packages.size
@@ -15,8 +15,8 @@ class ShipmentPackerTest < ActiveSupport::TestCase
     assert_equal Measured::Weight(1, :g), package.weight
   end
 
-  def test_divide_order_with_multiple_lines_into_a_single_package
-    items = [{:grams => 1, :quantity => 2, :price => 1.0}]
+  test "divide order with multiple lines into a single package" do
+    items = [{ grams: 1, quantity: 2, price: 1.0 }]
 
     packages = ShipmentPacker.pack(items, @dimensions, 2, 'USD')
     assert_equal 1, packages.size
@@ -25,8 +25,8 @@ class ShipmentPackerTest < ActiveSupport::TestCase
     assert_equal Measured::Weight(2, :g), package.weight
   end
 
-  def test_divide_order_with_single_line_into_two_packages
-    items = [{:grams => 1, :quantity => 2, :price => 1.0}]
+  test "divide order with single line into two packages" do
+    items = [{ grams: 1, quantity: 2, price: 1.0 }]
 
     packages = ShipmentPacker.pack(items, @dimensions, 1, 'USD')
     assert_equal 2, packages.size
@@ -36,7 +36,7 @@ class ShipmentPackerTest < ActiveSupport::TestCase
     end
   end
 
-  def test_divide_order_with_single_line_into_two_packages_max_weight_as_float
+  test "divide order with single line into two packages max weight as float" do
     max_weight = 68038.8555
 
     items = [{ grams: 45359, quantity: 2, price: 1.0 }]
@@ -49,10 +49,10 @@ class ShipmentPackerTest < ActiveSupport::TestCase
     end
   end
 
-  def test_divide_order_with_multiple_lines_into_two_packages
+  test "divide order with multiple lines into two packages" do
     items = [
-      {:grams => 1, :quantity => 1, :price => 1.0},
-      {:grams => 1, :quantity => 1, :price => 1.0}
+      { grams: 1, quantity: 1, price: 1.0 },
+      { grams: 1, quantity: 1, price: 1.0 }
     ]
 
     packages = ShipmentPacker.pack(items, @dimensions, 1, 'USD')
@@ -63,11 +63,11 @@ class ShipmentPackerTest < ActiveSupport::TestCase
     end
   end
 
-  def test_divide_order_into_two_packages_mixing_line_items
+  test "divide order into two packages mixing line items" do
     items = [
-      {:grams => 1, :quantity => 1, :price => 1.0},
-      {:grams => 1, :quantity => 1, :price => 1.0},
-      {:grams => 1, :quantity => 1, :price => 1.0}
+      { grams: 1, quantity: 1, price: 1.0 },
+      { grams: 1, quantity: 1, price: 1.0 },
+      { grams: 1, quantity: 1, price: 1.0 }
     ]
 
     packages = ShipmentPacker.pack(items, @dimensions, 2, 'USD')
@@ -77,28 +77,28 @@ class ShipmentPackerTest < ActiveSupport::TestCase
     assert_equal Measured::Weight(1, :g), packages[1].weight
   end
 
-  def test_raise_overweight_exception_when_a_single_item_exceeds_the_maximum_weight_of_a_package
+  test "raise overweight exception when a single item exceeds the maximum weight of a package" do
     assert_raises(ShipmentPacker::OverweightItem) do
-      items = [{:grams => 2, :quantity => 1, :price => 1.0}]
+      items = [{ grams: 2, quantity: 1, price: 1.0 }]
       ShipmentPacker.pack(items, @dimensions, 1, 'USD')
     end
   end
 
-  def test_raise_over_weight_exceptions_before_over_package_limit_exceptions
-      assert_raises(ShipmentPacker::OverweightItem) do
-        items = [{:grams => 5, :quantity => ShipmentPacker::EXCESS_PACKAGE_QUANTITY_THRESHOLD + 1, :price => 1.0}]
-        ShipmentPacker.pack(items, @dimensions, 4, 'USD')
-      end
+  test "raise over weight exceptions before over package limit exceptions" do
+    assert_raises(ShipmentPacker::OverweightItem) do
+      items = [{ grams: 5, quantity: ShipmentPacker::EXCESS_PACKAGE_QUANTITY_THRESHOLD + 1, price: 1.0 }]
+      ShipmentPacker.pack(items, @dimensions, 4, 'USD')
+    end
   end
 
-  def test_returns_an_empty_list_when_no_items_provided
+  test "returns an empty list when no items provided" do
     assert_equal [], ShipmentPacker.pack([], @dimensions, 1, 'USD')
   end
 
-  def test_add_summarized_prices_for_all_items_and_currency_to_package
+  test "add summarized prices for all items and currency to package" do
     items = [
-      {:grams => 1, :quantity => 3, :price => 1.0},
-      {:grams => 2, :quantity => 1, :price => 2.0}
+      { grams: 1, quantity: 3, price: 1.0 },
+      { grams: 2, quantity: 1, price: 2.0 }
     ]
     packages = ShipmentPacker.pack(items, @dimensions, 5, 'USD')
     assert_equal 1, packages.size
@@ -106,11 +106,11 @@ class ShipmentPackerTest < ActiveSupport::TestCase
     assert_equal 'USD', packages.first.currency
   end
 
-  def test_divide_items_and_prices_accordingly_when_splitting_into_two_packages
+  test "divide items and prices accordingly when splitting into two packages" do
     items = [
-      {:grams => 1, :quantity => 1, :price => 1.0},
-      {:grams => 1, :quantity => 1, :price => 1.0},
-      {:grams => 1, :quantity => 1, :price => 1.0}
+      { grams: 1, quantity: 1, price: 1.0 },
+      { grams: 1, quantity: 1, price: 1.0 },
+      { grams: 1, quantity: 1, price: 1.0 }
     ]
 
     packages = ShipmentPacker.pack(items, @dimensions, 2, 'USD')
@@ -122,9 +122,9 @@ class ShipmentPackerTest < ActiveSupport::TestCase
     assert_equal 'USD', packages[1].currency
   end
 
-  def test_symbolize_item_keys
-    string_key_items          = [{'grams' => 1, 'quantity' => 1, 'price' => 1.0}]
-    indifferent_access_items  = [{'grams' => 1, 'quantity' => 1, 'price' => 1.0}.with_indifferent_access]
+  test "symbolize item keys" do
+    string_key_items          = [{ 'grams' => 1, 'quantity' => 1, 'price' => 1.0 }]
+    indifferent_access_items  = [{ 'grams' => 1, 'quantity' => 1, 'price' => 1.0 }.with_indifferent_access]
 
     [string_key_items, indifferent_access_items].each do |items|
       packages = ShipmentPacker.pack(items, @dimensions, 1, 'USD')
@@ -136,8 +136,8 @@ class ShipmentPackerTest < ActiveSupport::TestCase
     end
   end
 
-  def test_cast_quantity_and_grams_to_int
-    items = [{:grams => '1', :quantity => '1', :price => '1.0'}]
+  test "cast quantity and grams to int" do
+    items = [{ grams: '1', quantity: '1', price: '1.0' }]
 
     packages = ShipmentPacker.pack(items, @dimensions, 1, 'USD')
 
@@ -146,15 +146,15 @@ class ShipmentPackerTest < ActiveSupport::TestCase
     assert_equal 100, package.value
   end
 
-  def test_excess_packages
+  test "excess packages" do
     assert_raises(ShipmentPacker::ExcessPackageQuantity) do
-      items = [{:grams => 1, :quantity => ShipmentPacker::EXCESS_PACKAGE_QUANTITY_THRESHOLD + 1, :price => 1.0}]
+      items = [{ grams: 1, quantity: ShipmentPacker::EXCESS_PACKAGE_QUANTITY_THRESHOLD + 1, price: 1.0 }]
       ShipmentPacker.pack(items, @dimensions, 1, 'USD')
     end
   end
 
-  def test_lots_of_zero_weight_items
-    items = [{:grams => 0, :quantity => 1_000_000, :price => 1.0}]
+  test "lots of zero weight items" do
+    items = [{ grams: 0, quantity: 1_000_000, price: 1.0 }]
     packages = ShipmentPacker.pack(items, @dimensions, 1, 'USD')
 
     assert_equal 1, packages.size
@@ -162,8 +162,8 @@ class ShipmentPackerTest < ActiveSupport::TestCase
     assert_equal 100_000_000, packages[0].value
   end
 
-  def test_dont_destroy_input_items
-    items = [{:grams => 1, :quantity => 5, :price => 1.0}]
+  test "dont destroy input items" do
+    items = [{ grams: 1, quantity: 5, price: 1.0 }]
 
     packages = ShipmentPacker.pack(items, @dimensions, 10, 'USD')
 
@@ -171,15 +171,15 @@ class ShipmentPackerTest < ActiveSupport::TestCase
     assert_equal 1, packages.size
   end
 
-  def test_dont_modify_input_item_quantities
-    items = [{:grams => 1, :quantity => 5, :price => 1.0}]
+  test "dont modify input item quantities" do
+    items = [{ grams: 1, quantity: 5, price: 1.0 }]
 
     ShipmentPacker.pack(items, @dimensions, 10, 'USD')
     assert_equal 5, items.first[:quantity]
   end
 
-  def test_items_with_negative_weight
-    items = [{:grams => -1, :quantity => 5, :price => 1.0}]
+  test "items with negative weight" do
+    items = [{ grams: -1, quantity: 5, price: 1.0 }]
 
     ShipmentPacker.pack(items, @dimensions, 10, 'USD')
     assert_equal 5, items.first[:quantity]


### PR DESCRIPTION
Just splitting out some of the work from https://github.com/Shopify/active_shipping/pull/484

Here I'm just renaming methods, using `test "blabla" do` syntax for tests, and changing hash rocket to colon syntax.

suggested in: https://github.com/Shopify/active_shipping/pull/484#discussion_r101571037