### PR TITLE
Release version 1.12.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # ActiveShipping CHANGELOG
 
+### v1.12.0
+- Update active_utils dependency to v3.3.0
+
 ### v1.8.6
 - Fix UPS TrackResponse with no status code
 - Stop FedEx from raising for successful responses with no statuses

--- a/lib/active_shipping/version.rb
+++ b/lib/active_shipping/version.rb
@@ -1,3 +1,3 @@
 module ActiveShipping
-  VERSION = "1.11.1"
+  VERSION = "1.12.0"
 end


### PR DESCRIPTION
Bumping active_utils dependency to `~> 3.3.0`, to support changes implemented on https://github.com/Shopify/active_utils/pull/78 and https://github.com/Shopify/active_utils/pull/79.

Related PRs: https://github.com/Shopify/active_shipping/pull/490, https://github.com/Shopify/active_shipping/pull/492 