### PR TITLE
removed 1.x vs 2.x versions disclaimer

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,10 +21,6 @@ This library interfaces with the web services of various shipping carriers. The 
 * [Australia Post](http://auspost.com.au/)
 
 
-## Versions
-Note: `2.x` contains breaking changes, please see the [changelog](https://github.com/Shopify/active_shipping/blob/master/CHANGELOG.md). Shopify will not be actively contibuting to the 2.0 version of this gem and is looking for maintainers.
-We have released `1.9` and will only backport small fixes to this version, on branch `1-9-stable`, and they should be on `master` first.
-
 ## Installation
 
 Using bundler, add to the `Gemfile`:


### PR DESCRIPTION
this doesn't seem to be true any more, so I removed it.

related: https://github.com/Shopify/active_shipping/issues/533