### PR TITLE
Add new Correios service codes and update defaults

### DIFF
--- a/lib/active_shipping/carriers/correios.rb
+++ b/lib/active_shipping/carriers/correios.rb
@@ -19,8 +19,10 @@ module ActiveShipping
 
     protected
 
-    DEFAULT_SERVICES = [41106, 40010]
+    DEFAULT_SERVICES = ['04510', '04014']
     AVAILABLE_SERVICES = {
+      '04510' => 'PAC sem contrato',
+      '04014' => 'SEDEX sem contrato',
       41106 => 'PAC sem contrato',
       41068 => 'PAC com contrato',
       41300 => 'PAC para grandes formatos',

--- a/test/unit/carriers/correios_test.rb
+++ b/test/unit/carriers/correios_test.rb
@@ -123,7 +123,7 @@ class CorreiosTest < ActiveSupport::TestCase
       "sCdMaoPropria=S",
       "nVlValorDeclarado=10%2C5",
       "sCdAvisoRecebimento=S",
-      "nCdServico=41106%2C40010",
+      "nCdServico=04510%2C04014",
       "sCepOrigem=01415000",
       "sCepDestino=38700000",
       "nVlPeso=0.25",
@@ -219,7 +219,7 @@ class CorreiosTest < ActiveSupport::TestCase
     services = Correios.available_services
 
     assert_kind_of Hash, services
-    assert_equal 19, services.size
+    assert_equal 21, services.size
     assert_equal 'PAC sem contrato', services[41106]
     assert_equal 'PAC com contrato', services[41068]
     assert_equal 'PAC para grandes formatos', services[41300]


### PR DESCRIPTION
### Summary
Due to some API changes, the Correios' endpoint deprecated service codes 41106 and 40010, in favour of the new ones: '04510', and '04014'. This PR adds the new service codes and updates the list of default services.

### Observations
- The new service codes must be used as is, with the leading zero. If used in the same format as the pre-existing ones, the request will fail.
- I did not update the existing services to strings to avoid having downstream problems. Maybe we can do that in the next major release.
