### PR TITLE
Upcase postal code for CanadaPostPWS

### DIFF
--- a/lib/active_shipping/carriers/canada_post_pws.rb
+++ b/lib/active_shipping/carriers/canada_post_pws.rb
@@ -782,7 +782,8 @@ module ActiveShipping
     end
 
     def get_sanitized_postal_code(location)
-      location.try(:postal_code).try(:gsub, /\s+/, '')
+      return nil if location.nil? || location.postal_code.nil?
+      location.postal_code.gsub(/\s+/, '').upcase
     end
 
     def sanitize_weight_kg(kg)

--- a/test/unit/carriers/canada_post_pws_test.rb
+++ b/test/unit/carriers/canada_post_pws_test.rb
@@ -1,0 +1,59 @@
+require 'test_helper'
+
+class CanadaPostPwsTest < ActiveSupport::TestCase
+
+  def setup
+    credentials = { platform_id: 123, api_key: '456', secret: '789' }
+    @cp = CanadaPostPWS.new(credentials)
+  end
+
+  def test_get_sanitized_postal_code_location_nil
+    postal_code = @cp.send(:get_sanitized_postal_code, nil)
+
+    assert_equal nil, postal_code
+  end
+
+  def test_get_sanitized_postal_code_postal_code_nil
+    location = Location.new(name: 'Test test')
+
+    assert_equal nil, location.postal_code
+
+    postal_code = @cp.send(:get_sanitized_postal_code, location)
+
+    assert_equal nil, postal_code
+  end
+
+  def test_get_sanitized_postal_code_spaces
+    location = Location.new(postal_code: '    K2P     1L4    ')
+
+    postal_code = @cp.send(:get_sanitized_postal_code, location)
+
+    assert_equal 'K2P1L4', postal_code
+  end
+
+  def test_get_sanitized_postal_code_lowercase
+    location = Location.new(postal_code: 'k2p 1l4')
+
+    postal_code = @cp.send(:get_sanitized_postal_code, location)
+
+    assert_equal 'K2P1L4', postal_code
+  end
+
+  def test_get_sanitzied_postal_code_proper
+    location = Location.new(postal_code: 'K2P1L4')
+
+    postal_code = @cp.send(:get_sanitized_postal_code, location)
+
+    assert_equal 'K2P1L4', postal_code
+  end
+
+  def test_get_sanitzied_postal_code_does_not_alter_original
+    location = Location.new(postal_code: 'K2P  1l4')
+
+    assert_equal 'K2P  1l4', location.postal_code
+
+    @cp.send(:get_sanitized_postal_code, location)
+
+    assert_equal 'K2P  1l4', location.postal_code
+  end
+end


### PR DESCRIPTION
Canada Posts web service API is not every friendly with downcase'd postal codes. Therefore as part of removing whitespaces also `upcase`. Also add some tests around this behaviour.

Test failures are all remote UPS related seems like the API is having some issues
```
ActiveShipping::ResponseError: Failure: XML Rating and Service Selection Service Unavailable
```