### PR TITLE
Patch UPS to use old Kosovo country code

### DIFF
--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -277,8 +277,14 @@ module ActiveShipping::Test
                                       :city => 'Melbourne',
                                       :state => 'VIC',
                                       :address1 => '192 George Street',
-                                      :postal_code => '3108')
+                                      :postal_code => '3108'),
+        :kosovo => Location.new(
+                                      :country => 'XK',
+                                      :city => 'Prishtinë',
+                                      :address1 => 'Ahmet Krasniqi',
+                                      :postal_code => '10000')
       }
+
     end
 
     def line_item_fixture

--- a/test/unit/carriers/ups_test.rb
+++ b/test/unit/carriers/ups_test.rb
@@ -656,4 +656,47 @@ class UPSTest < ActiveSupport::TestCase
     assert_equal :invalid, response.validity
   end
 
+  def test_kosovo_location_node
+    xml_builder = Nokogiri::XML::Builder.new do |xml|
+      @carrier.send(:build_location_node,
+                    xml,
+                    "KosovoRequest",
+                    location_fixtures[:kosovo],
+                    {}
+      )
+    end
+    request = Nokogiri::XML(xml_builder.to_xml)
+    assert_equal 'KV', request.search('/KosovoRequest/Address/CountryCode').text
+  end
+
+  def test_kosovo_build_address_artifact_format_location
+    xml_builder = Nokogiri::XML::Builder.new do |xml|
+      @carrier.send(:build_address_artifact_format_location,
+                    xml,
+                    "KosovoRequest",
+                    location_fixtures[:kosovo]
+      )
+    end
+    request = Nokogiri::XML(xml_builder.to_xml)
+    assert_equal 'KV', request.search('/KosovoRequest/AddressArtifactFormat/CountryCode').text
+  end
+
+  def test_kosovo_build_address_validation_request
+    xml = @carrier.send(:build_address_validation_request, location_fixtures[:kosovo])
+    request = Nokogiri::XML(xml)
+    assert_equal 'KV', request.search('/AddressValidationRequest/AddressKeyFormat/CountryCode').text
+  end
+
+  def test_kosovo_build_billing_info_node
+    options = {bill_third_party: true, bill_to_consignee: true, billing_account: 12345,
+               billing_zip: 12345, billing_country: 'XK'}
+    xml_builder = Nokogiri::XML::Builder.new do |xml|
+      @carrier.send(:build_billing_info_node,
+                    xml,
+                    options
+      )
+    end
+    request = Nokogiri::XML(xml_builder.to_xml)
+    assert_equal 'KV', request.search('/BillThirdParty/BillThirdPartyConsignee/ThirdParty/Address/CountryCode').text
+  end
 end


### PR DESCRIPTION
## What
Patch the `CountryCode` on a UPS XML request payload, changing the country code from `XK` to `KV` if necessary (Kosovo address).

## Why
In `ActiveUtils`, Kosovo's country code was recently updated from `KV` to `XK` (https://github.com/Shopify/active_utils/pull/79). UPS still uses Kosovo's old country code (`KV`), and will throw an invalid address if the new country code is used.