### PR TITLE
Adhere to property order if using objects with hash access.

### DIFF
--- a/lib/active_shipping/location.rb
+++ b/lib/active_shipping/location.rb
@@ -64,12 +64,7 @@ module ActiveShipping #:nodoc:
 
       attributes = {}
 
-      hash_access = begin
-        object[:some_symbol]
-        true
-      rescue
-        false
-      end
+      hash_access = object.respond_to?(:[])
 
       ATTRIBUTE_ALIASES.each do |attribute, aliases|
         aliases.detect do |sym|

--- a/lib/active_shipping/location.rb
+++ b/lib/active_shipping/location.rb
@@ -73,10 +73,11 @@ module ActiveShipping #:nodoc:
 
       ATTRIBUTE_ALIASES.each do |attribute, aliases|
         aliases.detect do |sym|
-          value = if hash_access
-            object[sym]
-          elsif object.respond_to?(sym)
-            object.send(sym)
+          value = object[sym] if hash_access
+          if !value &&
+            object.respond_to?(sym) &&
+            (!hash_access || !Hash.public_instance_methods.include?(sym))
+            value = object.send(sym)
           end
 
           attributes[attribute] = value if value

--- a/test/unit/location_test.rb
+++ b/test/unit/location_test.rb
@@ -47,7 +47,10 @@ class LocationTest < ActiveSupport::TestCase
       def method_missing(method)
         @hash[method]
       end
-      def respond_to?(method) ; true ; end
+      def respond_to?(method)
+        return false if method == :[]
+        true
+      end
     end.new(@attributes_hash)
 
     location = Location.from(object)
@@ -65,9 +68,8 @@ class LocationTest < ActiveSupport::TestCase
 
   test ".from adheres to propery order even if hash access is available" do
     object = Class.new do
-      def [](_index)
-        return "California" if index == :province
-        nil
+      def [](index)
+        { province: "California" }[index]
       end
 
       def province_code

--- a/test/unit/location_test.rb
+++ b/test/unit/location_test.rb
@@ -63,6 +63,20 @@ class LocationTest < ActiveSupport::TestCase
     assert_equal @attributes_hash[:name], location.name
   end
 
+  test ".from adheres to propery order even if hash access is available" do
+    object = Class.new do
+      def [](_index)
+        return "California" if index == :province
+        nil
+      end
+
+      def province_code
+        "CA"
+      end
+    end.new
+    assert_equal "CA", Location.from(object).province
+  end
+
   test ".from sets the name to nil if it is not provided" do
     location = Location.from({})
     assert_nil location.name


### PR DESCRIPTION
[Recent changes](https://github.com/Shopify/active_shipping/pull/446/files#diff-808f0e47ee0b93d89184bb01b6d1f652L67) to the code to read attributes for locations resulted in a very subtle change in behaviour for objects that have both hash access and methods that return values, such as ActiveRecord objects.

Example: An `Address` model with both `province` column and `province_code` method. We used to return "CA" but we now return "California", and we've always been missing a test around this behaviour.

The root cause of this is an interface that is exceptionally wide, and subsequent version of this library we will move to a more simple and explicit interface.

