### PR TITLE
add default location for CanadaPost PWS

### DIFF
--- a/lib/active_shipping/carriers/canada_post_pws.rb
+++ b/lib/active_shipping/carriers/canada_post_pws.rb
@@ -64,6 +64,16 @@ module ActiveShipping
       [:api_key, :secret]
     end
 
+    def self.default_location
+      {
+        :country     => 'CA',
+        :province    => 'ON',
+        :city        => 'Ottawa',
+        :address1    => '61A York St',
+        :postal_code => 'K1N5T2'
+      }
+    end
+
     def find_rates(origin, destination, line_items = [], options = {}, package = nil, services = [])
       url = endpoint + "rs/ship/price"
       request  = build_rates_request(origin, destination, line_items, options, package, services)


### PR DESCRIPTION
Canada Post PWS is a non US carrier, add a default location similar to the other Canada Post carrier [here](https://github.com/Shopify/active_shipping/blob/84f971deff31dc13a44ed472a9b35c0e281eb452/lib/active_shipping/carriers/canada_post.rb#L97-L105)