### PR TITLE
explicitly set USPS ssl_version to TLSv1_2

### DIFF
--- a/lib/active_shipping/carriers/usps.rb
+++ b/lib/active_shipping/carriers/usps.rb
@@ -11,6 +11,7 @@ module ActiveShipping
     EventDetails = Struct.new(:description, :time, :zoneless_time, :location, :event_code)
     ONLY_PREFIX_EVENTS = ['DELIVERED','OUT FOR DELIVERY']
     self.retry_safe = true
+    self.ssl_version = :TLSv1_2
 
     cattr_reader :name
     @@name = "USPS"

--- a/test/unit/carriers/usps_test.rb
+++ b/test/unit/carriers/usps_test.rb
@@ -15,6 +15,11 @@ class USPSTest < ActiveSupport::TestCase
     ]
   end
 
+  def test_using_tls_and_not_ssl_v3
+    refute_equal :SSLv3, @carrier.ssl_version, 'SSLv3 is no longer supported by USPS Web Tools'
+    assert_equal :TLSv1_2, @carrier.ssl_version
+  end
+
   def test_tracking_request_should_create_correct_xml
     @carrier.expects(:commit).with(:track, xml_fixture('usps/tracking_request'),false).returns(@tracking_response)
     @carrier.find_tracking_info('9102901000462189604217', :destination_zip => '12345', :mailing_date => Date.new(2010,1,30))


### PR DESCRIPTION
SSLv3 will no longer be supported by USPS Web Tools after March 24 2017.

> As of approximately 5:00 PM ET on February 13, SSLv3 support has been discontinued in the Web Tools CAT/external testing environment (https://stg-secure.shippingapis.com/shippingapi.dll)
>Effective March 24, 2017, Web Tools will discontinue support of SSLv3 for securing connections to our HTTPS APIs including but not limited to all shipping label and package pickup APIs. After this change, integrations leveraging SSLv3 will fail when attempting to access the APIs.

This PR explicitly sets the `ssl_version` for USPS to `:TLSv1_2`.  

However, tests are still passing in the external testing environment (which would fail with SSLv3 after Feb 13) even without explicitly setting the `ssl_version`.
`ActiveUtils` uses `net/http`, which establishes which SSL version to use when it creates the connection with the server, so setting the version explicitly is probably not required.  We could just leave the single assertion in the test to ensure that the `ssl_version` isn't set to SSLv3, but even that is probably unnecessary.

Remote tests are passing in both cases:
- when we set the `ssl_version` explicitly
- when we let it be set automatically during the handshake to establish the connection

Posting this to elicit a discussion on whether we should be explicit here.

cc @mdking, @kmcphillips, @jonathankwok 