### PR TITLE
Make `SATURDAY_DELIVERY` and option for fedex

### DIFF
--- a/lib/active_shipping/carriers/fedex.rb
+++ b/lib/active_shipping/carriers/fedex.rb
@@ -304,7 +304,7 @@ module ActiveShipping
           xml.ReturnTransitAndCommit(true)
 
           # Returns saturday delivery shipping options when available
-          xml.VariableOptions('SATURDAY_DELIVERY')
+          xml.VariableOptions('SATURDAY_DELIVERY') if options[:saturday_delivery]
 
           xml.RequestedShipment do
             if options[:pickup_date]

--- a/test/fixtures/xml/fedex/ottawa_to_beverly_hills_no_saturday_rate_request.xml
+++ b/test/fixtures/xml/fedex/ottawa_to_beverly_hills_no_saturday_rate_request.xml
@@ -1,0 +1,79 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<RateRequest xmlns="http://fedex.com/ws/rate/v13">
+  <WebAuthenticationDetail>
+    <UserCredential>
+      <Key>1111</Key>
+      <Password>2222</Password>
+    </UserCredential>
+  </WebAuthenticationDetail>
+  <ClientDetail>
+    <AccountNumber>3333</AccountNumber>
+    <MeterNumber>4444</MeterNumber>
+  </ClientDetail>
+  <TransactionDetail>
+    <CustomerTransactionId>ActiveShipping</CustomerTransactionId>
+  </TransactionDetail>
+  <Version>
+    <ServiceId>crs</ServiceId>
+    <Major>13</Major>
+    <Intermediate>0</Intermediate>
+    <Minor>0</Minor>
+  </Version>
+  <ReturnTransitAndCommit>true</ReturnTransitAndCommit>
+  <RequestedShipment>
+    <ShipTimestamp>2009-07-20T12:01:55-04:00</ShipTimestamp>
+    <DropoffType>REGULAR_PICKUP</DropoffType>
+    <PackagingType>YOUR_PACKAGING</PackagingType>
+    <Shipper>
+      <Address>
+        <StreetLines>110 Laurier Avenue West</StreetLines>
+        <City>Ottawa</City>
+        <PostalCode>K1P 1J1</PostalCode>
+        <CountryCode>CA</CountryCode>
+        <Residential>true</Residential>
+      </Address>
+    </Shipper>
+    <Recipient>
+      <Address>
+        <StreetLines>455 N. Rexford Dr.</StreetLines>
+        <StreetLines>3rd Floor</StreetLines>
+        <City>Beverly Hills</City>
+        <PostalCode>90210</PostalCode>
+        <CountryCode>US</CountryCode>
+        <Residential>true</Residential>
+      </Address>
+    </Recipient>
+    <SmartPostDetail>
+      <Indicia>PARCEL_SELECT</Indicia>
+      <HubId>5902</HubId>
+    </SmartPostDetail>
+    <RateRequestTypes>ACCOUNT</RateRequestTypes>
+    <PackageCount>2</PackageCount>
+    <RequestedPackageLineItems>
+      <GroupPackageCount>1</GroupPackageCount>
+      <Weight>
+        <Units>KG</Units>
+        <Value>0.25</Value>
+      </Weight>
+      <Dimensions>
+        <Length>19</Length>
+        <Width>14</Width>
+        <Height>2</Height>
+        <Units>CM</Units>
+      </Dimensions>
+    </RequestedPackageLineItems>
+    <RequestedPackageLineItems>
+      <GroupPackageCount>1</GroupPackageCount>
+      <Weight>
+        <Units>KG</Units>
+        <Value>3.402</Value>
+      </Weight>
+      <Dimensions>
+        <Length>39</Length>
+        <Width>26</Width>
+        <Height>12</Height>
+        <Units>CM</Units>
+      </Dimensions>
+    </RequestedPackageLineItems>
+  </RequestedShipment>
+</RateRequest>

--- a/test/unit/carriers/fedex_test.rb
+++ b/test/unit/carriers/fedex_test.rb
@@ -93,7 +93,7 @@ class FedExTest < ActiveSupport::TestCase
     destination = ActiveShipping::Location.from(location_fixtures[:beverly_hills].to_hash, :address_type => :commercial)
     @carrier.find_rates( location_fixtures[:ottawa],
                          destination,
-                         package_fixtures.values_at(:book, :wii), :test => true)
+                         package_fixtures.values_at(:book, :wii), test: true, saturday_delivery: true)
   end
 
   def test_building_freight_request_and_parsing_response
@@ -130,7 +130,7 @@ class FedExTest < ActiveSupport::TestCase
 
     response = @carrier.find_rates( shipping_location,
                                     location_fixtures[:ottawa],
-                                    [package_fixtures[:wii]],  :freight => freight_options, :test => true )
+                                    [package_fixtures[:wii]],  freight: freight_options, test: true, saturday_delivery: true )
 
     assert_equal ["FedEx Freight Economy", "FedEx Freight Priority"], response.rates.map(&:service_name)
     assert_equal [66263, 68513], response.rates.map(&:price)
@@ -164,7 +164,7 @@ class FedExTest < ActiveSupport::TestCase
     @carrier.expects(:commit).with { |request, test_mode| Hash.from_xml(request) == Hash.from_xml(expected_request) && test_mode }.returns(mock_response)
     response = @carrier.find_rates( location_fixtures[:ottawa],
                                     location_fixtures[:beverly_hills],
-                                    package_fixtures.values_at(:book, :wii), :test => true)
+                                    package_fixtures.values_at(:book, :wii), test: true, saturday_delivery: true)
     assert_equal ["FedEx Ground"], response.rates.map(&:service_name)
     assert_equal [3836], response.rates.map(&:price)
 
@@ -199,7 +199,7 @@ class FedExTest < ActiveSupport::TestCase
     exception = assert_raises(ActiveShipping::ResponseContentError) do
       @carrier.find_rates( location_fixtures[:ottawa],
                            location_fixtures[:beverly_hills],
-                           package_fixtures.values_at(:book, :wii), :test => true)
+                           package_fixtures.values_at(:book, :wii), test: true, saturday_delivery: true)
     end
     message = "Invalid document \n\n#{mock_response}"
     assert_equal message, exception.message

--- a/test/unit/carriers/fedex_test.rb
+++ b/test/unit/carriers/fedex_test.rb
@@ -96,6 +96,18 @@ class FedExTest < ActiveSupport::TestCase
                          package_fixtures.values_at(:book, :wii), test: true, saturday_delivery: true)
   end
 
+  def test_building_request_with_no_saturday_delivery_should_not_have_saturday_option_set
+    mock_response = xml_fixture('fedex/ottawa_to_beverly_hills_rate_response')
+    expected_request = xml_fixture('fedex/ottawa_to_beverly_hills_no_saturday_rate_request')
+
+    @carrier.expects(:ship_timestamp).returns(Time.parse("2009-07-20T12:01:55-04:00").in_time_zone('US/Eastern'))
+    @carrier.expects(:commit).with { |request, test_mode| Hash.from_xml(request) == Hash.from_xml(expected_request) && test_mode }.returns(mock_response)
+    destination = ActiveShipping::Location.from(location_fixtures[:beverly_hills].to_hash) 
+    @carrier.find_rates( location_fixtures[:ottawa],
+                         destination,
+                         package_fixtures.values_at(:book, :wii), test: true)
+  end
+
   def test_building_freight_request_and_parsing_response
     expected_request = xml_fixture('fedex/freight_rate_request')
     mock_response = xml_fixture('fedex/freight_rate_response')


### PR DESCRIPTION
There is no reason why we should be forcing possible saturday delivery rates when they are optional. Thus add a new option `saturday_delivery` for fedex that allows greater control over whether or not saturday delivery rates are displayed or not.