### PR TITLE
Trap ActiveUtils::ResponseError and return ActiveShipping::ResponseError instead

### DIFF
--- a/lib/active_shipping/carriers/canada_post_pws.rb
+++ b/lib/active_shipping/carriers/canada_post_pws.rb
@@ -115,6 +115,8 @@ module ActiveShipping
     def find_shipment_receipt(shipping_id, options = {})
       response = ssl_get(shipment_receipt_url(shipping_id, options), headers(options, SHIPMENT_MIMETYPE, SHIPMENT_MIMETYPE))
       parse_shipment_receipt_response(response)
+    rescue ActiveUtils::ResponseError => e
+      raise ActiveShipping::ResponseError.new(e.message)
     end
 
     def retrieve_shipping_label(shipping_response, options = {})

--- a/test/unit/carriers/canada_post_pws_shipping_test.rb
+++ b/test/unit/carriers/canada_post_pws_shipping_test.rb
@@ -229,6 +229,17 @@ class CanadaPostPwsShippingTest < ActiveSupport::TestCase
     assert_equal @cp.parse_shipment_receipt_response(xml_response), response
   end
 
+  def test_find_shipment_receipt_returns_active_shipping_response_error_if_active_utils_response_error
+    options = @default_options.dup
+    http_response = mock
+    http_response.stubs(:code).returns('400')
+    response_error = ActiveUtils::ResponseError.new(http_response)
+    @cp.expects(:ssl_get).once.raises(response_error)
+    assert_raises ActiveShipping::ResponseError do
+      response = @cp.find_shipment_receipt('1234567', options)
+    end
+  end
+
   def test_character_limit_on_customs_description
     @line_item1.first.stubs(:name).returns("Some super long description that exceeds the 44 character limit")
     options = @default_options.dup

--- a/test/unit/carriers/canada_post_pws_shipping_test.rb
+++ b/test/unit/carriers/canada_post_pws_shipping_test.rb
@@ -231,9 +231,8 @@ class CanadaPostPwsShippingTest < ActiveSupport::TestCase
 
   def test_find_shipment_receipt_returns_active_shipping_response_error_if_active_utils_response_error
     options = @default_options.dup
-    http_response = mock
-    http_response.stubs(:code).returns('400')
-    response_error = ActiveUtils::ResponseError.new(http_response)
+    bad_response = Net::HTTPResponse.new({}, 404, "404 Not Found")
+    response_error = ActiveUtils::ResponseError.new(bad_response)
     @cp.expects(:ssl_get).once.raises(response_error)
     assert_raises ActiveShipping::ResponseError do
       response = @cp.find_shipment_receipt('1234567', options)


### PR DESCRIPTION
### WHAT

Currently when we use `find_shipment_receipt` on Canada Post, in the case where the receipt is not found, `ssl_get` returns an `ActiveUtils::ResponseError`. This PR rescues that error and returns an `ActiveShipping::ResponseError` instead.

### WHY

We should only be raising `ActiveShipping` errors in this gem.

With most carriers, we rescue bad API responses and build a corresponding variation of the `ActiveShipping::Response` object to return so that the method fails gracefully. 

The Canada Post receipt is tricky because when it's parsed, it doesn't return a `Response` object, rather it's just a hash. Rescuing and returning a `Response` object here doesn't make sense so I'm making sure it at least raises an `ActiveShipping` related error.

Closes https://github.com/Shopify/active_shipping/issues/516