### PR TITLE
update FedEx web service URLs

### DIFF
--- a/lib/active_shipping/carriers/fedex.rb
+++ b/lib/active_shipping/carriers/fedex.rb
@@ -10,8 +10,8 @@ module ActiveShipping
     cattr_reader :name
     @@name = "FedEx"
 
-    TEST_URL = 'https://gatewaybeta.fedex.com:443/xml'
-    LIVE_URL = 'https://gateway.fedex.com:443/xml'
+    TEST_URL = 'https://wsbeta.fedex.com:443/xml'
+    LIVE_URL = 'https://ws.fedex.com:443/xml'
 
     CARRIER_CODES = {
       "fedex_ground" => "FDXG",


### PR DESCRIPTION
FedEx appears to have changed their values for these URLs. Our project just got certified and we were told to change `wsbeta.fedex.com` to `ws.fedex.com` in our WSDLs and/or XSD files. We weren't using either, at least not directly, but we set our production code to use `ws.fedex.com` as requested.

The old test URL still works; I don't know about the live URL. But it's always good to keep these things up to date.