### PR TITLE
Allow contract-number field in merchant response to be nil

### DIFF
--- a/lib/active_shipping/carriers/canada_post_pws.rb
+++ b/lib/active_shipping/carriers/canada_post_pws.rb
@@ -526,7 +526,7 @@ module ActiveShipping
       raise "No Merchant Info" if doc.root.at('customer-number').blank?
       options = {
         :customer_number => doc.root.at('customer-number').text,
-        :contract_number => doc.root.at('contract-number').text,
+        :contract_number => doc.root.at('contract-number').try(:text),
         :username => doc.root.at('merchant-username').text,
         :password => doc.root.at('merchant-password').text,
         :has_default_credit_card => doc.root.at('has-default-credit-card').text == 'true'

--- a/test/fixtures/xml/canadapost_pws/merchant_details_response_no_contract_number.xml
+++ b/test/fixtures/xml/canadapost_pws/merchant_details_response_no_contract_number.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<merchant-info xmlns="http://www.canadapost.ca/ws/merchant/registration">
+  <customer-number>1234567890</customer-number>
+  <merchant-username>1234567890123456</merchant-username>
+  <merchant-password>12343567890123456789012</merchant-password>
+  <has-default-credit-card>true</has-default-credit-card>
+</merchant-info>

--- a/test/unit/carriers/canada_post_pws_register_test.rb
+++ b/test/unit/carriers/canada_post_pws_register_test.rb
@@ -58,6 +58,20 @@ class CanadaPostPwsRegisterTest < Minitest::Test
     assert_equal false, response.has_default_credit_card
   end
 
+  def test_retrieve_merchant_details_without_contract_number
+    endpoint = @cp.endpoint + "ot/token/1234567890"
+    response = xml_fixture('canadapost_pws/merchant_details_response_no_contract_number')
+    @cp.expects(:ssl_get).with(endpoint, anything).returns(response)
+
+    response = @cp.retrieve_merchant_details(:token_id => '1234567890')
+    assert response.is_a?(CPPWSMerchantDetailsResponse)
+    assert_equal "1234567890", response.customer_number
+    assert_nil response.contract_number
+    assert_equal "1234567890123456", response.username
+    assert_equal "12343567890123456789012", response.password
+    assert_equal true, response.has_default_credit_card
+  end
+
   def test_retrieve_merchant_with_error
     endpoint = @cp.endpoint + "ot/token/1234567890"
     response = xml_fixture('canadapost_pws/merchant_details_error')


### PR DESCRIPTION
According to the [docs](https://www.canadapost.ca/cpo/mc/business/productsservices/developers/services/ecomplatforms/registrationinfo.jsf)

> contract-number
> The contract number of the merchant if the merchant has a single contract. If the merchant does not have a contract, or has multiple contracts, no contract number will be returned.
Contract numbers are 10 digits. If the number provided is less than 10 digits, the system will add leading zeros.

Since this is an optional field in the response xml, this PR prevents raising an error when contract-number is missing.