### PR TITLE
Strip 9 digit origin zip code for world rate requests

### DIFF
--- a/lib/active_shipping/carriers/usps.rb
+++ b/lib/active_shipping/carriers/usps.rb
@@ -419,7 +419,7 @@ module ActiveShipping
               xml.Length("%0.2f" % [package.inches(:length), 0.01].max)
               xml.Height("%0.2f" % [package.inches(:height), 0.01].max)
               xml.Girth("%0.2f" % [package.inches(:girth), 0.01].max)
-              xml.OriginZip(origin.zip)
+              xml.OriginZip(strip_zip(origin.zip))
               if commercial_type = commercial_type(options)
                 xml.public_send(COMMERCIAL_FLAG_NAME.fetch(commercial_type), 'Y')
               end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -144,6 +144,15 @@ module ActiveShipping::Test
                                       :zip => '90210',
                                       :phone => '1-310-285-1013',
                                       :fax => '1-310-275-8159'),
+        :beverly_hills_9_zip => Location.new(
+                                      :country => 'US',
+                                      :state => 'CA',
+                                      :city => 'Beverly Hills',
+                                      :address1 => '455 N. Rexford Dr.',
+                                      :address2 => '3rd Floor',
+                                      :zip => '90210-1234',
+                                      :phone => '1-310-285-1013',
+                                      :fax => '1-310-275-8159'),
         :real_home_as_commercial => Location.new(
                                       :country => 'US',
                                       :city => 'Tampa',

--- a/test/unit/carriers/usps_test.rb
+++ b/test/unit/carriers/usps_test.rb
@@ -386,6 +386,13 @@ class USPSTest < ActiveSupport::TestCase
     assert request =~ /\>12345\</
   end
 
+  def test_strip_9_digit_zip_codes_world_rates
+    request = URI.decode(@carrier.send(:build_world_rate_request, location_fixtures[:beverly_hills_9_zip],
+                                        package_fixtures[:book], location_fixtures[:auckland], {}))
+    refute_match /\<OriginZip\>90210-1234/, request
+    assert_match /\<OriginZip\>90210/, request
+  end
+
   def test_maximum_weight
     assert Package.new(70 * 16, [5, 5, 5], :units => :imperial).mass == @carrier.maximum_weight
     assert Package.new((70 * 16) + 0.01, [5, 5, 5], :units => :imperial).mass > @carrier.maximum_weight


### PR DESCRIPTION
## What

This PR truncates origin +4 zip codes for USPS world rate requests using the `strip_zip` method.

## Why

`build_world_rate_request` may throw an invalid zip code error if a +4 origin zip code is used in its original form. `build_us_rate_request` gets around this by calling `strip_zip` on any zip codes passed into the XML for cleansing. I'm adding the same behaviour to the `build_world_rate_request` method when it creates its own `xml`.
