### PR TITLE
Fix failing Kunaki remote tests

### DIFF
--- a/lib/active_shipping/carriers/kunaki.rb
+++ b/lib/active_shipping/carriers/kunaki.rb
@@ -5,7 +5,7 @@ module ActiveShipping
     cattr_reader :name
     @@name = "Kunaki"
 
-    URL = 'https://Kunaki.com/XMLService.ASP'
+    URL = 'http://Kunaki.com/XMLService.ASP'
 
     CARRIERS = ["UPS", "USPS", "FedEx", "Royal Mail", "Parcelforce", "Pharos", "Eurotrux", "Canada Post", "DHL"]
 

--- a/test/remote/kunaki_test.rb
+++ b/test/remote/kunaki_test.rb
@@ -5,9 +5,10 @@ class RemoteKunakiTest < ActiveSupport::TestCase
 
   def setup
     @carrier = Kunaki.new
-    @item1 = { :sku => 'XZZ1111111', :quantity => 2 }
-    @item2 = { :sku => 'PXZZ111112', :quantity => 1 }
-    @items = [@item1, @item2]
+    @item1 = { :sku => 'PX002LTGLS', :quantity => 2 }
+    @item2 = { :sku => 'PX00MXGKAR', :quantity => 1 }
+    @item3 = { :sku => 'PX00ZEDG6F', :quantity => 1 }
+    @items = [@item1, @item2, @item3]
   end
 
   def test_successful_rates_request


### PR DESCRIPTION
This is a fix for the failing Kunaki tests. The old tests were running outdated SKUs. I've contacted Kunaki and they provided the following example SKUs to use:

PX002LTGLS -- jacket case
PX00MXGKAR -- dvd case
PX00ZEDG6F -- jewel case