### PR TITLE
Bump to version 2.0.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # ActiveShipping CHANGELOG
 
+### v2.0.1
+- Raise ActiveShipping::ResponseError error in favour of ActiveUtils::ResponseError for CanadaPostPWS#find_shipment_receipt
+
 ### v2.0.0
 - Drop support for < ruby 2.2, support ruby 2.4
 - Drop support for < Rails 4.2.

--- a/lib/active_shipping/version.rb
+++ b/lib/active_shipping/version.rb
@@ -1,3 +1,3 @@
 module ActiveShipping
-  VERSION = "2.0.0"
+  VERSION = "2.0.1"
 end


### PR DESCRIPTION
### Summary

Release version v2.0.1 with the changes implemented on https://github.com/Shopify/active_shipping/pull/524.