### PR TITLE
Delivery estimates returning with USPS rates

### DIFF
--- a/active_shipping.gemspec
+++ b/active_shipping.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |s|
 
   s.add_dependency("measured", "~> 1.6.0")
   s.add_dependency("activesupport", ">= 4.2", "< 5.1.0")
-  s.add_dependency("active_utils", "~> 3.2.0")
+  s.add_dependency("active_utils", "~> 3.3.0")
   s.add_dependency("nokogiri", ">= 1.6")
 
   s.add_development_dependency("minitest")

--- a/gemfiles/activesupport50.gemfile
+++ b/gemfiles/activesupport50.gemfile
@@ -3,4 +3,4 @@ source "https://rubygems.org"
 gemspec path: '..'
 
 gem 'activesupport', '~> 5.0.0'
-gem 'active_utils', '~> 3.2.2'
+gem 'active_utils', '~> 3.3.0'

--- a/lib/active_shipping/carriers/usps.rb
+++ b/lib/active_shipping/carriers/usps.rb
@@ -11,6 +11,7 @@ module ActiveShipping
     EventDetails = Struct.new(:description, :time, :zoneless_time, :location, :event_code)
     ONLY_PREFIX_EVENTS = ['DELIVERED','OUT FOR DELIVERY']
     self.retry_safe = true
+    self.ssl_version = :TLSv1_2
 
     cattr_reader :name
     @@name = "USPS"

--- a/lib/active_shipping/carriers/usps.rb
+++ b/lib/active_shipping/carriers/usps.rb
@@ -423,7 +423,7 @@ module ActiveShipping
               xml.Length("%0.2f" % [package.inches(:length), 0.01].max)
               xml.Height("%0.2f" % [package.inches(:height), 0.01].max)
               xml.Girth("%0.2f" % [package.inches(:girth), 0.01].max)
-              xml.OriginZip(origin.zip)
+              xml.OriginZip(strip_zip(origin.zip))
               if commercial_type = commercial_type(options)
                 xml.public_send(COMMERCIAL_FLAG_NAME.fetch(commercial_type), 'Y')
               end

--- a/test/fixtures/xml/usps/us_rate_request_shipdate.xml
+++ b/test/fixtures/xml/usps/us_rate_request_shipdate.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0"?>
+<RateV4Request USERID="login">
+  <Package ID="0">
+    <Service>ALL</Service>
+    <FirstClassMailType/>
+    <ZipOrigination>90210</ZipOrigination>
+    <ZipDestination>10017</ZipDestination>
+    <Pounds>0</Pounds>
+    <Ounces>8.8</Ounces>
+    <Container/>
+    <Size>REGULAR</Size>
+    <Width>5.51</Width>
+    <Length>7.48</Length>
+    <Height>0.79</Height>
+    <Girth>12.60</Girth>
+    <Machinable>TRUE</Machinable>
+    <ShipDate>2017-02-28</ShipDate>
+  </Package>
+</RateV4Request>

--- a/test/remote/usps_test.rb
+++ b/test/remote/usps_test.rb
@@ -229,7 +229,7 @@ class RemoteUSPSTest < ActiveSupport::TestCase
     response = @carrier.find_rates(
        location_fixtures[:beverly_hills],
        location_fixtures[:new_york],
-      Package.new(16, [12, 6, 2], :units => :imperial),
+      Package.new(16, [12, 6, 2], units: :imperial),
       ship_date: Time.now
     )
 

--- a/test/remote/usps_test.rb
+++ b/test/remote/usps_test.rb
@@ -225,6 +225,19 @@ class RemoteUSPSTest < ActiveSupport::TestCase
     end
   end
 
+  def test_delivery_range_when_providing_ship_date
+    response = @carrier.find_rates(
+       location_fixtures[:beverly_hills],
+       location_fixtures[:new_york],
+      Package.new(16, [12, 6, 2], :units => :imperial),
+      ship_date: Time.now
+    )
+
+    response.rates.each do |rate|
+      assert_not_empty rate.delivery_range, "Rate should have delivery range"
+    end
+  end
+
   # Uncomment and switch out SPECIAL_COUNTRIES with some other batch to see which
   # countries are currently working. Commented out here just because it's a lot of
   # hits to their server at once:

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -144,6 +144,15 @@ module ActiveShipping::Test
                                       :zip => '90210',
                                       :phone => '1-310-285-1013',
                                       :fax => '1-310-275-8159'),
+        :beverly_hills_9_zip => Location.new(
+                                      :country => 'US',
+                                      :state => 'CA',
+                                      :city => 'Beverly Hills',
+                                      :address1 => '455 N. Rexford Dr.',
+                                      :address2 => '3rd Floor',
+                                      :zip => '90210-1234',
+                                      :phone => '1-310-285-1013',
+                                      :fax => '1-310-275-8159'),
         :real_home_as_commercial => Location.new(
                                       :country => 'US',
                                       :city => 'Tampa',

--- a/test/unit/carriers/usps_test.rb
+++ b/test/unit/carriers/usps_test.rb
@@ -15,6 +15,11 @@ class USPSTest < ActiveSupport::TestCase
     ]
   end
 
+  def test_using_tls_and_not_ssl_v3
+    refute_equal :SSLv3, @carrier.ssl_version, 'SSLv3 is no longer supported by USPS Web Tools'
+    assert_equal :TLSv1_2, @carrier.ssl_version
+  end
+
   def test_tracking_request_should_create_correct_xml
     @carrier.expects(:commit).with(:track, xml_fixture('usps/tracking_request'),false).returns(@tracking_response)
     @carrier.find_tracking_info('9102901000462189604217', :destination_zip => '12345', :mailing_date => Date.new(2010,1,30))

--- a/test/unit/carriers/usps_test.rb
+++ b/test/unit/carriers/usps_test.rb
@@ -254,6 +254,14 @@ class USPSTest < ActiveSupport::TestCase
     @carrier.find_rates(location_fixtures[:beverly_hills], location_fixtures[:new_york], package, :test => true)
   end
 
+  def test_build_us_rate_request_sends_ship_date_when_option_passed
+    expected_request = xml_fixture('usps/us_rate_request_shipdate')
+    @carrier.expects(:commit).with(:us_rates, expected_request, false).returns(expected_request)
+    @carrier.expects(:parse_rate_response)
+    package = package_fixtures[:book]
+    @carrier.find_rates(location_fixtures[:beverly_hills], location_fixtures[:new_york], package, :test => true, :ship_date => Time.new(2017,2,28))
+  end
+
   def test_build_world_rate_request
     expected_request = xml_fixture('usps/world_rate_request_without_value')
     @carrier.expects(:commit).with(:world_rates, expected_request, false).returns(expected_request)

--- a/test/unit/carriers/usps_test.rb
+++ b/test/unit/carriers/usps_test.rb
@@ -399,6 +399,13 @@ class USPSTest < ActiveSupport::TestCase
     assert request =~ /\>12345\</
   end
 
+  def test_strip_9_digit_zip_codes_world_rates
+    request = URI.decode(@carrier.send(:build_world_rate_request, location_fixtures[:beverly_hills_9_zip],
+                                        package_fixtures[:book], location_fixtures[:auckland], {}))
+    refute_match /\<OriginZip\>90210-1234/, request
+    assert_match /\<OriginZip\>90210/, request
+  end
+
   def test_maximum_weight
     assert Package.new(70 * 16, [5, 5, 5], :units => :imperial).mass == @carrier.maximum_weight
     assert Package.new((70 * 16) + 0.01, [5, 5, 5], :units => :imperial).mass > @carrier.maximum_weight

--- a/test/unit/carriers/usps_test.rb
+++ b/test/unit/carriers/usps_test.rb
@@ -259,7 +259,7 @@ class USPSTest < ActiveSupport::TestCase
     @carrier.expects(:commit).with(:us_rates, expected_request, false).returns(expected_request)
     @carrier.expects(:parse_rate_response)
     package = package_fixtures[:book]
-    @carrier.find_rates(location_fixtures[:beverly_hills], location_fixtures[:new_york], package, :test => true, :ship_date => Time.new(2017,2,28))
+    @carrier.find_rates(location_fixtures[:beverly_hills], location_fixtures[:new_york], package, test: true, ship_date: Time.new(2017,2,28))
   end
 
   def test_build_world_rate_request


### PR DESCRIPTION
To make the api of the USPS carrier consistent with UPs and FedEx as
much as possible, return the delivery_range with the rate response.

So as to not complicated existing workflows, I've used an option for the
optional node that must be returned to make commitments return.