### PR TITLE
fix up UPS tracker parsing for Kosovo (KV)

### DIFF
--- a/lib/active_shipping/carriers/ups.rb
+++ b/lib/active_shipping/carriers/ups.rb
@@ -1076,6 +1076,7 @@ module ActiveShipping
       return nil unless address
       country = address.at('CountryCode').try(:text)
       country = 'US' if country == 'ZZ' # Sometimes returned by SUREPOST in the US
+      country = 'XK' if country == 'KV' # ActiveUtils now refers to Kosovo by XK
       Location.new(
         :country     => country,
         :postal_code => address.at('PostalCode').try(:text),

--- a/test/fixtures/xml/ups/location_node_kosovo_kv.xml
+++ b/test/fixtures/xml/ups/location_node_kosovo_kv.xml
@@ -1,0 +1,7 @@
+<Address>
+  <AddressLine1>123 KOSOVO ST</AddressLine1>
+  <City>PRIZRENI</City>
+  <StateProvinceCode></StateProvinceCode>
+  <PostalCode></PostalCode>
+  <CountryCode>KV</CountryCode>
+</Address>

--- a/test/fixtures/xml/ups/location_node_kosovo_xk.xml
+++ b/test/fixtures/xml/ups/location_node_kosovo_xk.xml
@@ -1,0 +1,7 @@
+<Address>
+  <AddressLine1>123 KOSOVO ST</AddressLine1>
+  <City>PRIZRENI</City>
+  <StateProvinceCode></StateProvinceCode>
+  <PostalCode></PostalCode>
+  <CountryCode>XK</CountryCode>
+</Address>

--- a/test/fixtures/xml/ups/location_node_zz.xml
+++ b/test/fixtures/xml/ups/location_node_zz.xml
@@ -1,0 +1,7 @@
+<Address>
+  <AddressLine1>175 AMBASSADOR</AddressLine1>
+  <City>NAPERVILLE</City>
+  <StateProvinceCode>IL</StateProvinceCode>
+  <PostalCode>60540   3920</PostalCode>
+  <CountryCode>ZZ</CountryCode>
+</Address>

--- a/test/unit/carriers/ups_test.rb
+++ b/test/unit/carriers/ups_test.rb
@@ -173,6 +173,30 @@ class UPSTest < ActiveSupport::TestCase
     assert_empty response.shipment_events
   end
 
+  def test_location_from_address_node_kosovo_kv
+    address = Nokogiri::XML::DocumentFragment.parse(xml_fixture('ups/location_node_kosovo_kv'))
+
+    parsed = @carrier.send(:location_from_address_node, address)
+    assert_equal 'XK', parsed.country_code
+    assert_equal 'Kosovo', parsed.country.name
+  end
+
+  def test_location_from_address_node_kosovo_xk
+    address = Nokogiri::XML::DocumentFragment.parse(xml_fixture('ups/location_node_kosovo_xk'))
+
+    parsed = @carrier.send(:location_from_address_node, address)
+    assert_equal 'XK', parsed.country_code
+    assert_equal 'Kosovo', parsed.country.name
+  end
+
+  def test_location_from_address_node_zz
+    address = Nokogiri::XML::DocumentFragment.parse(xml_fixture('ups/location_node_zz'))
+
+    parsed = @carrier.send(:location_from_address_node, address)
+    assert_equal 'US', parsed.country_code
+    assert_equal 'United States', parsed.country.name
+  end
+
   def test_response_parsing_an_oversize_package
     mock_response = xml_fixture('ups/package_exceeds_maximum_length')
     @carrier.expects(:commit).returns(mock_response)


### PR DESCRIPTION
This PR fixes an issue where trying to parse tracking info for shipments that travel through (or end up in) Kosovo are raising `ActiveUtils::InvalidCountryCodeError: No country could be found for the country KV`

A little bit hacky, but fast.