### PR TITLE
Re-authenticate with stamps api on two additional faults.

### DIFF
--- a/lib/active_shipping/carriers/stamps.rb
+++ b/lib/active_shipping/carriers/stamps.rb
@@ -492,7 +492,9 @@ module ActiveShipping
       end
 
       # Renew the Authenticator if it has expired and retry the request
-      if error_code && error_code.downcase == '002b0202'
+      # Error code reference:
+      # http://developer.stamps.com/assets/documents/developer/downloads/Stamps.com_SWSIM_Reference_v42.pdf
+      if error_code && ['002b0202', '002b0203', '002b0204'].include?(error_code.downcase)
         request = renew_authenticator(last_request)
         commit(last_swsim_method, request)
       else


### PR DESCRIPTION
According to the Stamps API documentation re-authenticating is also a potential
fix for 'Conversation Out-Of-Sync' and 'Invalid Conversation Token' faults.

Ref: http://developer.stamps.com/assets/documents/developer/downloads/Stamps.com_SWSIM_Reference_v42.pdf

Note: This is just bringing back #312, but with CI passing. CI was failing on #312 due to bad luck... @kvanwagenen forked the project while it was broken ( 9ac1bb4
fixed the remote test failure)

PR #545 was recently closed by @maartenvg, and I assume that was because PR #545 wasn't a simple 1-commit merge against master. So I have re-based the changes against master, and re-submitted.